### PR TITLE
feat: add export scope functionality for channel data export and import

### DIFF
--- a/statgpt/admin/routers/channel.py
+++ b/statgpt/admin/routers/channel.py
@@ -71,6 +71,7 @@ async def get_channel_by_id(
 async def export_channel(
     background_tasks: BackgroundTasks,
     channel_id: int,
+    scope: schemas.ExportScope = Query(default=schemas.ExportScope.FULL),
     session: AsyncSession = Depends(models.get_session),
 ) -> schemas.Job:
     """Create a background job to export channel data to a zip file.
@@ -78,7 +79,7 @@ async def export_channel(
     """
 
     return await JobsService(session).create_export_job(
-        background_tasks, channel_id, auth_context=SystemUserAuthContext()
+        background_tasks, channel_id, scope=scope, auth_context=SystemUserAuthContext()
     )
 
 

--- a/statgpt/admin/services/channel.py
+++ b/statgpt/admin/services/channel.py
@@ -164,29 +164,56 @@ class AdminPortalChannelService(ChannelService):
             _log.exception(f"Failed to clear Elastic index {index_name!r}")
 
     async def export_channel_to_folder(
-        self, channel_id: int, folder_path: str, auth_context: AuthContext
+        self,
+        channel_id: int,
+        folder_path: str,
+        scope: schemas.ExportScope,
+        auth_context: AuthContext,
     ) -> models.Channel:
         channel_db = await self.get_model_by_id(channel_id)
         channel_schema = ChannelSerializer.db_to_schema(channel_db)
 
+        if scope.includes_configs():
+            channel_file = os.path.join(folder_path, JobsConfig.CHANNEL_FILE)
+            channel_data = channel_schema.model_dump(mode="json", include=JobsConfig.CHANNEL_FIELDS)
+            utils.write_yaml(channel_data, channel_file)
+
         if (
-            channel_schema.details.plain_content
+            scope.includes_dial_files()
+            and channel_schema.details.plain_content
             and channel_schema.details.plain_content.details.file_path
         ):
             await self._export_dial_file_to_folder(
-                channel_schema.details.plain_content.details.file_path, folder_path, auth_context
+                channel_schema.details.plain_content.details.file_path,
+                folder_path,
+                auth_context,
             )
 
-        channel_file = os.path.join(folder_path, JobsConfig.CHANNEL_FILE)
-        channel_data = channel_schema.model_dump(mode="json", include=JobsConfig.CHANNEL_FIELDS)
-        utils.write_yaml(channel_data, channel_file)
         return channel_db
 
     async def import_channel_from_zip(
-        self, zip_file: zipfile.ZipFile, clean_up: bool, auth_context: AuthContext
+        self,
+        zip_file: zipfile.ZipFile,
+        clean_up: bool,
+        scope: schemas.ExportScope,
+        deployment_id: str | None,
+        auth_context: AuthContext,
     ) -> models.Channel:
-        _log.info("Uploading DIAL files for channel import")
+        if scope.includes_dial_files():
+            await self._import_dial_files_from_zip(zip_file, auth_context)
 
+        if scope.includes_configs():
+            channel_data = await self._load_channel_data_from_zip(zip_file)
+            if clean_up:
+                await self._cleanup_existing_channel(channel_data.deployment_id, auth_context)
+            return await self._create_channel_model(channel_data)
+
+        return await self._get_existing_channel_by_deployment_id(deployment_id)
+
+    async def _import_dial_files_from_zip(
+        self, zip_file: zipfile.ZipFile, auth_context: AuthContext
+    ) -> None:
+        _log.info("Uploading DIAL files for channel import")
         with tempfile.TemporaryDirectory() as temp_dir:
             members = [
                 name
@@ -204,23 +231,33 @@ class AdminPortalChannelService(ChannelService):
                         file_path, dial_file_path, auth_context
                     )
 
+    async def _load_channel_data_from_zip(self, zip_file: zipfile.ZipFile) -> schemas.ChannelBase:
         with zip_file.open(JobsConfig.CHANNEL_FILE) as channel_file:
             channel_data_json = yaml.safe_load(channel_file.read())
 
         channel_data = schemas.ChannelBase.model_validate(channel_data_json)
         _log.info(f"Importing channel: {channel_data!r}")
+        return channel_data
 
-        if clean_up:
-            try:
-                existing_channel = await self.get_channel_by_deployment_id(
-                    channel_data.deployment_id
-                )
-            except NoResultFound:
-                pass  # No channel found, nothing to delete
-            else:
-                await self.delete(existing_channel.id, auth_context=auth_context)
+    async def _cleanup_existing_channel(
+        self, deployment_id: str, auth_context: AuthContext
+    ) -> None:
+        try:
+            existing_channel = await self.get_channel_by_deployment_id(deployment_id)
+        except NoResultFound:
+            pass  # No channel found, nothing to delete
+        else:
+            await self.delete(existing_channel.id, auth_context=auth_context)
 
-        return await self._create_channel_model(channel_data)
+    async def _get_existing_channel_by_deployment_id(
+        self, deployment_id: str | None
+    ) -> models.Channel:
+        if deployment_id is None:
+            raise ValueError("deployment_id is required when importing indexes only.")
+        try:
+            return await self.get_channel_by_deployment_id(deployment_id)
+        except NoResultFound:
+            raise ValueError(f"Channel with deployment_id {deployment_id} not found during import.")
 
     async def deduplicate_channel_dimensions(
         self, channel_id: int, auth_context: AuthContext

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -214,7 +214,11 @@ class AdminPortalDataSetService(DataSetService):
         utils.write_yaml({'data': data}, datasets_file)
 
     async def export_datasets(
-        self, channel: models.Channel, res_dir: str, auth_context: AuthContext
+        self,
+        channel: models.Channel,
+        res_dir: str,
+        scope: schemas.ExportScope,
+        auth_context: AuthContext,
     ) -> None:
         channel_config = schemas.ChannelConfig.model_validate(channel.details)
 
@@ -226,9 +230,12 @@ class AdminPortalDataSetService(DataSetService):
             allow_offline=True,
         )
 
-        data_sources = self._export_datasets_config(datasets, res_dir)
+        if scope.includes_configs():
+            data_sources = self._export_datasets_config(datasets, res_dir)
+            await DataSourceService.export_data_sources(data_sources.values(), res_dir)
 
-        await DataSourceService.export_data_sources(data_sources.values(), res_dir)
+        if not scope.includes_indexes():
+            return
 
         channel_datasets = await self.get_channel_dataset_models(
             limit=None, offset=0, channel_id=channel.id
@@ -236,6 +243,7 @@ class AdminPortalDataSetService(DataSetService):
         latest_completed_versions = await self._get_latest_successful_dataset_version(
             channel_dataset_ids=[cd.id for cd in channel_datasets]
         )
+
         versions = {
             next(d.id_ for d in datasets if d.id == ds_id): version.last_completed_version
             for ds_id, version in latest_completed_versions.items()
@@ -419,7 +427,7 @@ class AdminPortalDataSetService(DataSetService):
                 version = versions[dataset.id]
 
                 file_name = self._get_elasticsearch_store_file_name(dataset)
-                file_path = os.path.join(folder, file_name)
+                file_path = f"{folder}/{file_name}"
 
                 if file_path not in zip_file.namelist():
                     _log.warning(f"File '{file_path}' not found in the zip archive")
@@ -448,42 +456,96 @@ class AdminPortalDataSetService(DataSetService):
         zip_file: zipfile.ZipFile,
         update_datasets: bool,
         update_data_sources: bool,
+        scope: schemas.ExportScope,
         auth_context: AuthContext,
     ) -> None:
-        channel_config = schemas.ChannelConfig.model_validate(channel_db.details)
-
-        source_service = DataSourceService(self._session)
-        data_sources = await source_service.import_data_sources_from_zip(
-            zip_file, update_data_sources
+        datasets = await self._import_or_load_datasets(
+            zip_file, channel_db, update_datasets, update_data_sources, scope, auth_context
         )
 
-        datasets = await self._import_datasets(
-            zip_file, data_sources, update_datasets, auth_context=auth_context  # type: ignore
-        )
-        await self._add_datasets_to_channel(channel_id=channel_db.id, datasets=datasets)
-        versions = await self._import_datasets_versions(
-            zip_file, datasets, channel_id=channel_db.id
+        if scope.includes_indexes():
+            channel_config = schemas.ChannelConfig.model_validate(channel_db.details)
+            versions = await self._import_datasets_versions(
+                zip_file, datasets, channel_id=channel_db.id
+            )
+            await self._import_indexes(
+                zip_file, channel_db, datasets, versions, channel_config, auth_context
+            )
+            await self._mark_versions_completed(versions)
+
+        await self._session.commit()
+
+    async def _import_or_load_datasets(
+        self,
+        zip_file: zipfile.ZipFile,
+        channel_db: models.Channel,
+        update_datasets: bool,
+        update_data_sources: bool,
+        scope: schemas.ExportScope,
+        auth_context: AuthContext,
+    ) -> list[schemas.DataSet]:
+        if scope.includes_configs():
+            source_service = DataSourceService(self._session)
+            data_sources = await source_service.import_data_sources_from_zip(
+                zip_file, update_data_sources
+            )
+            datasets = await self._import_datasets(
+                zip_file, data_sources, update_datasets, auth_context=auth_context  # type: ignore
+            )
+            await self._add_datasets_to_channel(channel_id=channel_db.id, datasets=datasets)
+            return datasets
+
+        return await self.get_datasets_schemas(
+            limit=None,
+            offset=0,
+            channel_id=channel_db.id,
+            auth_context=auth_context,
+            allow_offline=True,
         )
 
+    async def _import_indexes(
+        self,
+        zip_file: zipfile.ZipFile,
+        channel_db: models.Channel,
+        datasets: list[schemas.DataSet],
+        versions: dict[int, models.ChannelDatasetVersion],
+        channel_config: schemas.ChannelConfig,
+        auth_context: AuthContext,
+    ) -> None:
         await self._import_vector_store_tables(
             zip_file, channel_db, datasets, versions, auth_context
         )
+        await self._import_elastic_data_if_needed(
+            zip_file, channel_db, datasets, versions, channel_config
+        )
 
+    async def _import_elastic_data_if_needed(
+        self,
+        zip_file: zipfile.ZipFile,
+        channel_db: models.Channel,
+        datasets: list[schemas.DataSet],
+        versions: dict[int, models.ChannelDatasetVersion],
+        channel_config: schemas.ChannelConfig,
+    ) -> None:
         if channel_config.data_query is None:
             _log.info("No data query configured, skipping data import")
-        else:
-            indexer_version = channel_config.data_query.details.indexer_version
-            _log.info(f"Indexer version: {indexer_version}")
-            if indexer_version == schemas.IndexerVersion.hybrid:
-                await self._import_elastic_data(zip_file, channel_db, datasets, versions)
-            else:
-                _log.info("Skipping importing elastic data")
+            return
 
+        indexer_version = channel_config.data_query.details.indexer_version
+        _log.info(f"Indexer version: {indexer_version}")
+
+        if indexer_version == schemas.IndexerVersion.hybrid:
+            await self._import_elastic_data(zip_file, channel_db, datasets, versions)
+        else:
+            _log.info("Skipping importing elastic data")
+
+    async def _mark_versions_completed(
+        self, versions: dict[int, models.ChannelDatasetVersion]
+    ) -> None:
         for item in versions.values():
             await self._update_channel_dataset_version_status(
                 item, new_status=StatusEnum.COMPLETED, do_commit=False
             )
-        await self._session.commit()
 
     async def _parse_details_field(
         self, handler: base.DataSourceHandler, details: dict[str, Any]

--- a/statgpt/admin/services/import_export_jobs.py
+++ b/statgpt/admin/services/import_export_jobs.py
@@ -9,6 +9,7 @@ from typing import BinaryIO
 
 import httpx
 from fastapi import BackgroundTasks, HTTPException, UploadFile, status
+from pydantic import BaseModel, ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.expression import func
@@ -25,6 +26,13 @@ from .dataset import AdminPortalDataSetService as DataSetService
 from .glossary_of_terms import AdminPortalGlossaryOfTermsService as GlossaryOfTermsService
 
 _log = logging.getLogger(__name__)
+
+
+class ExportMetadata(BaseModel):
+    export_start_datetime: str
+    export_finish_datetime: str
+    scope: schemas.ExportScope = schemas.ExportScope.FULL
+    deployment_id: str
 
 
 class JobsService:
@@ -134,7 +142,11 @@ class JobsService:
         await self._session.refresh(job)
 
     async def create_export_job(
-        self, background_tasks: BackgroundTasks, channel_id: int, auth_context: AuthContext
+        self,
+        background_tasks: BackgroundTasks,
+        channel_id: int,
+        scope: schemas.ExportScope,
+        auth_context: AuthContext,
     ) -> schemas.Job:
         channel_service = ChannelService(self._session)
         channel_db = await channel_service.get_model_by_id(channel_id)
@@ -147,7 +159,7 @@ class JobsService:
         self._session.add(job)
         await self._session.commit()
 
-        background_tasks.add_task(export_channel_in_background_task, job.id, auth_context)
+        background_tasks.add_task(export_channel_in_background_task, job.id, scope, auth_context)
         await self._update_job_status(job, schemas.PreprocessingStatusEnum.QUEUED)
 
         return schemas.Job.model_validate(job, from_attributes=True)
@@ -206,33 +218,36 @@ class JobsService:
 
     @staticmethod
     async def _export_data_to_folder(
-        channel_id: int, data_dir: str, auth_context: AuthContext
+        channel_id: int, data_dir: str, scope: schemas.ExportScope, auth_context: AuthContext
     ) -> str:
         """Export channel data including datasets and embeddings to the folder."""
 
         async with models.get_readonly_session_contex_manager() as session:
             channel_service = ChannelService(session)
             channel_db = await channel_service.export_channel_to_folder(
-                channel_id, data_dir, auth_context
+                channel_id, data_dir, scope=scope, auth_context=auth_context
             )
 
-            glossary_service = GlossaryOfTermsService(session)
-            await glossary_service.export_glossary_to_folder(channel_db, data_dir)
+            if scope is schemas.ExportScope.CONFIGS or scope is schemas.ExportScope.FULL:
+                glossary_service = GlossaryOfTermsService(session)
+                await glossary_service.export_glossary_to_folder(channel_db, data_dir)
 
             dataset_service = DataSetService(session)
-            await dataset_service.export_datasets(channel_db, data_dir, auth_context=auth_context)
-
-            export_name = (
-                f"{channel_db.deployment_id}-{datetime.now().strftime('%Y-%m-%dT%H-%M-%S.%f')}"
+            await dataset_service.export_datasets(
+                channel_db, data_dir, scope=scope, auth_context=auth_context
             )
-            return export_name
 
-    async def export_channel_in_background(self, job_id: int, auth_context: AuthContext) -> None:
+            return channel_db.deployment_id
+
+    async def export_channel_in_background(
+        self, job_id: int, scope: schemas.ExportScope, auth_context: AuthContext
+    ) -> None:
         _log.info(f"Exporting channel data to zip file. Job id={job_id}")
         job: models.Job = await self.get_job_model_by_id(job_id)
         await self._update_job_status(job, schemas.PreprocessingStatusEnum.IN_PROGRESS)
 
         try:
+            export_start_datetime = datetime.now().isoformat()
             with tempfile.TemporaryDirectory() as tmp_dir:
                 # folder for channel data before zipping:
                 data_dir = os.path.join(tmp_dir, "data")
@@ -240,9 +255,22 @@ class JobsService:
 
                 if not job.channel_id:
                     raise ValueError("Job must have a channel_id to export data")
-                archive_name = await self._export_data_to_folder(
-                    job.channel_id, data_dir, auth_context=auth_context
+                deployment_id = await self._export_data_to_folder(
+                    job.channel_id, data_dir, scope=scope, auth_context=auth_context
                 )
+
+                archive_name = f"{deployment_id}-{datetime.now().strftime('%Y-%m-%dT%H-%M-%S.%f')}"
+
+                export_finish_datetime = datetime.now().isoformat()
+                metadata = ExportMetadata(
+                    export_start_datetime=export_start_datetime,
+                    export_finish_datetime=export_finish_datetime,
+                    scope=scope,
+                    deployment_id=deployment_id,
+                )
+                metadata_path = os.path.join(data_dir, "metadata.json")
+                with open(metadata_path, "w", encoding="utf-8") as meta_file:
+                    meta_file.write(metadata.model_dump_json(indent=2))
 
                 res_file_path = os.path.abspath(os.path.join(tmp_dir, archive_name))
                 _log.info(f"Compressing {data_dir} to {res_file_path}.zip (non-blocking)")
@@ -317,16 +345,34 @@ class JobsService:
         """Import channel data including datasets and embeddings from the zip file."""
 
         async with models.get_session_contex_manager() as session:
+            deployment_id = None
+            scope = schemas.ExportScope.FULL
+            try:
+                with zip_file.open("metadata.json") as meta_file:
+                    metadata = ExportMetadata.model_validate_json(meta_file.read())
+                    deployment_id = metadata.deployment_id
+                    scope = metadata.scope
+            except KeyError:
+                _log.info("metadata.json is absent in import zip; proceeding with defaults")
+            except ValidationError as e:
+                _log.warning(
+                    "Invalid metadata.json in import zip; proceeding with defaults.", exc_info=e
+                )
+
             channel_service = ChannelService(session)
             channel_db = await channel_service.import_channel_from_zip(
-                zip_file, clean_up, auth_context
+                zip_file,
+                clean_up,
+                scope=scope,
+                deployment_id=deployment_id,
+                auth_context=auth_context,
             )
 
             job.channel_id = channel_db.id
             await self._update_job_status(job, schemas.PreprocessingStatusEnum.IN_PROGRESS)
-
-            glossary_service = GlossaryOfTermsService(session)
-            await glossary_service.import_glossary_from_zip(zip_file, channel_db.id)
+            if scope.includes_configs():
+                glossary_service = GlossaryOfTermsService(session)
+                await glossary_service.import_glossary_from_zip(zip_file, channel_db.id)
 
             dataset_service = DataSetService(session)
             await dataset_service.import_datasets_and_data_sources_from_zip(
@@ -334,6 +380,7 @@ class JobsService:
                 zip_file,
                 update_datasets,
                 update_data_sources,
+                scope=scope,
                 auth_context=auth_context,
             )
 
@@ -379,11 +426,15 @@ class JobsService:
         _log.info(f"Channel(id={channel_id}) imported successfully. Job id={job_id}")
 
 
-async def export_channel_in_background_task(job_id: int, auth_context: AuthContext) -> None:
+async def export_channel_in_background_task(
+    job_id: int, scope: schemas.ExportScope, auth_context: AuthContext
+) -> None:
     try:
         async with models.get_session_contex_manager() as session:
             service = JobsService(session)
-            await service.export_channel_in_background(job_id=job_id, auth_context=auth_context)
+            await service.export_channel_in_background(
+                job_id=job_id, scope=scope, auth_context=auth_context
+            )
     except Exception as e:
         _log.exception(e)
 

--- a/statgpt/common/schemas/__init__.py
+++ b/statgpt/common/schemas/__init__.py
@@ -25,6 +25,7 @@ from .dataset import DataSet, DataSetBase, DataSetDescriptor, DataSetUpdate
 from .enums import (
     ChannelIndexStatusScope,
     DecoderOfLatestEnum,
+    ExportScope,
     IndexerVersion,
     IndicatorSelectionVersion,
     JobType,

--- a/statgpt/common/schemas/enums.py
+++ b/statgpt/common/schemas/enums.py
@@ -20,6 +20,25 @@ class JobType(StrEnum):
     IMPORT = "IMPORT"
 
 
+class ExportScope(StrEnum):
+    FULL = "full"
+    CONFIGS = "configs"
+    INDEXES = "indexes"
+    DIAL_FILES = "dial_files"
+
+    def includes_configs(self) -> bool:
+        """Check if this scope includes configuration export."""
+        return self is ExportScope.CONFIGS or self is ExportScope.FULL
+
+    def includes_indexes(self) -> bool:
+        """Check if this scope includes indexes export."""
+        return self is ExportScope.INDEXES or self is ExportScope.FULL
+
+    def includes_dial_files(self) -> bool:
+        """Check if this scope includes DIAL files export."""
+        return self is ExportScope.DIAL_FILES or self is ExportScope.FULL
+
+
 class ToolTypes(StrEnum):
     AVAILABLE_DATASETS = "AVAILABLE_DATASETS"
     DATASETS_METADATA = "DATASETS_METADATA"


### PR DESCRIPTION
### Applicable issues

https://github.com/epam/statgpt-backend/issues/47

### Description of changes

- Introduced `ExportScope` enum to define export options (FULL, CONFIGS, INDEXES, DIAL_FILES).
- Updated `export_channel` and related services to accept and handle export scope.
- Enhanced dataset export and import methods to conditionally process based on the specified scope.
- Added metadata handling for export jobs, including start and finish timestamps and scope information.


