### PR TITLE
chore: drop outdated collections tables in migration f006354afe36

### DIFF
--- a/statgpt/admin/alembic/versions/2025_12_19_1452-f006354afe36_drop_outdated_collections_tables.py
+++ b/statgpt/admin/alembic/versions/2025_12_19_1452-f006354afe36_drop_outdated_collections_tables.py
@@ -1,0 +1,64 @@
+"""Drop outdated collections tables
+
+Revision ID: f006354afe36
+Revises: 5fac4226f0af
+Create Date: 2025-12-19 14:52:07.783585
+
+This migration removes legacy tables that were generated dynamically per-environment:
+- collections._names
+- collections.c_<uuid>
+- collections.c_<uuid>_mapping
+
+UUIDs vary per environment, so the upgrade discovers and drops matching tables at runtime.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'f006354afe36'
+down_revision: str | None = '5fac4226f0af'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT schemaname, tablename
+    FROM pg_tables
+    WHERE schemaname IN ('collections', 'public')
+      AND (
+        tablename = '_names'
+        OR tablename ~ '^c_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        OR tablename ~ '^c_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}_mapping$'
+      )
+  LOOP
+    EXECUTE format('DROP TABLE IF EXISTS %I.%I CASCADE', r.schemaname, r.tablename);
+  END LOOP;
+END $$;
+"""
+    )
+
+
+def downgrade() -> None:
+    # Only "_names" table can be restored to the previous state.
+    op.execute("CREATE SCHEMA IF NOT EXISTS collections")
+    op.execute(
+        """
+CREATE TABLE IF NOT EXISTS collections."_names" (
+  uuid UUID PRIMARY KEY,
+  collection_name VARCHAR NOT NULL,
+  datasource VARCHAR NULL,
+  embedding_model_name VARCHAR NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+"""
+    )

--- a/statgpt/admin/alembic/versions/2025_12_19_1452-f006354afe36_drop_outdated_collections_tables.py
+++ b/statgpt/admin/alembic/versions/2025_12_19_1452-f006354afe36_drop_outdated_collections_tables.py
@@ -33,7 +33,7 @@ BEGIN
   FOR r IN
     SELECT schemaname, tablename
     FROM pg_tables
-    WHERE schemaname IN ('collections', 'public')
+    WHERE schemaname = 'collections'
       AND (
         tablename = '_names'
         OR tablename ~ '^c_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'

--- a/statgpt/common/config/versions.py
+++ b/statgpt/common/config/versions.py
@@ -7,4 +7,4 @@ class Versions:
     # Please update this version when you create a new alembic revision.
     # Needed because alembic folder exist only in the statgpt.admin package.
     # (statgpt Dockerfile doesn't copy statgpt.admin package to the container)
-    ALEMBIC_TARGET_VERSION = '5fac4226f0af'
+    ALEMBIC_TARGET_VERSION = 'f006354afe36'


### PR DESCRIPTION
### Applicable issues

https://github.com/epam/statgpt-backend/issues/63
### Description of changes

Outdated tables are removed in new migration

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
