### PR TITLE
fix: the function that returns the list of available datasets

### DIFF
--- a/statgpt/admin/routers/data_source.py
+++ b/statgpt/admin/routers/data_source.py
@@ -3,6 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import statgpt.common.models as models
 import statgpt.common.schemas as schemas
+from statgpt.admin.auth.auth_context import SystemUserAuthContext
 from statgpt.admin.auth.user import require_jwt_auth
 from statgpt.admin.services import AdminPortalDataSetService as DataSetService
 from statgpt.admin.services import AdminPortalDataSourceService as DataSourceService
@@ -93,9 +94,17 @@ async def get_available_datasets(
     session: AsyncSession = Depends(models.get_session),
     _=Depends(cancel_on_disconnect),
 ) -> schemas.ListResponse[schemas.DataSetDescriptor]:
-    """Returns a list of datasets that can be loaded from the data source"""
+    """Returns a list of datasets that exists in the data source and can be added to the system.
 
-    datasets = await DataSetService(session).load_available_datasets(source_id=item_id)
+    NOTES:
+        * These list does NOT exclude datasets that are already added to the system.
+        * The returned datasets contain only some pre-configurations and require manual review
+          and updating before being added to the system.
+    """
+
+    datasets = await DataSetService(session).load_available_datasets(
+        source_id=item_id, auth_context=SystemUserAuthContext()
+    )
     datasets_count = len(datasets)
 
     return schemas.ListResponse[schemas.DataSetDescriptor](

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -14,7 +14,6 @@ from sqlalchemy.sql.expression import func, text, update
 
 import statgpt.common.models as models
 import statgpt.common.schemas as schemas
-from statgpt.admin.auth.auth_context import SystemUserAuthContext
 from statgpt.admin.settings.exim import ExImSettings, JobsConfig
 from statgpt.common import utils
 from statgpt.common.auth.auth_context import AuthContext
@@ -591,11 +590,13 @@ class AdminPortalDataSetService(DataSetService):
         )
         return DataSetSerializer.db_to_schema(item, dataset)
 
-    async def load_available_datasets(self, source_id: int) -> list[schemas.DataSetDescriptor]:
+    async def load_available_datasets(
+        self, source_id: int, auth_context: AuthContext
+    ) -> list[schemas.DataSetDescriptor]:
         handler = await self._get_handler(source_id)
 
         datasets = []
-        for ds in await handler.list_datasets(SystemUserAuthContext()):
+        for ds in await handler.list_datasets(auth_context):
             datasets.append(
                 schemas.DataSetDescriptor(
                     data_source_id=source_id,

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -602,7 +602,7 @@ class AdminPortalDataSetService(DataSetService):
                     data_source_id=source_id,
                     title=ds.name,
                     description=ds.description or "",
-                    details=ds.details,
+                    details=ds.details.model_dump(mode="json", by_alias=True),
                 )
             )
 

--- a/statgpt/common/data/base/__init__.py
+++ b/statgpt/common/data/base/__init__.py
@@ -1,7 +1,16 @@
 from .attribute import Attribute, CategoricalAttribute, StringAttribute
 from .base import BaseEntity
 from .category import Category, DimensionCategory, VirtualDimensionCategory
-from .config import DatasetCitation, IndexerConfig, IndexerIndicatorConfig, VirtualDimensionValue
+from .config import (
+    BaseDimensionConfig,
+    DatasetCitation,
+    IndexerConfig,
+    IndexerIndicatorConfig,
+    IndicatorDimensionConfig,
+    NonIndicatorDimensionConfig,
+    TimePeriodDimensionConfig,
+    VirtualDimensionValue,
+)
 from .dataset import DataResponse, DataResponseStatus, DataSet, DataSetConfig, OfflineDataSet
 from .dataset_hierarchy import (
     DatasetHierarchy,

--- a/statgpt/common/data/base/__init__.py
+++ b/statgpt/common/data/base/__init__.py
@@ -4,6 +4,7 @@ from .category import Category, DimensionCategory, VirtualDimensionCategory
 from .config import (
     BaseDimensionConfig,
     DatasetCitation,
+    DataSetConfigTemplate,
     IndexerConfig,
     IndexerIndicatorConfig,
     IndicatorDimensionConfig,

--- a/statgpt/common/data/base/config.py
+++ b/statgpt/common/data/base/config.py
@@ -87,7 +87,7 @@ class IndexerConfig(BaseModel):
 
 
 class BaseDimensionConfig(BaseModel):
-    dimension_type: str
+    dimension_type: str | None
     alias: str | None = Field(default=None)
     is_required: bool = Field(
         default=False,
@@ -115,6 +115,8 @@ class BaseDimensionConfig(BaseModel):
 
     @property
     def type(self) -> DimensionType:
+        if self.dimension_type is None:
+            raise ValueError("dimension_type is not set")
         return DimensionType(self.dimension_type)
 
     @property

--- a/statgpt/common/data/base/config.py
+++ b/statgpt/common/data/base/config.py
@@ -4,7 +4,7 @@ from collections.abc import Generator, Iterable
 from typing import Annotated, Literal, NamedTuple, Self
 
 from pydantic import BaseModel as PydanticBaseModel
-from pydantic import ConfigDict, Field, StrictStr, alias_generators, model_validator
+from pydantic import ConfigDict, Field, SkipValidation, StrictStr, alias_generators, model_validator
 
 from statgpt.common.config.utils import replace_env
 from statgpt.common.utils import crc32_hash, crc32_hash_incremental
@@ -163,13 +163,25 @@ DIMENSION_CONFIG_TYPES = Annotated[
 ]
 
 
-class DataSetConfig(BaseModel, ABC):
+class BaseDataSetConfig(BaseModel):
     is_official: bool = Field(default=False)
     citation: DatasetCitation | None = Field(default=None)
     indexer: IndexerConfig | None = Field(default=None)
     pinned_columns: list[str] = Field(
         description="Column names and order to pin in the data in grid", default_factory=list
     )
+
+
+class DataSetConfigTemplate(BaseDataSetConfig):
+
+    dimensions: dict[str, SkipValidation[BaseDimensionConfig]] = Field(
+        description="The draft configuration of the each dimension in the dataset by its ID",
+        default_factory=dict,
+    )
+
+
+class DataSetConfig(BaseDataSetConfig, ABC):
+
     dimensions: dict[str, DIMENSION_CONFIG_TYPES] = Field(
         description="The configuration of the each dimension in the dataset by its ID",
         default_factory=dict,

--- a/statgpt/common/data/base/datasource.py
+++ b/statgpt/common/data/base/datasource.py
@@ -3,12 +3,13 @@ import uuid
 from abc import ABC, abstractmethod
 
 from langchain_core.documents import Document
-from pydantic import BaseModel, ConfigDict, Field, alias_generators
+from pydantic import BaseModel, ConfigDict, Field, SkipValidation, alias_generators
 
 from statgpt.common.auth.auth_context import AuthContext
 
 from .base import BaseEntity, EntityType
 from .category import DimensionCategory
+from .config import DataSetConfigTemplate
 from .dataset import DataSet, DataSetConfig
 from .dataset_hierarchy import DatasetHierarchy
 from .indicator import BaseIndicator
@@ -19,8 +20,8 @@ class DataSetDescriptor(BaseModel):
     name: str = Field(description="The name of the dataset")
     description: t.Optional[str] = Field(description="The description of the dataset")
 
-    details: dict = Field(
-        description="Preliminary details defined by the data source.", default_factory=dict
+    details: SkipValidation[DataSetConfigTemplate] = Field(
+        description="Preliminary details defined by the data source."
     )
 
 

--- a/statgpt/common/data/sdmx/common/__init__.py
+++ b/statgpt/common/data/sdmx/common/__init__.py
@@ -10,6 +10,7 @@ from .config import (
     CategorySchemaDataSetHierarchyConfig,
     DefaultDataSetHierarchyConfig,
     SdmxDataSetConfig,
+    SdmxDataSetConfigTemplate,
     SdmxDataSourceConfig,
 )
 from .constants import SdmxConstants

--- a/statgpt/common/data/sdmx/common/config.py
+++ b/statgpt/common/data/sdmx/common/config.py
@@ -4,7 +4,12 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from statgpt.common.config import utils as config_utils
-from statgpt.common.data.base import DataSetConfig, DataSetHierarchyConfig, DataSourceConfig
+from statgpt.common.data.base import (
+    DataSetConfig,
+    DataSetConfigTemplate,
+    DataSetHierarchyConfig,
+    DataSourceConfig,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -153,7 +158,7 @@ class SdmxDataSourceConfig(DataSourceConfig):
         return self.sdmx_config.name
 
 
-class SdmxDataSetConfig(DataSetConfig):
+class SdmxDataSetConfigMixin:
     use_title_from_src: bool = Field(
         default=False, description="Whether to use the title obtained from the source"
     )
@@ -170,6 +175,13 @@ class SdmxDataSetConfig(DataSetConfig):
             "If set to an empty list, no default value codes will be used."
         ),
     )
+
+
+class SdmxDataSetConfigTemplate(SdmxDataSetConfigMixin, DataSetConfigTemplate):
+    pass
+
+
+class SdmxDataSetConfig(SdmxDataSetConfigMixin, DataSetConfig):
 
     def get_source_id(self) -> str:
         return self.urn

--- a/statgpt/common/data/sdmx/v21/datasource.py
+++ b/statgpt/common/data/sdmx/v21/datasource.py
@@ -147,7 +147,7 @@ class Sdmx21DataSourceHandler(
             elif dim.id.upper() in ["INDICATOR", "SERIES"]:
                 dimensions[entity_id] = IndicatorDimensionConfig(is_required=True)
             else:
-                dimensions[entity_id] = BaseDimensionConfig(dimension_type="TODO")
+                dimensions[entity_id] = BaseDimensionConfig(dimension_type=None)
 
         if not dimensions:
             raise ValueError(f"Could not find any dimensions in dataflow {dataflow.urn!r}")

--- a/statgpt/common/data/sdmx/v21/datasource.py
+++ b/statgpt/common/data/sdmx/v21/datasource.py
@@ -161,7 +161,7 @@ class Sdmx21DataSourceHandler(
             True
             for dim in dimensions.values()
             if dim.type is DimensionType.NON_INDICATOR
-            and dim.subtype is SpecialNonIndicatorDimensions.FREQUENCY
+            and dim.subtype is SpecialNonIndicatorDimensions.FREQUENCY  # type: ignore[attr-defined]
         ):
             not_found.append("frequency")
 
@@ -171,7 +171,7 @@ class Sdmx21DataSourceHandler(
             )
             # NOTE: we skip validation here, as it is better to have a partially valid config
             # than to have no config at all. It is expected that the user will fix the config.
-            dataset_config = SdmxDataSetConfig.model_construct(urn=short_urn, dimensions=dimensions)
+            dataset_config = SdmxDataSetConfig.model_construct(urn=short_urn, dimensions=dimensions)  # type: ignore[arg-type]
         else:
             dataset_config = SdmxDataSetConfig(urn=short_urn, dimensions=dimensions)
 

--- a/statgpt/common/data/sdmx/v21/datasource.py
+++ b/statgpt/common/data/sdmx/v21/datasource.py
@@ -5,17 +5,23 @@ from operator import itemgetter
 
 from langchain_core.documents import Document
 from sdmx.message import StructureMessage
+from sdmx.model.common import TimeDimension
 from sdmx.model.v21 import DataflowDefinition as Dataflow
 
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.config import multiline_logger as logger
 from statgpt.common.data.base import (
+    BaseDimensionConfig,
     DataSetDescriptor,
     DatasetHierarchy,
     DataSourceHandler,
     DataSourceType,
     DefaultDatasetHierarchyCreator,
     DimensionType,
+    IndicatorDimensionConfig,
+    NonIndicatorDimensionConfig,
+    SpecialNonIndicatorDimensions,
+    TimePeriodDimensionConfig,
     VirtualDimensionCategory,
 )
 from statgpt.common.data.sdmx.common import (
@@ -97,20 +103,79 @@ class Sdmx21DataSourceHandler(
         client = await self.create_sdmx_client(auth_context)
 
         message: StructureMessage = await client.dataflow(
-            agency_id="all", resource_id="all", version="latest", params={}
+            agency_id="all",
+            resource_id="all",
+            version="latest",
+            params={"references": "datastructure"},
         )
         dataflows: list[Dataflow] = list(message.dataflow.values())
-        return [
-            DataSetDescriptor(
-                source_id=self._urn_parser.parse(dataflow.urn).get_short_urn(),
-                name=dataflow.name[self._config.locale],
-                description=dataflow.description.localizations.get(self._config.locale),
-                details=SdmxDataSetConfig(
-                    urn=self._urn_parser.parse(dataflow.urn).get_short_urn()
-                ).model_dump(by_alias=True),
+
+        res = [self._get_dataset_descriptor(dataflow) for dataflow in dataflows]
+        return res
+
+    def _get_dataset_descriptor(self, dataflow: Dataflow) -> DataSetDescriptor:
+        urn = self._urn_parser.parse(dataflow.urn).get_short_urn()
+        config: dict
+        try:
+            config = self._create_config_for(dataflow, urn)
+        except Exception:
+            logger.warning(
+                f"Failed to create dataset config for dataflow urn={dataflow.urn!r}", exc_info=True
             )
-            for dataflow in dataflows
-        ]
+            config = {"urn": urn}
+
+        return DataSetDescriptor(
+            source_id=urn,
+            name=dataflow.name[self._config.locale],
+            description=dataflow.description.localizations.get(self._config.locale),
+            details=config,
+        )
+
+    @staticmethod
+    def _create_config_for(dataflow: Dataflow, short_urn: str) -> dict:
+        """We do our best to create a valid dataset configuration from the dataflow structure."""
+
+        dimensions: dict[str, BaseDimensionConfig] = {}
+        for dim in dataflow.structure.dimensions:
+            entity_id = dim.id
+            if isinstance(dim, TimeDimension):
+                dimensions[entity_id] = TimePeriodDimensionConfig()
+            elif dim.id.upper() in ["FREQ", "FREQUENCY"]:
+                dimensions[entity_id] = NonIndicatorDimensionConfig(
+                    subtype=SpecialNonIndicatorDimensions.FREQUENCY
+                )
+            elif dim.id.upper() in ["INDICATOR", "SERIES"]:
+                dimensions[entity_id] = IndicatorDimensionConfig(is_required=True)
+            else:
+                dimensions[entity_id] = NonIndicatorDimensionConfig()
+
+        if not dimensions:
+            raise ValueError(f"Could not find any dimensions in dataflow {dataflow.urn!r}")
+
+        not_found = []
+        if not any(True for dim in dimensions.values() if dim.type is DimensionType.TIME_PERIOD):
+            not_found.append("time period")
+        if not any(True for dim in dimensions.values() if dim.type is DimensionType.INDICATOR):
+            not_found.append("indicator")
+        if not any(
+            True
+            for dim in dimensions.values()
+            if dim.type is DimensionType.NON_INDICATOR
+            and dim.subtype is SpecialNonIndicatorDimensions.FREQUENCY
+        ):
+            not_found.append("frequency")
+
+        if not_found:
+            logger.warning(
+                f"Could not find expected dimensions ({', '.join(not_found)}) in dataflow {dataflow.urn!r}"
+            )
+            # NOTE: we skip validation here, as it is better to have a partially valid config
+            # than to have no config at all. It is expected that the user will fix the config.
+            dataset_config = SdmxDataSetConfig.model_construct(urn=short_urn, dimensions=dimensions)
+        else:
+            dataset_config = SdmxDataSetConfig(urn=short_urn, dimensions=dimensions)
+
+        return dataset_config.model_dump(mode="json")
 
     @property
     def entity_id(self) -> str:

--- a/statgpt/common/data/sdmx/v21/datasource.py
+++ b/statgpt/common/data/sdmx/v21/datasource.py
@@ -29,6 +29,7 @@ from statgpt.common.data.sdmx.common import (
     DimensionCodeCategory,
     SdmxConstants,
     SdmxDataSetConfig,
+    SdmxDataSetConfigTemplate,
     SdmxDataSourceConfig,
     SdmxDimension,
     UrnParser,
@@ -115,14 +116,13 @@ class Sdmx21DataSourceHandler(
 
     def _get_dataset_descriptor(self, dataflow: Dataflow) -> DataSetDescriptor:
         urn = self._urn_parser.parse(dataflow.urn).get_short_urn()
-        config: dict
         try:
             config = self._create_config_for(dataflow, urn)
         except Exception:
             logger.warning(
                 f"Failed to create dataset config for dataflow urn={dataflow.urn!r}", exc_info=True
             )
-            config = {"urn": urn}
+            config = SdmxDataSetConfigTemplate(urn=urn)
 
         return DataSetDescriptor(
             source_id=urn,
@@ -132,7 +132,7 @@ class Sdmx21DataSourceHandler(
         )
 
     @staticmethod
-    def _create_config_for(dataflow: Dataflow, short_urn: str) -> dict:
+    def _create_config_for(dataflow: Dataflow, short_urn: str) -> SdmxDataSetConfigTemplate:
         """We do our best to create a valid dataset configuration from the dataflow structure."""
 
         dimensions: dict[str, BaseDimensionConfig] = {}
@@ -147,35 +147,12 @@ class Sdmx21DataSourceHandler(
             elif dim.id.upper() in ["INDICATOR", "SERIES"]:
                 dimensions[entity_id] = IndicatorDimensionConfig(is_required=True)
             else:
-                dimensions[entity_id] = NonIndicatorDimensionConfig()
+                dimensions[entity_id] = BaseDimensionConfig(dimension_type="TODO")
 
         if not dimensions:
             raise ValueError(f"Could not find any dimensions in dataflow {dataflow.urn!r}")
 
-        not_found = []
-        if not any(True for dim in dimensions.values() if dim.type is DimensionType.TIME_PERIOD):
-            not_found.append("time period")
-        if not any(True for dim in dimensions.values() if dim.type is DimensionType.INDICATOR):
-            not_found.append("indicator")
-        if not any(
-            True
-            for dim in dimensions.values()
-            if dim.type is DimensionType.NON_INDICATOR
-            and dim.subtype is SpecialNonIndicatorDimensions.FREQUENCY  # type: ignore[attr-defined]
-        ):
-            not_found.append("frequency")
-
-        if not_found:
-            logger.warning(
-                f"Could not find expected dimensions ({', '.join(not_found)}) in dataflow {dataflow.urn!r}"
-            )
-            # NOTE: we skip validation here, as it is better to have a partially valid config
-            # than to have no config at all. It is expected that the user will fix the config.
-            dataset_config = SdmxDataSetConfig.model_construct(urn=short_urn, dimensions=dimensions)  # type: ignore[arg-type]
-        else:
-            dataset_config = SdmxDataSetConfig(urn=short_urn, dimensions=dimensions)
-
-        return dataset_config.model_dump(mode="json")
+        return SdmxDataSetConfigTemplate(urn=short_urn, dimensions=dimensions)
 
     @property
     def entity_id(self) -> str:


### PR DESCRIPTION
### Applicable issues

- fixes #82 

### Description of changes

Enhances the `/data-sources/{id}/available-datasets endpoint` to return pre-configured dataset definitions by analyzing dataflow structure.

  - Fetches data structure definitions alongside dataflows to enable dimension analysis.
  - Auto-detects dimension types (time, frequency, indicator) from dataflow metadata.
  - Falls back to partial config with warning when required dimensions can't be identified.
  - Moves `AuthContext` creation from service to router level.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
