### PR TITLE
fix: convert empty strings to None for max_embeddings in CLI settings

### DIFF
--- a/statgpt/cli/settings.py
+++ b/statgpt/cli/settings.py
@@ -77,7 +77,7 @@ class CLISettings(BaseSettings):
 
     @field_validator("max_embeddings", mode="before")
     @classmethod
-    def empty_str_to_none(cls, v: Any) -> int | None:
+    def empty_str_to_none(cls, v: Any) -> Any:
         """Convert empty strings to None for optional int fields."""
         if v == "":
             return None

--- a/statgpt/cli/settings.py
+++ b/statgpt/cli/settings.py
@@ -4,7 +4,7 @@ import os
 from enum import StrEnum
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -74,6 +74,14 @@ class CLISettings(BaseSettings):
         description="Maximum number of embeddings for reindex operations",
         json_schema_extra=field_meta(SettingsSection.CONTENT),
     )
+
+    @field_validator("max_embeddings", mode="before")
+    @classmethod
+    def empty_str_to_none(cls, v: Any) -> int | None:
+        """Convert empty strings to None for optional int fields."""
+        if v == "":
+            return None
+        return v
 
     auth_provider: str | None = Field(
         default=None,

--- a/tests/unit/cli/shared/test_settings.py
+++ b/tests/unit/cli/shared/test_settings.py
@@ -77,6 +77,17 @@ class TestCLISettingsEnvOverride:
         assert settings.auth_azure_authority == "https://login.microsoftonline.com/tenant"
         assert settings.auth_azure_scope == "api://scope/.default"
 
+    def test_max_embeddings_from_env(self, clean_cli_env, monkeypatch):
+        monkeypatch.setenv("STATGPT_CLI_MAX_EMBEDDINGS", "100")
+        settings = make_settings()
+        assert settings.max_embeddings == 100
+
+    def test_max_embeddings_empty_string_becomes_none(self, clean_cli_env, monkeypatch):
+        """Empty string for max_embeddings should be treated as None."""
+        monkeypatch.setenv("STATGPT_CLI_MAX_EMBEDDINGS", "")
+        settings = make_settings()
+        assert settings.max_embeddings is None
+
 
 class TestCLIDataDir:
     """Tests for cli_data_dir property."""


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

Added conversion of empty string to none for `max_embeddings` property of cli settings

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
