### PR TITLE
fix: CLI issues

### DIFF
--- a/statgpt/cli/README.md
+++ b/statgpt/cli/README.md
@@ -16,6 +16,45 @@ Before using the CLI:
 make statgpt_cli
 ```
 
+## Global Flags
+
+| Flag                | Description                                          | Modes        |
+|---------------------|------------------------------------------------------|--------------|
+| `--debug`           | Show full stack trace on errors                      | Direct, REPL |
+| `--non-interactive` | Disable interactive prompts (fail if input required) | Direct only  |
+
+### Non-Interactive Mode
+
+Use `--non-interactive` for CI/CD pipelines or scripts where interactive prompts are not possible:
+
+```bash
+# Will fail with helpful message if required parameters are missing
+statgpt --non-interactive content init --client-id my-client --datasets urn1,urn2 -y
+
+# Combined with -y to skip all confirmations
+statgpt --non-interactive channel import --file archive.zip
+```
+
+**Note:** In non-interactive mode:
+
+- Commands fail fast with helpful error messages showing required parameters
+- Use `-y/--yes` to skip confirmation prompts
+- All required parameters must be provided via command-line arguments
+
+### Debug Mode
+
+Use `--debug` to see full stack traces when errors occur:
+
+```bash
+# Direct mode
+statgpt --debug content init --client-id my-client
+
+# REPL mode - start REPL with debug enabled
+statgpt --debug
+```
+
+This is useful for troubleshooting and reporting bugs.
+
 ## Interactive Features
 
 - **Tab Completion**: Press Tab to see available commands and autocomplete
@@ -96,7 +135,8 @@ statgpt> channel reindex -c my-channel --mode all
 statgpt> content init                             # interactive client selection
 statgpt> content init --client-id my-client       # specific client
 statgpt> content init --only channels,glossaries  # specific components
-statgpt> content init -y                          # skip all prompts
+statgpt> content init -y                          # skip all prompts, process ALL datasets
+statgpt> content init --datasets urn1,urn2        # specific datasets only
 ```
 
 | Option        | Description                                                              |
@@ -104,12 +144,17 @@ statgpt> content init -y                          # skip all prompts
 | `--client-id` | Comma-separated client IDs (interactive selection if omitted)            |
 | `--datasets`  | Comma-separated dataset URNs to process                                  |
 | `-o, --only`  | Components: `channels`, `datasources`, `datasets`, `glossaries`, `files` |
-| `-y, --yes`   | Skip all confirmation prompts                                            |
+| `-y, --yes`   | Skip all confirmation prompts and process ALL available content          |
 
 **Notes:**
 
 - Specifying `datasets` automatically includes `datasources` (dependency)
 - Interactive selectors: arrow keys to navigate, space to toggle, enter to confirm
+- **Important:** Using `-y` without `--datasets` processes ALL available datasets for selected clients
+- For non-interactive use in CI/CD, always specify `--client-id` and optionally `--datasets`:
+  ```bash
+  statgpt --non-interactive content init --client-id my-client --datasets urn1,urn2 -y
+  ```
 
 ## Environment Variables
 

--- a/statgpt/cli/__init__.py
+++ b/statgpt/cli/__init__.py
@@ -11,12 +11,18 @@ from statgpt.cli.shared.console import console, print_error
 from statgpt.cli.shared.logging import setup_logging
 
 
-async def _execute_direct(registry: CommandRegistry, args: list[str], non_interactive: bool) -> int:
+async def _execute_direct(
+    registry: CommandRegistry,
+    args: list[str],
+    non_interactive: bool,
+    debug: bool = False,
+) -> int:
     """Execute a command directly from command-line arguments.
 
     Returns 0 for success, 1 for error.
     """
     cli_runtime.non_interactive = non_interactive
+    cli_runtime.debug = debug
 
     command_str = " ".join(args)
 
@@ -48,7 +54,10 @@ async def _execute_direct(registry: CommandRegistry, args: list[str], non_intera
             console.print("[dim]Run 'statgpt help' for available commands.[/dim]")
             return 1
         return 0
-    except Exception:
+    except Exception as e:
+        print_error(f"Command failed: {e}")
+        if debug:
+            raise
         return 1
 
 
@@ -61,18 +70,23 @@ def main() -> None:
         registry = create_registry()
 
         args = sys.argv[1:]
-        if args:
-            command_args = []
-            non_interactive = False
-            for arg in args:
-                if arg == "--non-interactive":
-                    non_interactive = True
-                elif arg != "--debug":
-                    command_args.append(arg)
+        command_args = []
+        non_interactive = False
+        debug = False
+        for arg in args:
+            if arg == "--non-interactive":
+                non_interactive = True
+            elif arg == "--debug":
+                debug = True
+            else:
+                command_args.append(arg)
 
-            if command_args:
-                exit_code = asyncio.run(_execute_direct(registry, command_args, non_interactive))
-                sys.exit(exit_code)
+        # Set debug in runtime state (used by both direct and REPL modes)
+        cli_runtime.debug = debug
+
+        if command_args:
+            exit_code = asyncio.run(_execute_direct(registry, command_args, non_interactive, debug))
+            sys.exit(exit_code)
 
         asyncio.run(run_repl(registry))
     except KeyboardInterrupt:
@@ -82,7 +96,7 @@ def main() -> None:
     except Exception as e:
         logger.exception("CLI crashed with error")
         print(f"Error: {e}", file=sys.stderr)
-        if "--debug" in sys.argv:
+        if cli_runtime.debug:
             raise
         sys.exit(1)
 

--- a/statgpt/cli/__init__.py
+++ b/statgpt/cli/__init__.py
@@ -11,19 +11,30 @@ from statgpt.cli.shared.console import console, print_error
 from statgpt.cli.shared.logging import setup_logging
 
 
-async def _execute_direct(
-    registry: CommandRegistry,
-    args: list[str],
-    non_interactive: bool,
-    debug: bool = False,
-) -> int:
+def _init_runtime() -> list[str]:
+    """Parse global flags from sys.argv and initialize cli_runtime.
+
+    Returns:
+        Command arguments with global flags removed.
+    """
+    command_args = []
+
+    for arg in sys.argv[1:]:
+        if arg == "--non-interactive":
+            cli_runtime.non_interactive = True
+        elif arg == "--debug":
+            cli_runtime.debug = True
+        else:
+            command_args.append(arg)
+
+    return command_args
+
+
+async def _execute_direct(registry: CommandRegistry, args: list[str]) -> int:
     """Execute a command directly from command-line arguments.
 
     Returns 0 for success, 1 for error.
     """
-    cli_runtime.non_interactive = non_interactive
-    cli_runtime.debug = debug
-
     command_str = " ".join(args)
 
     if args[0] == "help":
@@ -56,7 +67,7 @@ async def _execute_direct(
         return 0
     except Exception as e:
         print_error(f"Command failed: {e}")
-        if debug:
+        if cli_runtime.debug:
             raise
         return 1
 
@@ -68,24 +79,10 @@ def main() -> None:
 
     try:
         registry = create_registry()
-
-        args = sys.argv[1:]
-        command_args = []
-        non_interactive = False
-        debug = False
-        for arg in args:
-            if arg == "--non-interactive":
-                non_interactive = True
-            elif arg == "--debug":
-                debug = True
-            else:
-                command_args.append(arg)
-
-        # Set debug in runtime state (used by both direct and REPL modes)
-        cli_runtime.debug = debug
+        command_args = _init_runtime()
 
         if command_args:
-            exit_code = asyncio.run(_execute_direct(registry, command_args, non_interactive, debug))
+            exit_code = asyncio.run(_execute_direct(registry, command_args))
             sys.exit(exit_code)
 
         asyncio.run(run_repl(registry))

--- a/statgpt/cli/commands/content.py
+++ b/statgpt/cli/commands/content.py
@@ -4,12 +4,12 @@ import os
 from typing import Any
 
 from rich.panel import Panel
-from rich.prompt import Confirm
 
 from statgpt.cli.commands.base import Command, CommandArg, CommandGroup
 from statgpt.cli.settings import cli_settings
 from statgpt.cli.shared import (
     AdminClient,
+    confirm_interactive,
     console,
     get_admin_client,
     print_error,
@@ -73,7 +73,15 @@ def _confirm_full_init(clients: list[str], components: set[str]) -> bool:
         f"[bold]Clients:[/bold] {', '.join(clients)}"
     )
     console.print(Panel(content, title="Content Initialization", border_style="yellow"))
-    return Confirm.ask("Proceed?", default=False)
+    return confirm_interactive(
+        "Proceed?",
+        default=False,
+        error_message=(
+            "Full initialization requires confirmation.\n"
+            "  Use -y/--yes to skip confirmation.\n"
+            "  Usage: statgpt content init -y"
+        ),
+    )
 
 
 def _load_available_datasets(client_config_dir: str) -> list[tuple[str, str]]:
@@ -170,7 +178,16 @@ async def init_handler(
             # Remove duplicates and sort
             available_datasets = sorted(set(available_datasets), key=lambda x: x[1])
 
-            if Confirm.ask("Would you like to select specific datasets?", default=False):
+            if confirm_interactive(
+                "Would you like to select specific datasets?",
+                default=False,
+                error_message=(
+                    "Dataset selection requires interactive mode.\n"
+                    "  Use --datasets to specify datasets in non-interactive mode.\n"
+                    "  Usage: statgpt content init --datasets <urn1,urn2,...>\n"
+                    "  Or use -y to process all datasets."
+                ),
+            ):
                 selected = await select_datasets_interactive(available_datasets)
                 if not selected:
                     print_info("No datasets selected. Aborted.")

--- a/statgpt/cli/repl.py
+++ b/statgpt/cli/repl.py
@@ -1,7 +1,6 @@
 """Interactive REPL for StatGPT CLI."""
 
 import asyncio
-import sys
 from pathlib import Path
 
 from prompt_toolkit import PromptSession
@@ -10,7 +9,7 @@ from prompt_toolkit.styles import Style
 
 from statgpt.cli.commands.base import CommandRegistry
 from statgpt.cli.completer import StatGPTCompleter
-from statgpt.cli.settings import cli_settings
+from statgpt.cli.settings import cli_runtime, cli_settings
 from statgpt.cli.shared.auth import get_token_info, is_logged_in
 from statgpt.cli.shared.console import console, print_banner, print_error
 
@@ -149,7 +148,7 @@ class REPL:
                 break
             except Exception as e:
                 print_error(f"Error: {e}")
-                if "--debug" in sys.argv:
+                if cli_runtime.debug:
                     console.print_exception()
 
 

--- a/statgpt/cli/settings.py
+++ b/statgpt/cli/settings.py
@@ -218,9 +218,11 @@ class CLIRuntimeState:
     Attributes:
         non_interactive: When True, interactive prompts raise NonInteractiveError
             instead of displaying UI selectors.
+        debug: When True, full stack traces are shown on errors.
     """
 
     non_interactive: bool = False
+    debug: bool = False
 
 
 cli_runtime = CLIRuntimeState()

--- a/statgpt/cli/shared/__init__.py
+++ b/statgpt/cli/shared/__init__.py
@@ -33,6 +33,7 @@ from statgpt.cli.shared.console import (
 from statgpt.cli.shared.logging import get_logger, setup_logging
 from statgpt.cli.shared.prompts import (
     NonInteractiveError,
+    confirm_interactive,
     select_clients_interactive,
     select_datasets_interactive,
     select_item_interactive,
@@ -72,6 +73,7 @@ __all__ = [
     "get_logger",
     # Prompts
     "NonInteractiveError",
+    "confirm_interactive",
     "select_item_interactive",
     "select_items_interactive",
     "select_clients_interactive",

--- a/statgpt/cli/shared/prompts.py
+++ b/statgpt/cli/shared/prompts.py
@@ -6,6 +6,7 @@ from prompt_toolkit.layout import Layout
 from prompt_toolkit.layout.containers import Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.styles import Style
+from rich.prompt import Confirm
 
 from statgpt.cli.settings import cli_runtime
 
@@ -16,6 +17,34 @@ class NonInteractiveError(Exception):
     This exception is caught by command handlers to provide helpful error messages
     indicating which parameters must be provided via command-line arguments.
     """
+
+
+def confirm_interactive(
+    prompt: str,
+    default: bool = False,
+    error_message: str | None = None,
+) -> bool:
+    """Show confirmation prompt or raise NonInteractiveError in non-interactive mode.
+
+    Args:
+        prompt: The confirmation prompt text
+        default: Default value if user just presses Enter
+        error_message: Custom error message for non-interactive mode.
+                      If None, a generic message is used.
+
+    Returns:
+        True if confirmed, False otherwise
+
+    Raises:
+        NonInteractiveError: If non-interactive mode is enabled
+    """
+    if cli_runtime.non_interactive:
+        raise NonInteractiveError(
+            error_message
+            or "Confirmation required but --non-interactive mode is enabled. "
+            "Use -y/--yes to skip confirmations."
+        )
+    return Confirm.ask(prompt, default=default)
 
 
 class CheckboxSelector:
@@ -379,8 +408,9 @@ async def select_clients_interactive(available_clients: list[str]) -> set[str] |
     """
     if cli_runtime.non_interactive:
         raise NonInteractiveError(
-            "Interactive client selection required but --non-interactive mode is enabled. "
-            "Please provide the required parameter."
+            "Interactive client selection required but --non-interactive mode is enabled.\n"
+            "  Use --client-id to specify clients.\n"
+            "  Usage: statgpt content init --client-id <client1,client2,...>"
         )
     items = [("__all__", "All clients")] + [(c, c) for c in sorted(available_clients)]
 
@@ -416,8 +446,9 @@ async def select_datasets_interactive(
     """
     if cli_runtime.non_interactive:
         raise NonInteractiveError(
-            "Interactive dataset selection required but --non-interactive mode is enabled. "
-            "Please provide the required parameter."
+            "Interactive dataset selection required but --non-interactive mode is enabled.\n"
+            "  Use --datasets to specify datasets.\n"
+            "  Usage: statgpt content init --datasets <urn1,urn2,...>"
         )
     selected = await select_items_interactive(
         datasets,


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

Fixed CLI non-interactive mode and debug flag issues.

#### Bug Fixes

- Non-interactive mode prompts: `Confirm.ask()` now properly raises NonInteractiveError instead of prompting for y/n in `--non-interactive` mode
- Debug flag: `--debug` now shows full stack traces in both direct and REPL modes

#### Improvements

- Improved `NonInteractiveError` messages to include full command syntax (e.g.,`Usage: statgpt content init --datasets <urn1,urn2,...>`)
- Added `debug` field to CLIRuntimeState for consistent state management (alongside `non_interactive`)

#### Documentation

- Added "Global Flags" section to README documenting `--debug` and `--non-interactive`
- Clarified `-y` flag behavior: processes ALL datasets when used without `--datasets`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
