### PR TITLE
feat: add Auth0 authentication provider #90

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -64,7 +64,8 @@ STATGPT_CLI_DIAL_API_KEY=dial_api_key
 # Authentication Provider Selection (optional for local dev, set to: azure, keycloak, or auth0)
 STATGPT_CLI_AUTH_PROVIDER=
 # Fixed port for OAuth callback (required for providers like Auth0 that don't allow wildcard ports)
-STATGPT_CLI_AUTH_CALLBACK_PORT=
+# Uncomment for auth0 usage
+# STATGPT_CLI_AUTH_CALLBACK_PORT=8142
 
 # Azure Entra ID Authentication (interactive login uses public client, M2M uses client credentials)
 STATGPT_CLI_AUTH_AZURE_CLIENT_ID=

--- a/.env.template
+++ b/.env.template
@@ -61,7 +61,7 @@ STATGPT_CLI_MAX_EMBEDDINGS=
 STATGPT_CLI_DIAL_URL=http://localhost:8080
 STATGPT_CLI_DIAL_API_KEY=dial_api_key
 
-# Authentication Provider Selection (optional for local dev, set to: azure or keycloak)
+# Authentication Provider Selection (optional for local dev, set to: azure, keycloak, or auth0)
 STATGPT_CLI_AUTH_PROVIDER=
 
 # Azure Entra ID Authentication
@@ -80,6 +80,15 @@ STATGPT_CLI_AUTH_KEYCLOAK_CLIENT_SECRET=
 STATGPT_CLI_AUTH_KEYCLOAK_SCOPE=openid
 STATGPT_CLI_AUTH_KEYCLOAK_USERNAME=
 STATGPT_CLI_AUTH_KEYCLOAK_PASSWORD=
+
+# Auth0 Authentication
+STATGPT_CLI_AUTH_AUTH0_DOMAIN=mytenant.us.auth0.com
+STATGPT_CLI_AUTH_AUTH0_CLIENT_ID=
+STATGPT_CLI_AUTH_AUTH0_AUDIENCE=
+STATGPT_CLI_AUTH_AUTH0_CLIENT_SECRET=
+STATGPT_CLI_AUTH_AUTH0_SCOPE=openid profile email offline_access
+STATGPT_CLI_AUTH_AUTH0_USERNAME=
+STATGPT_CLI_AUTH_AUTH0_PASSWORD=
 
 # General
 STATGPT_CLI_LOG_LEVEL=INFO

--- a/.env.template
+++ b/.env.template
@@ -63,32 +63,28 @@ STATGPT_CLI_DIAL_API_KEY=dial_api_key
 
 # Authentication Provider Selection (optional for local dev, set to: azure, keycloak, or auth0)
 STATGPT_CLI_AUTH_PROVIDER=
+# Fixed port for OAuth callback (required for providers like Auth0 that don't allow wildcard ports)
+STATGPT_CLI_AUTH_CALLBACK_PORT=
 
-# Azure Entra ID Authentication
+# Azure Entra ID Authentication (interactive login uses public client, M2M uses client credentials)
 STATGPT_CLI_AUTH_AZURE_CLIENT_ID=
 STATGPT_CLI_AUTH_AZURE_AUTHORITY=https://login.microsoftonline.com/{tenant-id}
 STATGPT_CLI_AUTH_AZURE_SCOPE=api://{client-id}/.default
 STATGPT_CLI_AUTH_AZURE_CLIENT_SECRET=
-STATGPT_CLI_AUTH_AZURE_USERNAME=
-STATGPT_CLI_AUTH_AZURE_PASSWORD=
 
-# Keycloak Authentication
+# Keycloak Authentication (interactive login uses public client, M2M uses client credentials)
 STATGPT_CLI_AUTH_KEYCLOAK_SERVER_URL=https://keycloak.example.com
 STATGPT_CLI_AUTH_KEYCLOAK_REALM=
 STATGPT_CLI_AUTH_KEYCLOAK_CLIENT_ID=
 STATGPT_CLI_AUTH_KEYCLOAK_CLIENT_SECRET=
 STATGPT_CLI_AUTH_KEYCLOAK_SCOPE=openid
-STATGPT_CLI_AUTH_KEYCLOAK_USERNAME=
-STATGPT_CLI_AUTH_KEYCLOAK_PASSWORD=
 
-# Auth0 Authentication
+# Auth0 Authentication (interactive login uses public client, M2M uses client credentials)
 STATGPT_CLI_AUTH_AUTH0_DOMAIN=mytenant.us.auth0.com
 STATGPT_CLI_AUTH_AUTH0_CLIENT_ID=
 STATGPT_CLI_AUTH_AUTH0_AUDIENCE=
 STATGPT_CLI_AUTH_AUTH0_CLIENT_SECRET=
 STATGPT_CLI_AUTH_AUTH0_SCOPE=openid profile email offline_access
-STATGPT_CLI_AUTH_AUTH0_USERNAME=
-STATGPT_CLI_AUTH_AUTH0_PASSWORD=
 
 # General
 STATGPT_CLI_LOG_LEVEL=INFO

--- a/statgpt/cli/README.md
+++ b/statgpt/cli/README.md
@@ -172,26 +172,21 @@ All variables are prefixed with `STATGPT_CLI_`.
 | `DIAL_API_KEY`                |    No    | DIAL API key                                      | -                                     |
 | **Authentication**            |          |                                                   |                                       |
 | `AUTH_PROVIDER`               |    No    | Auth provider (`azure`, `keycloak`, `auth0`)      | -                                     |
+| `AUTH_CALLBACK_PORT`          | Yes****  | Fixed port for OAuth callback (e.g., `8085`)      | dynamic                               |
 | `AUTH_AZURE_CLIENT_ID`        |  Yes**   | Azure application/client ID                       | -                                     |
 | `AUTH_AZURE_AUTHORITY`        |  Yes**   | Authority URL (includes tenant)                   | -                                     |
 | `AUTH_AZURE_SCOPE`            |  Yes**   | Token scope                                       | -                                     |
-| `AUTH_AZURE_CLIENT_SECRET`    |  Yes***  | Client secret (system_user only)                  | -                                     |
-| `AUTH_AZURE_USERNAME`         |  Yes***  | Username (system_user only)                       | -                                     |
-| `AUTH_AZURE_PASSWORD`         |  Yes***  | Password (system_user only)                       | -                                     |
+| `AUTH_AZURE_CLIENT_SECRET`    |  Yes***  | Client secret (M2M/CI only)                       | -                                     |
 | `AUTH_KEYCLOAK_SERVER_URL`    |  Yes**   | Keycloak server URL                               | -                                     |
 | `AUTH_KEYCLOAK_REALM`         |  Yes**   | Keycloak realm name                               | -                                     |
 | `AUTH_KEYCLOAK_CLIENT_ID`     |  Yes**   | Keycloak client ID                                | -                                     |
-| `AUTH_KEYCLOAK_CLIENT_SECRET` |    No    | Client secret (confidential only)                 | -                                     |
+| `AUTH_KEYCLOAK_CLIENT_SECRET` |  Yes***  | Client secret (M2M/CI only)                       | -                                     |
 | `AUTH_KEYCLOAK_SCOPE`         |    No    | OAuth scope                                       | `openid`                              |
-| `AUTH_KEYCLOAK_USERNAME`      |  Yes***  | Username (system_user only)                       | -                                     |
-| `AUTH_KEYCLOAK_PASSWORD`      |  Yes***  | Password (system_user only)                       | -                                     |
 | `AUTH_AUTH0_DOMAIN`           |  Yes**   | Auth0 tenant domain (e.g., mytenant.us.auth0.com) | -                                     |
 | `AUTH_AUTH0_CLIENT_ID`        |  Yes**   | Auth0 application client ID                       | -                                     |
 | `AUTH_AUTH0_AUDIENCE`         |  Yes**   | Auth0 API identifier (audience)                   | -                                     |
-| `AUTH_AUTH0_CLIENT_SECRET`    |    No    | Client secret (confidential clients)              | -                                     |
+| `AUTH_AUTH0_CLIENT_SECRET`    |  Yes***  | Client secret (M2M/CI only)                       | -                                     |
 | `AUTH_AUTH0_SCOPE`            |    No    | OAuth scope                                       | `openid profile email offline_access` |
-| `AUTH_AUTH0_USERNAME`         |  Yes***  | Username (system_user only)                       | -                                     |
-| `AUTH_AUTH0_PASSWORD`         |  Yes***  | Password (system_user only)                       | -                                     |
 | **General**                   |          |                                                   |                                       |
 | `LOG_LEVEL`                   |    No    | `DEBUG`, `INFO`, `WARNING`, `ERROR`               | `INFO`                                |
 | `DATA_DIR`                    |    No    | CLI data directory                                | `~/.statgpt`                          |
@@ -199,6 +194,7 @@ All variables are prefixed with `STATGPT_CLI_`.
 \* Required for `content init` command
 \** Required for `auth login` (Azure, Keycloak, or Auth0, depending on `AUTH_PROVIDER`)
 \*** Required for `auth login --method system_user`
+\**** Required for Auth0 interactive login (Auth0 doesn't support wildcard ports)
 
 ## Data Directory
 
@@ -208,6 +204,103 @@ The CLI stores persistent data in `~/.statgpt/` (configurable via `STATGPT_CLI_D
 |--------------------|-------------------------------------------------------|
 | `cli_history`      | Command history for up/down arrow navigation          |
 | `token_cache.json` | Cached authentication tokens (restricted permissions) |
+
+## Authentication Provider Setup
+
+All providers support two authentication flows:
+- **Interactive login** - Browser-based authentication using PKCE (for developers)
+- **System user login** - Client Credentials Grant (for CI/CD pipelines)
+
+### Azure Entra ID
+
+**For Interactive Login (Public Client):**
+
+1. Go to Azure Portal → Microsoft Entra ID → App registrations
+2. Create new registration (e.g., "StatGPT CLI")
+3. Under Authentication:
+   - Add platform: Mobile and desktop applications
+   - Add redirect URI: `http://localhost` (MSAL handles port internally)
+   - Enable "Allow public client flows"
+4. Note the Application (client) ID and Directory (tenant) ID
+5. Configure environment variables:
+   ```bash
+   STATGPT_CLI_AUTH_PROVIDER=azure
+   STATGPT_CLI_AUTH_AZURE_CLIENT_ID={application-id}
+   STATGPT_CLI_AUTH_AZURE_AUTHORITY=https://login.microsoftonline.com/{tenant-id}
+   STATGPT_CLI_AUTH_AZURE_SCOPE=api://{api-client-id}/.default
+   ```
+
+**For M2M/CI (Service Principal):**
+
+1. In the same or different app registration, go to Certificates & secrets
+2. Create new client secret, note the value
+3. Ensure the app has required API permissions (Application permissions, not Delegated)
+4. Grant admin consent for the permissions
+5. Add to environment:
+   ```bash
+   STATGPT_CLI_AUTH_AZURE_CLIENT_SECRET={secret-value}
+   ```
+
+### Keycloak
+
+**For Interactive Login (Public Client):**
+
+1. Go to Keycloak Admin Console → Clients → Create client
+2. Client type: OpenID Connect
+3. Client ID: e.g., `statgpt-cli`
+4. Client authentication: OFF (public client)
+5. Standard flow: Enabled
+6. Valid redirect URIs: `http://localhost:*/callback` or fixed port (e.g., `http://localhost:8085/callback`)
+7. Configure environment variables:
+   ```bash
+   STATGPT_CLI_AUTH_PROVIDER=keycloak
+   STATGPT_CLI_AUTH_KEYCLOAK_SERVER_URL=https://keycloak.example.com
+   STATGPT_CLI_AUTH_KEYCLOAK_REALM={realm-name}
+   STATGPT_CLI_AUTH_KEYCLOAK_CLIENT_ID=statgpt-cli
+   ```
+
+**For M2M/CI (Service Account):**
+
+1. Create a new client (can be same or separate from interactive client)
+2. Client authentication: ON (confidential client)
+3. Enable "Service accounts roles" in capability config
+4. In Credentials tab, copy the client secret
+5. Assign required roles to the service account user
+6. Add to environment:
+   ```bash
+   STATGPT_CLI_AUTH_KEYCLOAK_CLIENT_SECRET={client-secret}
+   ```
+
+### Auth0
+
+**For Interactive Login (Native Application):**
+
+1. Go to Auth0 Dashboard → Applications → Create Application
+2. Choose "Native" application type
+3. In Settings:
+   - Allowed Callback URLs: `http://localhost:8085/callback` (must match `AUTH_CALLBACK_PORT`)
+4. Note the Domain and Client ID
+5. Configure environment variables:
+   ```bash
+   STATGPT_CLI_AUTH_PROVIDER=auth0
+   STATGPT_CLI_AUTH_AUTH0_DOMAIN={tenant}.us.auth0.com
+   STATGPT_CLI_AUTH_AUTH0_CLIENT_ID={client-id}
+   STATGPT_CLI_AUTH_AUTH0_AUDIENCE={api-identifier}
+   STATGPT_CLI_AUTH_CALLBACK_PORT=8085
+   ```
+
+**For M2M/CI (Machine-to-Machine):**
+
+1. Create NEW Application → Machine to Machine
+2. Select the API to authorize
+3. Copy Client ID and Client Secret
+4. Configure environment (use M2M app credentials):
+   ```bash
+   STATGPT_CLI_AUTH_AUTH0_CLIENT_ID={m2m-client-id}
+   STATGPT_CLI_AUTH_AUTH0_CLIENT_SECRET={m2m-client-secret}
+   ```
+
+**Note:** Auth0 requires a fixed callback port (doesn't support wildcard ports in redirect URIs).
 
 ## Example Workflows
 

--- a/statgpt/cli/README.md
+++ b/statgpt/cli/README.md
@@ -172,7 +172,7 @@ All variables are prefixed with `STATGPT_CLI_`.
 | `DIAL_API_KEY`                |    No    | DIAL API key                                      | -                                     |
 | **Authentication**            |          |                                                   |                                       |
 | `AUTH_PROVIDER`               |    No    | Auth provider (`azure`, `keycloak`, `auth0`)      | -                                     |
-| `AUTH_CALLBACK_PORT`          | Yes****  | Fixed port for OAuth callback (e.g., `8085`)      | dynamic                               |
+| `AUTH_CALLBACK_PORT`          | Yes****  | Fixed port for OAuth callback (e.g., `8142`)      | dynamic                               |
 | `AUTH_AZURE_CLIENT_ID`        |  Yes**   | Azure application/client ID                       | -                                     |
 | `AUTH_AZURE_AUTHORITY`        |  Yes**   | Authority URL (includes tenant)                   | -                                     |
 | `AUTH_AZURE_SCOPE`            |  Yes**   | Token scope                                       | -                                     |
@@ -250,7 +250,7 @@ All providers support two authentication flows:
 3. Client ID: e.g., `statgpt-cli`
 4. Client authentication: OFF (public client)
 5. Standard flow: Enabled
-6. Valid redirect URIs: `http://localhost:*/callback` or fixed port (e.g., `http://localhost:8085/callback`)
+6. Valid redirect URIs: `http://localhost:*/callback` or fixed port (e.g., `http://localhost:8142/callback`)
 7. Configure environment variables:
    ```bash
    STATGPT_CLI_AUTH_PROVIDER=keycloak
@@ -278,7 +278,7 @@ All providers support two authentication flows:
 1. Go to Auth0 Dashboard → Applications → Create Application
 2. Choose "Native" application type
 3. In Settings:
-   - Allowed Callback URLs: `http://localhost:8085/callback` (must match `AUTH_CALLBACK_PORT`)
+   - Allowed Callback URLs: `http://localhost:8142/callback` (must match `AUTH_CALLBACK_PORT`)
 4. Note the Domain and Client ID
 5. Configure environment variables:
    ```bash
@@ -286,7 +286,7 @@ All providers support two authentication flows:
    STATGPT_CLI_AUTH_AUTH0_DOMAIN={tenant}.us.auth0.com
    STATGPT_CLI_AUTH_AUTH0_CLIENT_ID={client-id}
    STATGPT_CLI_AUTH_AUTH0_AUDIENCE={api-identifier}
-   STATGPT_CLI_AUTH_CALLBACK_PORT=8085
+   STATGPT_CLI_AUTH_CALLBACK_PORT=8142
    ```
 
 **For M2M/CI (Machine-to-Machine):**

--- a/statgpt/cli/README.md
+++ b/statgpt/cli/README.md
@@ -160,37 +160,44 @@ statgpt> content init --datasets urn1,urn2        # specific datasets only
 
 All variables are prefixed with `STATGPT_CLI_`.
 
-| Variable                      | Required | Description                         | Default                 |
-|-------------------------------|:--------:|-------------------------------------|-------------------------|
-| **Admin API**                 |          |                                     |                         |
-| `ADMIN_URL`                   |    No    | StatGPT Admin API URL               | `http://localhost:8000` |
-| **Content Init**              |          |                                     |                         |
-| `CONFIG_DIR`                  |   Yes*   | Configuration directory path        | -                       |
-| `MAX_EMBEDDINGS`              |    No    | Max embeddings for reindex          | unlimited               |
-| **DIAL Integration**          |          |                                     |                         |
-| `DIAL_URL`                    |    No    | DIAL URL for file uploads           | -                       |
-| `DIAL_API_KEY`                |    No    | DIAL API key                        | -                       |
-| **Authentication**            |          |                                     |                         |
-| `AUTH_PROVIDER`               |    No    | Auth provider (`azure`, `keycloak`) | `azure`                 |
-| `AUTH_AZURE_CLIENT_ID`        |  Yes**   | Azure application/client ID         | -                       |
-| `AUTH_AZURE_AUTHORITY`        |  Yes**   | Authority URL (includes tenant)     | -                       |
-| `AUTH_AZURE_SCOPE`            |  Yes**   | Token scope                         | -                       |
-| `AUTH_AZURE_CLIENT_SECRET`    |  Yes***  | Client secret (system_user only)    | -                       |
-| `AUTH_AZURE_USERNAME`         |  Yes***  | Username (system_user only)         | -                       |
-| `AUTH_AZURE_PASSWORD`         |  Yes***  | Password (system_user only)         | -                       |
-| `AUTH_KEYCLOAK_SERVER_URL`    |  Yes**   | Keycloak server URL                 | -                       |
-| `AUTH_KEYCLOAK_REALM`         |  Yes**   | Keycloak realm name                 | -                       |
-| `AUTH_KEYCLOAK_CLIENT_ID`     |  Yes**   | Keycloak client ID                  | -                       |
-| `AUTH_KEYCLOAK_CLIENT_SECRET` |    No    | Client secret (confidential only)   | -                       |
-| `AUTH_KEYCLOAK_SCOPE`         |    No    | OAuth scope                         | `openid`                |
-| `AUTH_KEYCLOAK_USERNAME`      |  Yes***  | Username (system_user only)         | -                       |
-| `AUTH_KEYCLOAK_PASSWORD`      |  Yes***  | Password (system_user only)         | -                       |
-| **General**                   |          |                                     |                         |
-| `LOG_LEVEL`                   |    No    | `DEBUG`, `INFO`, `WARNING`, `ERROR` | `INFO`                  |
-| `DATA_DIR`                    |    No    | CLI data directory                  | `~/.statgpt`            |
+| Variable                      | Required | Description                                       | Default                               |
+|-------------------------------|:--------:|---------------------------------------------------|---------------------------------------|
+| **Admin API**                 |          |                                                   |                                       |
+| `ADMIN_URL`                   |    No    | StatGPT Admin API URL                             | `http://localhost:8000`               |
+| **Content Init**              |          |                                                   |                                       |
+| `CONFIG_DIR`                  |   Yes*   | Configuration directory path                      | -                                     |
+| `MAX_EMBEDDINGS`              |    No    | Max embeddings for reindex                        | unlimited                             |
+| **DIAL Integration**          |          |                                                   |                                       |
+| `DIAL_URL`                    |    No    | DIAL URL for file uploads                         | -                                     |
+| `DIAL_API_KEY`                |    No    | DIAL API key                                      | -                                     |
+| **Authentication**            |          |                                                   |                                       |
+| `AUTH_PROVIDER`               |    No    | Auth provider (`azure`, `keycloak`, `auth0`)      | -                                     |
+| `AUTH_AZURE_CLIENT_ID`        |  Yes**   | Azure application/client ID                       | -                                     |
+| `AUTH_AZURE_AUTHORITY`        |  Yes**   | Authority URL (includes tenant)                   | -                                     |
+| `AUTH_AZURE_SCOPE`            |  Yes**   | Token scope                                       | -                                     |
+| `AUTH_AZURE_CLIENT_SECRET`    |  Yes***  | Client secret (system_user only)                  | -                                     |
+| `AUTH_AZURE_USERNAME`         |  Yes***  | Username (system_user only)                       | -                                     |
+| `AUTH_AZURE_PASSWORD`         |  Yes***  | Password (system_user only)                       | -                                     |
+| `AUTH_KEYCLOAK_SERVER_URL`    |  Yes**   | Keycloak server URL                               | -                                     |
+| `AUTH_KEYCLOAK_REALM`         |  Yes**   | Keycloak realm name                               | -                                     |
+| `AUTH_KEYCLOAK_CLIENT_ID`     |  Yes**   | Keycloak client ID                                | -                                     |
+| `AUTH_KEYCLOAK_CLIENT_SECRET` |    No    | Client secret (confidential only)                 | -                                     |
+| `AUTH_KEYCLOAK_SCOPE`         |    No    | OAuth scope                                       | `openid`                              |
+| `AUTH_KEYCLOAK_USERNAME`      |  Yes***  | Username (system_user only)                       | -                                     |
+| `AUTH_KEYCLOAK_PASSWORD`      |  Yes***  | Password (system_user only)                       | -                                     |
+| `AUTH_AUTH0_DOMAIN`           |  Yes**   | Auth0 tenant domain (e.g., mytenant.us.auth0.com) | -                                     |
+| `AUTH_AUTH0_CLIENT_ID`        |  Yes**   | Auth0 application client ID                       | -                                     |
+| `AUTH_AUTH0_AUDIENCE`         |  Yes**   | Auth0 API identifier (audience)                   | -                                     |
+| `AUTH_AUTH0_CLIENT_SECRET`    |    No    | Client secret (confidential clients)              | -                                     |
+| `AUTH_AUTH0_SCOPE`            |    No    | OAuth scope                                       | `openid profile email offline_access` |
+| `AUTH_AUTH0_USERNAME`         |  Yes***  | Username (system_user only)                       | -                                     |
+| `AUTH_AUTH0_PASSWORD`         |  Yes***  | Password (system_user only)                       | -                                     |
+| **General**                   |          |                                                   |                                       |
+| `LOG_LEVEL`                   |    No    | `DEBUG`, `INFO`, `WARNING`, `ERROR`               | `INFO`                                |
+| `DATA_DIR`                    |    No    | CLI data directory                                | `~/.statgpt`                          |
 
 \* Required for `content init` command
-\** Required for `auth login` (Azure or Keycloak, depending on `AUTH_PROVIDER`)
+\** Required for `auth login` (Azure, Keycloak, or Auth0, depending on `AUTH_PROVIDER`)
 \*** Required for `auth login --method system_user`
 
 ## Data Directory
@@ -236,9 +243,9 @@ statgpt> channel import --file export.zip --clean
 
 ## Troubleshooting
 
-| Problem                 | Solution                                                  |
-|-------------------------|-----------------------------------------------------------|
-| Module not found        | Run `poetry install -E cli` or `pip install statgpt[cli]` |
-| Authentication failures | Check `settings` command, verify Azure/Keycloak config    |
-| Connection refused      | Verify Admin API: `curl http://localhost:8000/health`     |
-| Command not recognized  | Run `help` to see available commands                      |
+| Problem                 | Solution                                                     |
+|-------------------------|--------------------------------------------------------------|
+| Module not found        | Run `poetry install -E cli` or `pip install statgpt[cli]`    |
+| Authentication failures | Check `settings` command, verify Azure/Keycloak/Auth0 config |
+| Connection refused      | Verify Admin API: `curl http://localhost:8000/health`        |
+| Command not recognized  | Run `help` to see available commands                         |

--- a/statgpt/cli/settings.py
+++ b/statgpt/cli/settings.py
@@ -89,6 +89,11 @@ class CLISettings(BaseSettings):
         description="Authentication provider to use (azure, keycloak, auth0). Optional for local development.",
         json_schema_extra=field_meta(SettingsSection.AUTHENTICATION),
     )
+    auth_callback_port: int | None = Field(
+        default=None,
+        description="Fixed port for OAuth callback server (use when provider requires exact redirect URI)",
+        json_schema_extra=field_meta(SettingsSection.AUTHENTICATION),
+    )
 
     auth_azure_client_id: str | None = Field(
         default=None,
@@ -107,17 +112,7 @@ class CLISettings(BaseSettings):
     )
     auth_azure_client_secret: str | None = Field(
         default=None,
-        description="Azure Entra ID client secret (for system user login)",
-        json_schema_extra=field_meta(SettingsSection.AZURE, secret=True),
-    )
-    auth_azure_username: str | None = Field(
-        default=None,
-        description="Username for Azure Entra ID system user login",
-        json_schema_extra=field_meta(SettingsSection.AZURE),
-    )
-    auth_azure_password: str | None = Field(
-        default=None,
-        description="Password for Azure Entra ID system user login",
+        description="Azure Entra ID client secret (required for M2M/CI authentication)",
         json_schema_extra=field_meta(SettingsSection.AZURE, secret=True),
     )
 
@@ -138,17 +133,7 @@ class CLISettings(BaseSettings):
     )
     auth_keycloak_client_secret: str | None = Field(
         default=None,
-        description="Keycloak client secret (for confidential clients)",
-        json_schema_extra=field_meta(SettingsSection.KEYCLOAK, secret=True),
-    )
-    auth_keycloak_username: str | None = Field(
-        default=None,
-        description="Username for Keycloak system user login",
-        json_schema_extra=field_meta(SettingsSection.KEYCLOAK),
-    )
-    auth_keycloak_password: str | None = Field(
-        default=None,
-        description="Password for Keycloak system user login",
+        description="Keycloak client secret (required for M2M/CI authentication)",
         json_schema_extra=field_meta(SettingsSection.KEYCLOAK, secret=True),
     )
     auth_keycloak_scope: str | None = Field(
@@ -169,7 +154,7 @@ class CLISettings(BaseSettings):
     )
     auth_auth0_client_secret: str | None = Field(
         default=None,
-        description="Auth0 client secret (for confidential clients)",
+        description="Auth0 client secret (required for M2M/CI authentication)",
         json_schema_extra=field_meta(SettingsSection.AUTH0, secret=True),
     )
     auth_auth0_audience: str | None = Field(
@@ -181,16 +166,6 @@ class CLISettings(BaseSettings):
         default=None,
         description="OAuth scope for Auth0 (default: openid profile email offline_access)",
         json_schema_extra=field_meta(SettingsSection.AUTH0),
-    )
-    auth_auth0_username: str | None = Field(
-        default=None,
-        description="Username for Auth0 system user login",
-        json_schema_extra=field_meta(SettingsSection.AUTH0),
-    )
-    auth_auth0_password: str | None = Field(
-        default=None,
-        description="Password for Auth0 system user login",
-        json_schema_extra=field_meta(SettingsSection.AUTH0, secret=True),
     )
 
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(

--- a/statgpt/cli/settings.py
+++ b/statgpt/cli/settings.py
@@ -17,6 +17,7 @@ class SettingsSection(StrEnum):
     AUTHENTICATION = "Authentication"
     AZURE = "Azure Entra ID"
     KEYCLOAK = "Keycloak"
+    AUTH0 = "Auth0"
     GENERAL = "General"
 
 
@@ -85,7 +86,7 @@ class CLISettings(BaseSettings):
 
     auth_provider: str | None = Field(
         default=None,
-        description="Authentication provider to use (azure, keycloak). Optional for local development.",
+        description="Authentication provider to use (azure, keycloak, auth0). Optional for local development.",
         json_schema_extra=field_meta(SettingsSection.AUTHENTICATION),
     )
 
@@ -154,6 +155,42 @@ class CLISettings(BaseSettings):
         default=None,
         description="OAuth scope for Keycloak (default: openid)",
         json_schema_extra=field_meta(SettingsSection.KEYCLOAK),
+    )
+
+    auth_auth0_domain: str | None = Field(
+        default=None,
+        description="Auth0 tenant domain (e.g., mytenant.us.auth0.com)",
+        json_schema_extra=field_meta(SettingsSection.AUTH0),
+    )
+    auth_auth0_client_id: str | None = Field(
+        default=None,
+        description="Auth0 application client ID",
+        json_schema_extra=field_meta(SettingsSection.AUTH0),
+    )
+    auth_auth0_client_secret: str | None = Field(
+        default=None,
+        description="Auth0 client secret (for confidential clients)",
+        json_schema_extra=field_meta(SettingsSection.AUTH0, secret=True),
+    )
+    auth_auth0_audience: str | None = Field(
+        default=None,
+        description="Auth0 API identifier (audience)",
+        json_schema_extra=field_meta(SettingsSection.AUTH0),
+    )
+    auth_auth0_scope: str | None = Field(
+        default=None,
+        description="OAuth scope for Auth0 (default: openid profile email offline_access)",
+        json_schema_extra=field_meta(SettingsSection.AUTH0),
+    )
+    auth_auth0_username: str | None = Field(
+        default=None,
+        description="Username for Auth0 system user login",
+        json_schema_extra=field_meta(SettingsSection.AUTH0),
+    )
+    auth_auth0_password: str | None = Field(
+        default=None,
+        description="Password for Auth0 system user login",
+        json_schema_extra=field_meta(SettingsSection.AUTH0, secret=True),
     )
 
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(

--- a/statgpt/cli/shared/auth/__init__.py
+++ b/statgpt/cli/shared/auth/__init__.py
@@ -27,6 +27,7 @@ import logging
 from typing import Literal
 
 from statgpt.cli.settings import cli_settings
+from statgpt.cli.shared.auth.auth0 import Auth0Provider
 from statgpt.cli.shared.auth.azure import AzureEntraIDProvider
 from statgpt.cli.shared.auth.base import (
     AuthConfigError,
@@ -117,7 +118,7 @@ def login(method: LoginMethod, force: bool = False) -> AuthResult:
     if not cli_settings.auth_provider:
         raise AuthenticationError(
             "Authentication provider not configured. "
-            "Set STATGPT_CLI_AUTH_PROVIDER to 'azure' or 'keycloak'."
+            "Set STATGPT_CLI_AUTH_PROVIDER to 'azure', 'keycloak', or 'auth0'."
         )
 
     provider = get_provider(cli_settings.auth_provider)
@@ -249,6 +250,7 @@ def get_auth_headers(method: LoginMethod | None) -> dict[str, str]:
 # Register built-in providers
 register_provider("azure", AzureEntraIDProvider)
 register_provider("keycloak", KeycloakProvider)
+register_provider("auth0", Auth0Provider)
 
 # Export public API
 __all__ = [

--- a/statgpt/cli/shared/auth/auth0.py
+++ b/statgpt/cli/shared/auth/auth0.py
@@ -1,13 +1,9 @@
 """Auth0 authentication provider using Authorization Code Flow with PKCE."""
 
-import base64
-import hashlib
 import secrets
-import socket
 import webbrowser
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import TYPE_CHECKING
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import urlencode
 
 import httpx
 
@@ -17,125 +13,46 @@ from statgpt.cli.shared.auth.base import (
     AuthProvider,
     AuthResult,
 )
+from statgpt.cli.shared.auth.oauth import (
+    OAuthCallbackHandler,
+    generate_code_challenge,
+    generate_code_verifier,
+    get_callback_port,
+    run_oauth_callback_server,
+)
 
 if TYPE_CHECKING:
     from statgpt.cli.settings import CLISettings
 
 DEFAULT_EXPIRES_IN = 3600
-CALLBACK_TIMEOUT = 300
 DEFAULT_SCOPE = "openid profile email offline_access"
 
 
-def _generate_code_verifier(length: int = 64) -> str:
-    """Generate a cryptographically random code verifier for PKCE.
-
-    Args:
-        length: Number of random bytes (43-128 characters per RFC 7636)
-
-    Returns:
-        URL-safe base64-encoded random string
-    """
-    random_bytes = secrets.token_bytes(length)
-    return base64.urlsafe_b64encode(random_bytes).rstrip(b"=").decode("ascii")
-
-
-def _generate_code_challenge(verifier: str) -> str:
-    """Generate S256 code challenge from verifier.
-
-    Args:
-        verifier: The code verifier string
-
-    Returns:
-        URL-safe base64-encoded SHA256 hash of verifier
-    """
-    digest = hashlib.sha256(verifier.encode("ascii")).digest()
-    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-
-
-def _find_available_port() -> int:
-    """Find an available port for the callback server."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-class _AuthCallbackHandler(BaseHTTPRequestHandler):
-    """HTTP handler for OAuth callback."""
-
-    authorization_code: str | None = None
-    error: str | None = None
-    state_received: str | None = None
-
-    def log_message(self, format: str, *args: object) -> None:
-        """Suppress HTTP server logging."""
-
-    def do_GET(self) -> None:
-        """Handle GET request from OAuth callback."""
-        parsed = urlparse(self.path)
-        params = parse_qs(parsed.query)
-
-        if "code" in params:
-            _AuthCallbackHandler.authorization_code = params["code"][0]
-            _AuthCallbackHandler.state_received = params.get("state", [None])[0]
-            self._send_success_response()
-        elif "error" in params:
-            error_desc = params.get("error_description", params["error"])[0]
-            _AuthCallbackHandler.error = error_desc
-            self._send_error_response(error_desc)
-        else:
-            _AuthCallbackHandler.error = "Missing authorization code"
-            self._send_error_response("Missing authorization code")
-
-    def _send_success_response(self) -> None:
-        """Send success HTML response to browser."""
-        self.send_response(200)
-        self.send_header("Content-type", "text/html")
-        self.end_headers()
-        html = """
-        <!DOCTYPE html>
-        <html>
-        <head><title>Authentication Successful</title></head>
-        <body style="font-family: sans-serif; text-align: center; padding-top: 50px;">
-            <h1 style="color: #28a745;">Authentication Successful</h1>
-            <p>You can close this window and return to the CLI.</p>
-        </body>
-        </html>
-        """
-        self.wfile.write(html.encode())
-
-    def _send_error_response(self, error: str) -> None:
-        """Send error HTML response to browser."""
-        self.send_response(400)
-        self.send_header("Content-type", "text/html")
-        self.end_headers()
-        html = f"""
-        <!DOCTYPE html>
-        <html>
-        <head><title>Authentication Failed</title></head>
-        <body style="font-family: sans-serif; text-align: center; padding-top: 50px;">
-            <h1 style="color: #dc3545;">Authentication Failed</h1>
-            <p>{error}</p>
-        </body>
-        </html>
-        """
-        self.wfile.write(html.encode())
-
-
 class Auth0Provider(AuthProvider):
-    """Authentication provider for Auth0 using Authorization Code Flow with PKCE.
+    """Authentication provider for Auth0.
 
-    Required environment variables for interactive login:
-        - STATGPT_CLI_AUTH_AUTH0_DOMAIN
-        - STATGPT_CLI_AUTH_AUTH0_CLIENT_ID
-        - STATGPT_CLI_AUTH_AUTH0_AUDIENCE
+    Supports two authentication flows:
 
-    Additional variables for system user login:
-        - STATGPT_CLI_AUTH_AUTH0_USERNAME
-        - STATGPT_CLI_AUTH_AUTH0_PASSWORD
+    1. Interactive login (for developers):
+       - Authorization Code Flow with PKCE
+       - Public client (no client_secret required)
+       - Opens browser for user authentication
+
+    2. System user login (for CI/CD - Machine-to-Machine):
+       - Client Credentials Grant
+       - Requires client_secret
+       - No browser interaction
+
+    Required settings for interactive login:
+        - auth_auth0_domain
+        - auth_auth0_client_id
+        - auth_auth0_audience
+
+    Additional settings for M2M (system_user) login:
+        - auth_auth0_client_secret
 
     Optional:
-        - STATGPT_CLI_AUTH_AUTH0_SCOPE (default: 'openid profile email offline_access')
-        - STATGPT_CLI_AUTH_AUTH0_CLIENT_SECRET (for confidential clients)
+        - auth_auth0_scope (default: 'openid profile email offline_access')
     """
 
     @property
@@ -158,49 +75,19 @@ class Auth0Provider(AuthProvider):
         """Validate Auth0 configuration."""
         self._validate_base_config(settings)
 
-        if not interactive:
-            missing = []
-            if not settings.auth_auth0_username:
-                missing.append("STATGPT_CLI_AUTH_AUTH0_USERNAME")
-            if not settings.auth_auth0_password:
-                missing.append("STATGPT_CLI_AUTH_AUTH0_PASSWORD")
-            if missing:
-                raise AuthConfigError(self.name, missing)
+        if interactive:
+            if not settings.auth_callback_port:
+                raise AuthConfigError(self.name, ["STATGPT_CLI_AUTH_CALLBACK_PORT"])
+        else:
+            if not settings.auth_auth0_client_secret:
+                raise AuthConfigError(self.name, ["STATGPT_CLI_AUTH_AUTH0_CLIENT_SECRET"])
 
-    def _get_token_url(self, settings: "CLISettings") -> str:
-        """Get the Auth0 token endpoint URL."""
-        domain = settings.auth_auth0_domain
-        if domain and not domain.startswith("https://"):
+    def _get_base_url(self, settings: "CLISettings") -> str:
+        """Get the Auth0 base URL with https scheme."""
+        domain = settings.auth_auth0_domain or ""
+        if not domain.startswith("https://"):
             domain = f"https://{domain}"
-        return f"{domain}/oauth/token"
-
-    def _get_authorize_url(self, settings: "CLISettings") -> str:
-        """Get the Auth0 authorization endpoint URL."""
-        domain = settings.auth_auth0_domain
-        if domain and not domain.startswith("https://"):
-            domain = f"https://{domain}"
-        return f"{domain}/authorize"
-
-    def _build_auth_url(
-        self,
-        settings: "CLISettings",
-        redirect_uri: str,
-        scope: str,
-        state: str,
-        code_challenge: str,
-    ) -> str:
-        """Build authorization URL with PKCE parameters."""
-        params = {
-            "client_id": settings.auth_auth0_client_id,
-            "redirect_uri": redirect_uri,
-            "response_type": "code",
-            "scope": scope,
-            "state": state,
-            "code_challenge": code_challenge,
-            "code_challenge_method": "S256",
-            "audience": settings.auth_auth0_audience,
-        }
-        return f"{self._get_authorize_url(settings)}?{urlencode(params)}"
+        return domain
 
     def _parse_token_response(self, response: httpx.Response) -> AuthResult:
         """Parse Auth0 token response into AuthResult."""
@@ -224,15 +111,58 @@ class Auth0Provider(AuthProvider):
             refresh_token=data.get("refresh_token"),
         )
 
+    def _build_auth_url(
+        self,
+        settings: "CLISettings",
+        redirect_uri: str,
+        scope: str,
+        state: str,
+        code_challenge: str,
+    ) -> str:
+        """Build authorization URL with PKCE parameters."""
+        params = {
+            "client_id": settings.auth_auth0_client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "scope": scope,
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "audience": settings.auth_auth0_audience,
+        }
+        return f"{self._get_base_url(settings)}/authorize?{urlencode(params)}"
+
+    def _exchange_code_for_token(
+        self,
+        settings: "CLISettings",
+        code: str,
+        redirect_uri: str,
+        code_verifier: str,
+    ) -> AuthResult:
+        """Exchange authorization code for tokens."""
+        token_data = {
+            "grant_type": "authorization_code",
+            "client_id": settings.auth_auth0_client_id,
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        }
+        response = httpx.post(
+            f"{self._get_base_url(settings)}/oauth/token",
+            data=token_data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        return self._parse_token_response(response)
+
     def interactive_login(self, settings: "CLISettings") -> AuthResult:
         """Perform interactive Auth0 login via browser using PKCE."""
         self.validate_config(settings, interactive=True)
 
-        code_verifier = _generate_code_verifier()
-        code_challenge = _generate_code_challenge(code_verifier)
+        code_verifier = generate_code_verifier()
+        code_challenge = generate_code_challenge(code_verifier)
         state = secrets.token_urlsafe(32)
 
-        port = _find_available_port()
+        port = get_callback_port(settings)
         redirect_uri = f"http://localhost:{port}/callback"
 
         scope = settings.auth_auth0_scope or DEFAULT_SCOPE
@@ -244,73 +174,42 @@ class Auth0Provider(AuthProvider):
             code_challenge=code_challenge,
         )
 
-        _AuthCallbackHandler.authorization_code = None
-        _AuthCallbackHandler.error = None
-        _AuthCallbackHandler.state_received = None
-
-        server = HTTPServer(("127.0.0.1", port), _AuthCallbackHandler)
-        server.timeout = CALLBACK_TIMEOUT
-
+        OAuthCallbackHandler.reset()
         webbrowser.open(auth_url)
+        run_oauth_callback_server(port)
 
-        try:
-            server.handle_request()
-        finally:
-            server.server_close()
+        if OAuthCallbackHandler.error:
+            raise AuthenticationError(f"Auth0 authentication failed: {OAuthCallbackHandler.error}")
 
-        if _AuthCallbackHandler.error:
-            raise AuthenticationError(f"Auth0 authentication failed: {_AuthCallbackHandler.error}")
-
-        if not _AuthCallbackHandler.authorization_code:
+        if not OAuthCallbackHandler.authorization_code:
             raise AuthenticationError(
                 "Auth0 authentication failed: No authorization code received (timeout?)"
             )
 
-        if _AuthCallbackHandler.state_received != state:
+        if OAuthCallbackHandler.state_received != state:
             raise AuthenticationError(
                 "Auth0 authentication failed: State mismatch (possible CSRF attack)"
             )
 
-        token_data = {
-            "grant_type": "authorization_code",
-            "client_id": settings.auth_auth0_client_id,
-            "code": _AuthCallbackHandler.authorization_code,
-            "redirect_uri": redirect_uri,
-            "code_verifier": code_verifier,
-        }
-        if settings.auth_auth0_client_secret:
-            token_data["client_secret"] = settings.auth_auth0_client_secret
-
-        response = httpx.post(
-            self._get_token_url(settings),
-            data=token_data,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        return self._exchange_code_for_token(
+            settings=settings,
+            code=OAuthCallbackHandler.authorization_code,
+            redirect_uri=redirect_uri,
+            code_verifier=code_verifier,
         )
-        return self._parse_token_response(response)
 
     def system_user_login(self, settings: "CLISettings") -> AuthResult:
-        """Perform Auth0 system user login using Resource Owner Password Grant.
-
-        Note: Resource Owner Password Credentials grant is deprecated in OAuth 2.1
-        but may still be needed for service accounts or automation.
-        The Auth0 application must have "Password" grant type enabled.
-        """
+        """Perform Auth0 M2M login using Client Credentials Grant."""
         self.validate_config(settings, interactive=False)
 
-        scope = settings.auth_auth0_scope or DEFAULT_SCOPE
         token_data = {
-            "grant_type": "password",
+            "grant_type": "client_credentials",
             "client_id": settings.auth_auth0_client_id,
-            "username": settings.auth_auth0_username,
-            "password": settings.auth_auth0_password,
+            "client_secret": settings.auth_auth0_client_secret,
             "audience": settings.auth_auth0_audience,
-            "scope": scope,
         }
-        if settings.auth_auth0_client_secret:
-            token_data["client_secret"] = settings.auth_auth0_client_secret
-
         response = httpx.post(
-            self._get_token_url(settings),
+            f"{self._get_base_url(settings)}/oauth/token",
             data=token_data,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
@@ -325,11 +224,8 @@ class Auth0Provider(AuthProvider):
             "client_id": settings.auth_auth0_client_id,
             "refresh_token": refresh_token,
         }
-        if settings.auth_auth0_client_secret:
-            token_data["client_secret"] = settings.auth_auth0_client_secret
-
         response = httpx.post(
-            self._get_token_url(settings),
+            f"{self._get_base_url(settings)}/oauth/token",
             data=token_data,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )

--- a/statgpt/cli/shared/auth/auth0.py
+++ b/statgpt/cli/shared/auth/auth0.py
@@ -1,0 +1,336 @@
+"""Auth0 authentication provider using Authorization Code Flow with PKCE."""
+
+import base64
+import hashlib
+import secrets
+import socket
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import httpx
+
+from statgpt.cli.shared.auth.base import (
+    AuthConfigError,
+    AuthenticationError,
+    AuthProvider,
+    AuthResult,
+)
+
+if TYPE_CHECKING:
+    from statgpt.cli.settings import CLISettings
+
+DEFAULT_EXPIRES_IN = 3600
+CALLBACK_TIMEOUT = 300
+DEFAULT_SCOPE = "openid profile email offline_access"
+
+
+def _generate_code_verifier(length: int = 64) -> str:
+    """Generate a cryptographically random code verifier for PKCE.
+
+    Args:
+        length: Number of random bytes (43-128 characters per RFC 7636)
+
+    Returns:
+        URL-safe base64-encoded random string
+    """
+    random_bytes = secrets.token_bytes(length)
+    return base64.urlsafe_b64encode(random_bytes).rstrip(b"=").decode("ascii")
+
+
+def _generate_code_challenge(verifier: str) -> str:
+    """Generate S256 code challenge from verifier.
+
+    Args:
+        verifier: The code verifier string
+
+    Returns:
+        URL-safe base64-encoded SHA256 hash of verifier
+    """
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _find_available_port() -> int:
+    """Find an available port for the callback server."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _AuthCallbackHandler(BaseHTTPRequestHandler):
+    """HTTP handler for OAuth callback."""
+
+    authorization_code: str | None = None
+    error: str | None = None
+    state_received: str | None = None
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Suppress HTTP server logging."""
+
+    def do_GET(self) -> None:
+        """Handle GET request from OAuth callback."""
+        parsed = urlparse(self.path)
+        params = parse_qs(parsed.query)
+
+        if "code" in params:
+            _AuthCallbackHandler.authorization_code = params["code"][0]
+            _AuthCallbackHandler.state_received = params.get("state", [None])[0]
+            self._send_success_response()
+        elif "error" in params:
+            error_desc = params.get("error_description", params["error"])[0]
+            _AuthCallbackHandler.error = error_desc
+            self._send_error_response(error_desc)
+        else:
+            _AuthCallbackHandler.error = "Missing authorization code"
+            self._send_error_response("Missing authorization code")
+
+    def _send_success_response(self) -> None:
+        """Send success HTML response to browser."""
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        html = """
+        <!DOCTYPE html>
+        <html>
+        <head><title>Authentication Successful</title></head>
+        <body style="font-family: sans-serif; text-align: center; padding-top: 50px;">
+            <h1 style="color: #28a745;">Authentication Successful</h1>
+            <p>You can close this window and return to the CLI.</p>
+        </body>
+        </html>
+        """
+        self.wfile.write(html.encode())
+
+    def _send_error_response(self, error: str) -> None:
+        """Send error HTML response to browser."""
+        self.send_response(400)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        html = f"""
+        <!DOCTYPE html>
+        <html>
+        <head><title>Authentication Failed</title></head>
+        <body style="font-family: sans-serif; text-align: center; padding-top: 50px;">
+            <h1 style="color: #dc3545;">Authentication Failed</h1>
+            <p>{error}</p>
+        </body>
+        </html>
+        """
+        self.wfile.write(html.encode())
+
+
+class Auth0Provider(AuthProvider):
+    """Authentication provider for Auth0 using Authorization Code Flow with PKCE.
+
+    Required environment variables for interactive login:
+        - STATGPT_CLI_AUTH_AUTH0_DOMAIN
+        - STATGPT_CLI_AUTH_AUTH0_CLIENT_ID
+        - STATGPT_CLI_AUTH_AUTH0_AUDIENCE
+
+    Additional variables for system user login:
+        - STATGPT_CLI_AUTH_AUTH0_USERNAME
+        - STATGPT_CLI_AUTH_AUTH0_PASSWORD
+
+    Optional:
+        - STATGPT_CLI_AUTH_AUTH0_SCOPE (default: 'openid profile email offline_access')
+        - STATGPT_CLI_AUTH_AUTH0_CLIENT_SECRET (for confidential clients)
+    """
+
+    @property
+    def name(self) -> str:
+        return "auth0"
+
+    def _validate_base_config(self, settings: "CLISettings") -> None:
+        """Validate base Auth0 configuration required for all operations."""
+        missing = []
+        if not settings.auth_auth0_domain:
+            missing.append("STATGPT_CLI_AUTH_AUTH0_DOMAIN")
+        if not settings.auth_auth0_client_id:
+            missing.append("STATGPT_CLI_AUTH_AUTH0_CLIENT_ID")
+        if not settings.auth_auth0_audience:
+            missing.append("STATGPT_CLI_AUTH_AUTH0_AUDIENCE")
+        if missing:
+            raise AuthConfigError(self.name, missing)
+
+    def validate_config(self, settings: "CLISettings", interactive: bool) -> None:
+        """Validate Auth0 configuration."""
+        self._validate_base_config(settings)
+
+        if not interactive:
+            missing = []
+            if not settings.auth_auth0_username:
+                missing.append("STATGPT_CLI_AUTH_AUTH0_USERNAME")
+            if not settings.auth_auth0_password:
+                missing.append("STATGPT_CLI_AUTH_AUTH0_PASSWORD")
+            if missing:
+                raise AuthConfigError(self.name, missing)
+
+    def _get_token_url(self, settings: "CLISettings") -> str:
+        """Get the Auth0 token endpoint URL."""
+        domain = settings.auth_auth0_domain
+        if domain and not domain.startswith("https://"):
+            domain = f"https://{domain}"
+        return f"{domain}/oauth/token"
+
+    def _get_authorize_url(self, settings: "CLISettings") -> str:
+        """Get the Auth0 authorization endpoint URL."""
+        domain = settings.auth_auth0_domain
+        if domain and not domain.startswith("https://"):
+            domain = f"https://{domain}"
+        return f"{domain}/authorize"
+
+    def _build_auth_url(
+        self,
+        settings: "CLISettings",
+        redirect_uri: str,
+        scope: str,
+        state: str,
+        code_challenge: str,
+    ) -> str:
+        """Build authorization URL with PKCE parameters."""
+        params = {
+            "client_id": settings.auth_auth0_client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "scope": scope,
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "audience": settings.auth_auth0_audience,
+        }
+        return f"{self._get_authorize_url(settings)}?{urlencode(params)}"
+
+    def _parse_token_response(self, response: httpx.Response) -> AuthResult:
+        """Parse Auth0 token response into AuthResult."""
+        if response.status_code != 200:
+            try:
+                error_data = response.json()
+                error_msg = error_data.get(
+                    "error_description", error_data.get("error", "Unknown error")
+                )
+            except Exception:
+                error_msg = response.text or f"HTTP {response.status_code}"
+            raise AuthenticationError(f"Auth0 authentication failed: {error_msg}")
+
+        data = response.json()
+        if not data.get("access_token"):
+            raise AuthenticationError("Auth0 authentication failed: No access token received")
+
+        return AuthResult(
+            access_token=data["access_token"],
+            expires_in=data.get("expires_in", DEFAULT_EXPIRES_IN),
+            refresh_token=data.get("refresh_token"),
+        )
+
+    def interactive_login(self, settings: "CLISettings") -> AuthResult:
+        """Perform interactive Auth0 login via browser using PKCE."""
+        self.validate_config(settings, interactive=True)
+
+        code_verifier = _generate_code_verifier()
+        code_challenge = _generate_code_challenge(code_verifier)
+        state = secrets.token_urlsafe(32)
+
+        port = _find_available_port()
+        redirect_uri = f"http://localhost:{port}/callback"
+
+        scope = settings.auth_auth0_scope or DEFAULT_SCOPE
+        auth_url = self._build_auth_url(
+            settings=settings,
+            redirect_uri=redirect_uri,
+            scope=scope,
+            state=state,
+            code_challenge=code_challenge,
+        )
+
+        _AuthCallbackHandler.authorization_code = None
+        _AuthCallbackHandler.error = None
+        _AuthCallbackHandler.state_received = None
+
+        server = HTTPServer(("127.0.0.1", port), _AuthCallbackHandler)
+        server.timeout = CALLBACK_TIMEOUT
+
+        webbrowser.open(auth_url)
+
+        try:
+            server.handle_request()
+        finally:
+            server.server_close()
+
+        if _AuthCallbackHandler.error:
+            raise AuthenticationError(f"Auth0 authentication failed: {_AuthCallbackHandler.error}")
+
+        if not _AuthCallbackHandler.authorization_code:
+            raise AuthenticationError(
+                "Auth0 authentication failed: No authorization code received (timeout?)"
+            )
+
+        if _AuthCallbackHandler.state_received != state:
+            raise AuthenticationError(
+                "Auth0 authentication failed: State mismatch (possible CSRF attack)"
+            )
+
+        token_data = {
+            "grant_type": "authorization_code",
+            "client_id": settings.auth_auth0_client_id,
+            "code": _AuthCallbackHandler.authorization_code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        }
+        if settings.auth_auth0_client_secret:
+            token_data["client_secret"] = settings.auth_auth0_client_secret
+
+        response = httpx.post(
+            self._get_token_url(settings),
+            data=token_data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        return self._parse_token_response(response)
+
+    def system_user_login(self, settings: "CLISettings") -> AuthResult:
+        """Perform Auth0 system user login using Resource Owner Password Grant.
+
+        Note: Resource Owner Password Credentials grant is deprecated in OAuth 2.1
+        but may still be needed for service accounts or automation.
+        The Auth0 application must have "Password" grant type enabled.
+        """
+        self.validate_config(settings, interactive=False)
+
+        scope = settings.auth_auth0_scope or DEFAULT_SCOPE
+        token_data = {
+            "grant_type": "password",
+            "client_id": settings.auth_auth0_client_id,
+            "username": settings.auth_auth0_username,
+            "password": settings.auth_auth0_password,
+            "audience": settings.auth_auth0_audience,
+            "scope": scope,
+        }
+        if settings.auth_auth0_client_secret:
+            token_data["client_secret"] = settings.auth_auth0_client_secret
+
+        response = httpx.post(
+            self._get_token_url(settings),
+            data=token_data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        return self._parse_token_response(response)
+
+    def refresh_token(self, settings: "CLISettings", refresh_token: str) -> AuthResult:
+        """Refresh an access token using a refresh token."""
+        self._validate_base_config(settings)
+
+        token_data = {
+            "grant_type": "refresh_token",
+            "client_id": settings.auth_auth0_client_id,
+            "refresh_token": refresh_token,
+        }
+        if settings.auth_auth0_client_secret:
+            token_data["client_secret"] = settings.auth_auth0_client_secret
+
+        response = httpx.post(
+            self._get_token_url(settings),
+            data=token_data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        return self._parse_token_response(response)

--- a/statgpt/cli/shared/auth/azure.py
+++ b/statgpt/cli/shared/auth/azure.py
@@ -14,53 +14,58 @@ from statgpt.cli.shared.auth.base import (
 if TYPE_CHECKING:
     from statgpt.cli.settings import CLISettings
 
-# Default token lifetime if not provided by MSAL (1 hour)
 DEFAULT_EXPIRES_IN = 3600
 
 
 class AzureEntraIDProvider(AuthProvider):
     """Authentication provider for Azure Entra ID using MSAL.
 
-    Required environment variables for interactive login:
-        - STATGPT_CLI_AUTH_AZURE_CLIENT_ID
-        - STATGPT_CLI_AUTH_AZURE_AUTHORITY
-        - STATGPT_CLI_AUTH_AZURE_SCOPE
+    Supports two authentication flows:
 
-    Additional variables for system user login:
-        - STATGPT_CLI_AUTH_AZURE_CLIENT_SECRET
-        - STATGPT_CLI_AUTH_AZURE_USERNAME
-        - STATGPT_CLI_AUTH_AZURE_PASSWORD
+    1. Interactive login (for developers):
+       - Uses MSAL PublicClientApplication
+       - Opens browser for user authentication
+       - No client_secret required
+
+    2. System user login (for CI/CD - Machine-to-Machine):
+       - Uses MSAL ConfidentialClientApplication with Client Credentials Grant
+       - Requires client_secret
+       - No browser interaction
+
+    Required settings for interactive login:
+        - auth_azure_client_id
+        - auth_azure_authority
+        - auth_azure_scope
+
+    Additional settings for M2M (system_user) login:
+        - auth_azure_client_secret
     """
 
     @property
     def name(self) -> str:
         return "azure"
 
-    def validate_config(self, settings: "CLISettings", interactive: bool) -> None:
-        """Validate Azure Entra ID configuration."""
+    def _validate_base_config(self, settings: "CLISettings") -> None:
+        """Validate base Azure Entra ID configuration required for all operations."""
         missing = []
-
-        # Required for both login types
         if not settings.auth_azure_client_id:
             missing.append("STATGPT_CLI_AUTH_AZURE_CLIENT_ID")
         if not settings.auth_azure_authority:
             missing.append("STATGPT_CLI_AUTH_AZURE_AUTHORITY")
         if not settings.auth_azure_scope:
             missing.append("STATGPT_CLI_AUTH_AZURE_SCOPE")
-
-        # Additional requirements for system user login
-        if not interactive:
-            if not settings.auth_azure_client_secret:
-                missing.append("STATGPT_CLI_AUTH_AZURE_CLIENT_SECRET")
-            if not settings.auth_azure_username:
-                missing.append("STATGPT_CLI_AUTH_AZURE_USERNAME")
-            if not settings.auth_azure_password:
-                missing.append("STATGPT_CLI_AUTH_AZURE_PASSWORD")
-
         if missing:
             raise AuthConfigError(self.name, missing)
 
-    def _parse_result(self, result: dict) -> AuthResult:
+    def validate_config(self, settings: "CLISettings", interactive: bool) -> None:
+        """Validate Azure Entra ID configuration."""
+        self._validate_base_config(settings)
+
+        if not interactive:
+            if not settings.auth_azure_client_secret:
+                raise AuthConfigError(self.name, ["STATGPT_CLI_AUTH_AZURE_CLIENT_SECRET"])
+
+    def _parse_token_response(self, result: dict) -> AuthResult:
         """Parse MSAL result into AuthResult."""
         if not result.get("access_token"):
             error_desc = result.get("error_description", result.get("error", "Unknown error"))
@@ -85,10 +90,10 @@ class AzureEntraIDProvider(AuthProvider):
             scopes=[settings.auth_azure_scope],  # type: ignore[list-item]
         )
 
-        return self._parse_result(result)
+        return self._parse_token_response(result)
 
     def system_user_login(self, settings: "CLISettings") -> AuthResult:
-        """Perform Azure Entra ID system user login."""
+        """Perform Azure Entra ID M2M login using Client Credentials Grant."""
         self.validate_config(settings, interactive=False)
 
         app = msal.ConfidentialClientApplication(
@@ -97,32 +102,18 @@ class AzureEntraIDProvider(AuthProvider):
             client_credential=settings.auth_azure_client_secret,
         )
 
-        result = app.acquire_token_by_username_password(
-            username=settings.auth_azure_username,  # type: ignore[arg-type]
-            password=settings.auth_azure_password,  # type: ignore[arg-type]
+        result = app.acquire_token_for_client(
             scopes=[settings.auth_azure_scope],  # type: ignore[list-item]
         )
 
-        return self._parse_result(result)
+        if result is None:
+            raise AuthenticationError("Azure Entra ID authentication failed: No response received")
+
+        return self._parse_token_response(result)
 
     def refresh_token(self, settings: "CLISettings", refresh_token: str) -> AuthResult:
-        """Refresh an access token using a refresh token.
-
-        Args:
-            settings: CLI settings instance
-            refresh_token: The refresh token to use
-
-        Returns:
-            AuthResult with new access token and expiration
-
-        Raises:
-            AuthenticationError: If refresh fails
-        """
-        # Only need basic config for refresh
-        if not settings.auth_azure_client_id:
-            raise AuthConfigError(self.name, ["STATGPT_CLI_AUTH_AZURE_CLIENT_ID"])
-        if not settings.auth_azure_scope:
-            raise AuthConfigError(self.name, ["STATGPT_CLI_AUTH_AZURE_SCOPE"])
+        """Refresh an access token using a refresh token."""
+        self._validate_base_config(settings)
 
         app = msal.PublicClientApplication(
             client_id=settings.auth_azure_client_id,
@@ -134,4 +125,4 @@ class AzureEntraIDProvider(AuthProvider):
             scopes=[settings.auth_azure_scope],  # type: ignore[list-item]
         )
 
-        return self._parse_result(result)
+        return self._parse_token_response(result)

--- a/statgpt/cli/shared/auth/keycloak.py
+++ b/statgpt/cli/shared/auth/keycloak.py
@@ -1,14 +1,11 @@
-"""Keycloak authentication provider using Authorization Code Flow with PKCE."""
+"""Keycloak authentication provider."""
 
-import base64
-import hashlib
 import secrets
-import socket
 import webbrowser
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import TYPE_CHECKING
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import urlencode
 
+import httpx
 from keycloak import KeycloakOpenID
 from keycloak.exceptions import KeycloakAuthenticationError, KeycloakError
 
@@ -18,124 +15,45 @@ from statgpt.cli.shared.auth.base import (
     AuthProvider,
     AuthResult,
 )
+from statgpt.cli.shared.auth.oauth import (
+    OAuthCallbackHandler,
+    generate_code_challenge,
+    generate_code_verifier,
+    get_callback_port,
+    run_oauth_callback_server,
+)
 
 if TYPE_CHECKING:
     from statgpt.cli.settings import CLISettings
 
 DEFAULT_EXPIRES_IN = 3600
-CALLBACK_TIMEOUT = 300
-
-
-def _generate_code_verifier(length: int = 64) -> str:
-    """Generate a cryptographically random code verifier for PKCE.
-
-    Args:
-        length: Number of random bytes (43-128 characters per RFC 7636)
-
-    Returns:
-        URL-safe base64-encoded random string
-    """
-    random_bytes = secrets.token_bytes(length)
-    return base64.urlsafe_b64encode(random_bytes).rstrip(b"=").decode("ascii")
-
-
-def _generate_code_challenge(verifier: str) -> str:
-    """Generate S256 code challenge from verifier.
-
-    Args:
-        verifier: The code verifier string
-
-    Returns:
-        URL-safe base64-encoded SHA256 hash of verifier
-    """
-    digest = hashlib.sha256(verifier.encode("ascii")).digest()
-    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-
-
-def _find_available_port() -> int:
-    """Find an available port for the callback server."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-class _AuthCallbackHandler(BaseHTTPRequestHandler):
-    """HTTP handler for OAuth callback."""
-
-    authorization_code: str | None = None
-    error: str | None = None
-    state_received: str | None = None
-
-    def log_message(self, format: str, *args: object) -> None:
-        """Suppress HTTP server logging."""
-
-    def do_GET(self) -> None:
-        """Handle GET request from OAuth callback."""
-        parsed = urlparse(self.path)
-        params = parse_qs(parsed.query)
-
-        if "code" in params:
-            _AuthCallbackHandler.authorization_code = params["code"][0]
-            _AuthCallbackHandler.state_received = params.get("state", [None])[0]
-            self._send_success_response()
-        elif "error" in params:
-            error_desc = params.get("error_description", params["error"])[0]
-            _AuthCallbackHandler.error = error_desc
-            self._send_error_response(error_desc)
-        else:
-            _AuthCallbackHandler.error = "Missing authorization code"
-            self._send_error_response("Missing authorization code")
-
-    def _send_success_response(self) -> None:
-        """Send success HTML response to browser."""
-        self.send_response(200)
-        self.send_header("Content-type", "text/html")
-        self.end_headers()
-        html = """
-        <!DOCTYPE html>
-        <html>
-        <head><title>Authentication Successful</title></head>
-        <body style="font-family: sans-serif; text-align: center; padding-top: 50px;">
-            <h1 style="color: #28a745;">Authentication Successful</h1>
-            <p>You can close this window and return to the CLI.</p>
-        </body>
-        </html>
-        """
-        self.wfile.write(html.encode())
-
-    def _send_error_response(self, error: str) -> None:
-        """Send error HTML response to browser."""
-        self.send_response(400)
-        self.send_header("Content-type", "text/html")
-        self.end_headers()
-        html = f"""
-        <!DOCTYPE html>
-        <html>
-        <head><title>Authentication Failed</title></head>
-        <body style="font-family: sans-serif; text-align: center; padding-top: 50px;">
-            <h1 style="color: #dc3545;">Authentication Failed</h1>
-            <p>{error}</p>
-        </body>
-        </html>
-        """
-        self.wfile.write(html.encode())
 
 
 class KeycloakProvider(AuthProvider):
-    """Authentication provider for Keycloak using Authorization Code Flow with PKCE.
+    """Authentication provider for Keycloak.
 
-    Required environment variables for interactive login:
-        - STATGPT_CLI_AUTH_KEYCLOAK_SERVER_URL
-        - STATGPT_CLI_AUTH_KEYCLOAK_REALM
-        - STATGPT_CLI_AUTH_KEYCLOAK_CLIENT_ID
+    Supports two authentication flows:
 
-    Additional variables for system user login:
-        - STATGPT_CLI_AUTH_KEYCLOAK_CLIENT_SECRET (optional for public clients)
-        - STATGPT_CLI_AUTH_KEYCLOAK_USERNAME
-        - STATGPT_CLI_AUTH_KEYCLOAK_PASSWORD
+    1. Interactive login (for developers):
+       - Authorization Code Flow with PKCE
+       - Public client (no client_secret required)
+       - Opens browser for user authentication
+
+    2. System user login (for CI/CD - Machine-to-Machine):
+       - Client Credentials Grant
+       - Requires client_secret (confidential client with service account)
+       - No browser interaction
+
+    Required settings for interactive login:
+        - auth_keycloak_server_url
+        - auth_keycloak_realm
+        - auth_keycloak_client_id
+
+    Additional settings for M2M (system_user) login:
+        - auth_keycloak_client_secret
 
     Optional:
-        - STATGPT_CLI_AUTH_KEYCLOAK_SCOPE (default: 'openid')
+        - auth_keycloak_scope (default: 'openid')
     """
 
     @property
@@ -159,13 +77,8 @@ class KeycloakProvider(AuthProvider):
         self._validate_base_config(settings)
 
         if not interactive:
-            missing = []
-            if not settings.auth_keycloak_username:
-                missing.append("STATGPT_CLI_AUTH_KEYCLOAK_USERNAME")
-            if not settings.auth_keycloak_password:
-                missing.append("STATGPT_CLI_AUTH_KEYCLOAK_PASSWORD")
-            if missing:
-                raise AuthConfigError(self.name, missing)
+            if not settings.auth_keycloak_client_secret:
+                raise AuthConfigError(self.name, ["STATGPT_CLI_AUTH_KEYCLOAK_CLIENT_SECRET"])
 
     def _create_keycloak_client(self, settings: "CLISettings") -> KeycloakOpenID:
         """Create KeycloakOpenID client instance."""
@@ -176,6 +89,13 @@ class KeycloakProvider(AuthProvider):
             client_secret_key=settings.auth_keycloak_client_secret,
         )
 
+    def _get_openid_endpoint(self, settings: "CLISettings", endpoint: str) -> str:
+        """Build OpenID Connect endpoint URL."""
+        return (
+            f"{settings.auth_keycloak_server_url}/realms/"
+            f"{settings.auth_keycloak_realm}/protocol/openid-connect/{endpoint}"
+        )
+
     def _build_auth_url(
         self,
         settings: "CLISettings",
@@ -184,14 +104,7 @@ class KeycloakProvider(AuthProvider):
         state: str,
         code_challenge: str,
     ) -> str:
-        """Build authorization URL with PKCE parameters.
-
-        KeycloakOpenID.auth_url() doesn't support PKCE, so we build it manually.
-        """
-        base_url = (
-            f"{settings.auth_keycloak_server_url}/realms/"
-            f"{settings.auth_keycloak_realm}/protocol/openid-connect/auth"
-        )
+        """Build authorization URL with PKCE parameters."""
         params = {
             "client_id": settings.auth_keycloak_client_id,
             "redirect_uri": redirect_uri,
@@ -201,7 +114,7 @@ class KeycloakProvider(AuthProvider):
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         }
-        return f"{base_url}?{urlencode(params)}"
+        return f"{self._get_openid_endpoint(settings, 'auth')}?{urlencode(params)}"
 
     def _parse_token_response(self, token_response: dict) -> AuthResult:
         """Parse Keycloak token response into AuthResult."""
@@ -214,15 +127,29 @@ class KeycloakProvider(AuthProvider):
             refresh_token=token_response.get("refresh_token"),
         )
 
+    def _parse_http_response(self, response: httpx.Response, error_prefix: str) -> AuthResult:
+        """Parse HTTP response, raising AuthenticationError on failure."""
+        if response.status_code != 200:
+            try:
+                error_data = response.json()
+                error_msg = error_data.get(
+                    "error_description", error_data.get("error", "Unknown error")
+                )
+            except Exception:
+                error_msg = response.text or f"HTTP {response.status_code}"
+            raise AuthenticationError(f"{error_prefix}: {error_msg}")
+
+        return self._parse_token_response(response.json())
+
     def interactive_login(self, settings: "CLISettings") -> AuthResult:
         """Perform interactive Keycloak login via browser using PKCE."""
         self.validate_config(settings, interactive=True)
 
-        code_verifier = _generate_code_verifier()
-        code_challenge = _generate_code_challenge(code_verifier)
+        code_verifier = generate_code_verifier()
+        code_challenge = generate_code_challenge(code_verifier)
         state = secrets.token_urlsafe(32)
 
-        port = _find_available_port()
+        port = get_callback_port(settings)
         redirect_uri = f"http://localhost:{port}/callback"
 
         keycloak_client = self._create_keycloak_client(settings)
@@ -236,31 +163,21 @@ class KeycloakProvider(AuthProvider):
             code_challenge=code_challenge,
         )
 
-        _AuthCallbackHandler.authorization_code = None
-        _AuthCallbackHandler.error = None
-        _AuthCallbackHandler.state_received = None
-
-        server = HTTPServer(("127.0.0.1", port), _AuthCallbackHandler)
-        server.timeout = CALLBACK_TIMEOUT
-
+        OAuthCallbackHandler.reset()
         webbrowser.open(auth_url)
+        run_oauth_callback_server(port)
 
-        try:
-            server.handle_request()
-        finally:
-            server.server_close()
-
-        if _AuthCallbackHandler.error:
+        if OAuthCallbackHandler.error:
             raise AuthenticationError(
-                f"Keycloak authentication failed: {_AuthCallbackHandler.error}"
+                f"Keycloak authentication failed: {OAuthCallbackHandler.error}"
             )
 
-        if not _AuthCallbackHandler.authorization_code:
+        if not OAuthCallbackHandler.authorization_code:
             raise AuthenticationError(
                 "Keycloak authentication failed: No authorization code received (timeout?)"
             )
 
-        if _AuthCallbackHandler.state_received != state:
+        if OAuthCallbackHandler.state_received != state:
             raise AuthenticationError(
                 "Keycloak authentication failed: State mismatch (possible CSRF attack)"
             )
@@ -268,7 +185,7 @@ class KeycloakProvider(AuthProvider):
         try:
             token_response = keycloak_client.token(
                 grant_type="authorization_code",
-                code=_AuthCallbackHandler.authorization_code,
+                code=OAuthCallbackHandler.authorization_code,
                 redirect_uri=redirect_uri,
                 code_verifier=code_verifier,
             )
@@ -279,28 +196,28 @@ class KeycloakProvider(AuthProvider):
             raise AuthenticationError(f"Keycloak error: {e}") from e
 
     def system_user_login(self, settings: "CLISettings") -> AuthResult:
-        """Perform Keycloak system user login using Direct Grant.
+        """Perform Keycloak M2M login using Client Credentials Grant.
 
-        Note: Direct Grant (Resource Owner Password Credentials) is deprecated
-        in OAuth 2.1 but may still be needed for service accounts or automation.
+        Requires a confidential client with "Service accounts roles" enabled.
         """
         self.validate_config(settings, interactive=False)
 
-        keycloak_client = self._create_keycloak_client(settings)
-        scope = settings.auth_keycloak_scope or "openid"
+        token_data = {
+            "grant_type": "client_credentials",
+            "client_id": settings.auth_keycloak_client_id,
+            "client_secret": settings.auth_keycloak_client_secret,
+            "scope": settings.auth_keycloak_scope or "openid",
+        }
 
         try:
-            token_response = keycloak_client.token(
-                username=settings.auth_keycloak_username,
-                password=settings.auth_keycloak_password,
-                grant_type="password",
-                scope=scope,
+            response = httpx.post(
+                self._get_openid_endpoint(settings, "token"),
+                data=token_data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
-            return self._parse_token_response(token_response)
-        except KeycloakAuthenticationError as e:
-            raise AuthenticationError(f"Keycloak system user authentication failed: {e}") from e
-        except KeycloakError as e:
-            raise AuthenticationError(f"Keycloak error: {e}") from e
+            return self._parse_http_response(response, "Keycloak M2M authentication failed")
+        except httpx.RequestError as e:
+            raise AuthenticationError(f"Keycloak connection error: {e}") from e
 
     def refresh_token(self, settings: "CLISettings", refresh_token: str) -> AuthResult:
         """Refresh an access token using a refresh token."""

--- a/statgpt/cli/shared/auth/oauth.py
+++ b/statgpt/cli/shared/auth/oauth.py
@@ -1,0 +1,125 @@
+"""Shared OAuth utilities for PKCE flow and callback handling."""
+
+import base64
+import hashlib
+import secrets
+import socket
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, urlparse
+
+if TYPE_CHECKING:
+    from statgpt.cli.settings import CLISettings
+
+CALLBACK_TIMEOUT = 300
+
+
+def generate_code_verifier(length: int = 64) -> str:
+    """Generate a cryptographically random code verifier for PKCE."""
+    random_bytes = secrets.token_bytes(length)
+    return base64.urlsafe_b64encode(random_bytes).rstrip(b"=").decode("ascii")
+
+
+def generate_code_challenge(verifier: str) -> str:
+    """Generate S256 code challenge from verifier."""
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def find_available_port() -> int:
+    """Find an available port for the callback server."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def get_callback_port(settings: "CLISettings") -> int:
+    """Get callback port - use configured port or find available one.
+
+    Use configured port when the OAuth provider requires exact redirect URI matching
+    (e.g., Auth0). Falls back to dynamic port allocation for providers that allow
+    wildcard ports (e.g., Keycloak).
+    """
+    if settings.auth_callback_port:
+        return settings.auth_callback_port
+    return find_available_port()
+
+
+class OAuthCallbackHandler(BaseHTTPRequestHandler):
+    """HTTP handler for OAuth callback."""
+
+    authorization_code: str | None = None
+    error: str | None = None
+    state_received: str | None = None
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        """Suppress HTTP server logging."""
+        del format, args
+
+    def do_GET(self) -> None:
+        """Handle GET request from OAuth callback."""
+        parsed = urlparse(self.path)
+        params = parse_qs(parsed.query)
+
+        if "code" in params:
+            OAuthCallbackHandler.authorization_code = params["code"][0]
+            OAuthCallbackHandler.state_received = params.get("state", [None])[0]
+            self._send_success_response()
+        elif "error" in params:
+            error_desc = params.get("error_description", params["error"])[0]
+            OAuthCallbackHandler.error = error_desc
+            self._send_error_response(error_desc)
+        else:
+            OAuthCallbackHandler.error = "Missing authorization code"
+            self._send_error_response("Missing authorization code")
+
+    def _send_success_response(self) -> None:
+        """Send success HTML response to browser."""
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        html = """
+        <!DOCTYPE html>
+        <html>
+        <head><title>Authentication Successful</title></head>
+        <body style="font-family: sans-serif; text-align: center; padding-top: 50px;">
+            <h1 style="color: #28a745;">Authentication Successful</h1>
+            <p>You can close this window and return to the CLI.</p>
+        </body>
+        </html>
+        """
+        self.wfile.write(html.encode())
+
+    def _send_error_response(self, error: str) -> None:
+        """Send error HTML response to browser."""
+        self.send_response(400)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        html = f"""
+        <!DOCTYPE html>
+        <html>
+        <head><title>Authentication Failed</title></head>
+        <body style="font-family: sans-serif; text-align: center; padding-top: 50px;">
+            <h1 style="color: #dc3545;">Authentication Failed</h1>
+            <p>{error}</p>
+        </body>
+        </html>
+        """
+        self.wfile.write(html.encode())
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset handler state before starting a new OAuth flow."""
+        cls.authorization_code = None
+        cls.error = None
+        cls.state_received = None
+
+
+def run_oauth_callback_server(port: int) -> None:
+    """Run the OAuth callback server and wait for a single request."""
+    server = HTTPServer(("127.0.0.1", port), OAuthCallbackHandler)
+    server.timeout = CALLBACK_TIMEOUT
+    try:
+        server.handle_request()
+    finally:
+        server.server_close()

--- a/tests/unit/cli/shared/test_settings.py
+++ b/tests/unit/cli/shared/test_settings.py
@@ -144,8 +144,6 @@ class TestGetAuthSettingsForProvider:
         monkeypatch.setenv("STATGPT_CLI_AUTH_AZURE_AUTHORITY", "https://authority")
         monkeypatch.setenv("STATGPT_CLI_AUTH_AZURE_SCOPE", "scope")
         monkeypatch.setenv("STATGPT_CLI_AUTH_AZURE_CLIENT_SECRET", "secret")
-        monkeypatch.setenv("STATGPT_CLI_AUTH_AZURE_USERNAME", "user")
-        monkeypatch.setenv("STATGPT_CLI_AUTH_AZURE_PASSWORD", "pass")
 
         settings = make_settings()
         azure_settings = settings.get_auth_settings_for_provider("azure")
@@ -154,8 +152,6 @@ class TestGetAuthSettingsForProvider:
         assert azure_settings["authority"] == "https://authority"
         assert azure_settings["scope"] == "scope"
         assert azure_settings["client_secret"] == "secret"
-        assert azure_settings["username"] == "user"
-        assert azure_settings["password"] == "pass"
 
     def test_azure_provider_settings_partial(self, clean_cli_env, monkeypatch):
         monkeypatch.setenv("STATGPT_CLI_AUTH_AZURE_CLIENT_ID", "client-123")
@@ -180,8 +176,6 @@ class TestGetAuthSettingsForProvider:
             "authority",
             "scope",
             "client_secret",
-            "username",
-            "password",
         }
         assert set(azure_settings.keys()) == expected_keys
 


### PR DESCRIPTION
Add Auth0 authentication provider support for the CLI and align all authentication providers (Azure, Keycloak, Auth0) to a consistent pattern:                                     
                                                                                                                                                                                     
- Interactive login: Authorization Code Flow with PKCE (public client, no client_secret)                                                                                           
- System user login (M2M/CI): Client Credentials Grant (confidential client)

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #90

### Description of changes

<!-- Please explain the changes you made right below this line. -->

#### New Features                                                                                                                                                                       
                                                                                                                                                                                     
- Add Auth0 authentication provider with PKCE for interactive login and Client Credentials Grant for M2M                                                                           
- Add configurable OAuth callback port (AUTH_CALLBACK_PORT) for providers that don't support wildcard redirect URIs (required for Auth0)                                           
- Extract shared OAuth utilities (PKCE helpers, callback server) to oauth.py module                                                                                                
                                                                                                                                                                                     
#### Breaking Changes                                                                                                                                                                   
                                                                                                                                                                                     
- Remove AUTH_AZURE_USERNAME / AUTH_AZURE_PASSWORD settings (replaced by Client Credentials Grant)                                                                                 
- Remove AUTH_KEYCLOAK_USERNAME / AUTH_KEYCLOAK_PASSWORD settings (replaced by Client Credentials Grant)                                                                           
- Auth0 interactive login now requires AUTH_CALLBACK_PORT to be set                                                                                                             
                                                                                                                                                                                     
#### Documentation                                                                                                                                                                      
                                                                                                                                                                                     
- Add comprehensive "Authentication Provider Setup" section to CLI README with step-by-step instructions for configuring Azure, Keycloak, and Auth0                                
- Update environment variables table and .env.template    

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
