### PR TITLE
feat: resolve dynamic URNs, add indexing hash system and auto-propagate config #94

### DIFF
--- a/statgpt/admin/alembic/versions/2026_01_14_1344-77c67d91641c_add_resolved_config_to_channel_dataset_.py
+++ b/statgpt/admin/alembic/versions/2026_01_14_1344-77c67d91641c_add_resolved_config_to_channel_dataset_.py
@@ -1,0 +1,30 @@
+"""add resolved_config to channel_dataset_versions
+
+Revision ID: 77c67d91641c
+Revises: 109220bfa072
+Create Date: 2026-01-14 13:44:34.851958
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '77c67d91641c'
+down_revision: str | None = '109220bfa072'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'channel_dataset_versions',
+        sa.Column('resolved_config', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('channel_dataset_versions', 'resolved_config')

--- a/statgpt/admin/alembic/versions/2026_01_15_1200-a1b2c3d4e5f6_add_unified_config_hash.py
+++ b/statgpt/admin/alembic/versions/2026_01_15_1200-a1b2c3d4e5f6_add_unified_config_hash.py
@@ -1,0 +1,48 @@
+"""Replace legacy config hashes with unified indexing_config_hash
+
+Revision ID: a1b2c3d4e5f6
+Revises: 77c67d91641c
+Create Date: 2026-01-15 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: str | None = '77c67d91641c'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Add new unified config hash
+    op.add_column(
+        'channel_dataset_versions',
+        sa.Column('indexing_config_hash', sa.String(length=10), nullable=True),
+    )
+    # Drop legacy separate config hashes
+    op.drop_column('channel_dataset_versions', 'indicators_config_hash')
+    op.drop_column('channel_dataset_versions', 'non_indicators_config_hash')
+    op.drop_column('channel_dataset_versions', 'special_dimensions_config_hash')
+
+
+def downgrade() -> None:
+    # Re-add legacy config hashes
+    op.add_column(
+        'channel_dataset_versions',
+        sa.Column('indicators_config_hash', sa.String(length=10), nullable=True),
+    )
+    op.add_column(
+        'channel_dataset_versions',
+        sa.Column('non_indicators_config_hash', sa.String(length=10), nullable=True),
+    )
+    op.add_column(
+        'channel_dataset_versions',
+        sa.Column('special_dimensions_config_hash', sa.String(length=10), nullable=True),
+    )
+    # Drop unified config hash
+    op.drop_column('channel_dataset_versions', 'indexing_config_hash')

--- a/statgpt/admin/alembic/versions/2026_01_15_1200-c7f068b2d47d_add_unified_config_hash.py
+++ b/statgpt/admin/alembic/versions/2026_01_15_1200-c7f068b2d47d_add_unified_config_hash.py
@@ -1,6 +1,6 @@
 """Replace legacy config hashes with unified indexing_config_hash
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: c7f068b2d47d
 Revises: 77c67d91641c
 Create Date: 2026-01-15 12:00:00.000000
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = 'a1b2c3d4e5f6'
+revision: str = 'c7f068b2d47d'
 down_revision: str | None = '77c67d91641c'
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/statgpt/admin/app.py
+++ b/statgpt/admin/app.py
@@ -33,7 +33,7 @@ async def lifespan(app_: FastAPI):
         await DatabaseHealthChecker().check()
 
         # Start data preloading in the background
-        asyncio.create_task(preload_data(allow_cached_datasets=False))
+        asyncio.create_task(preload_data(allow_cached_datasets=False, use_resolved_config=False))
 
         yield
         # Clean up

--- a/statgpt/admin/routers/channel.py
+++ b/statgpt/admin/routers/channel.py
@@ -460,26 +460,6 @@ async def rollback_channel_dataset_to_previous_version(
     )
 
 
-@router.post(path="/{channel_id}/datasets/{dataset_id}/versions/apply-config")
-async def apply_config_to_channel_dataset(
-    channel_id: int,
-    dataset_id: int,
-    session: AsyncSession = Depends(models.get_session),
-) -> schemas.ChannelDatasetVersion:
-    """Apply current dataset config to channel without re-indexing.
-
-    Creates a new version that uses the current DataSet.details config
-    (with resolved URN preserved) but reuses indexed data from the
-    last completed version.
-
-    Use this after updating non-indexing config fields like citation,
-    pinned_columns, is_official, dimension.is_required, dimension.defaultQueries, etc.
-    """
-    return await DataSetService(session).apply_config_to_channel_dataset(
-        channel_id=channel_id, dataset_id=dataset_id
-    )
-
-
 @router.delete(
     path="/{channel_id}/datasets/{dataset_id}/versions/clear-data",
     status_code=status.HTTP_204_NO_CONTENT,

--- a/statgpt/admin/routers/channel.py
+++ b/statgpt/admin/routers/channel.py
@@ -460,6 +460,26 @@ async def rollback_channel_dataset_to_previous_version(
     )
 
 
+@router.post(path="/{channel_id}/datasets/{dataset_id}/versions/apply-config")
+async def apply_config_to_channel_dataset(
+    channel_id: int,
+    dataset_id: int,
+    session: AsyncSession = Depends(models.get_session),
+) -> schemas.ChannelDatasetVersion:
+    """Apply current dataset config to channel without re-indexing.
+
+    Creates a new version that uses the current DataSet.details config
+    (with resolved URN preserved) but reuses indexed data from the
+    last completed version.
+
+    Use this after updating non-indexing config fields like citation,
+    pinned_columns, is_official, dimension.is_required, dimension.defaultQueries, etc.
+    """
+    return await DataSetService(session).apply_config_to_channel_dataset(
+        channel_id=channel_id, dataset_id=dataset_id
+    )
+
+
 @router.delete(
     path="/{channel_id}/datasets/{dataset_id}/versions/clear-data",
     status_code=status.HTTP_204_NO_CONTENT,

--- a/statgpt/admin/routers/dataset.py
+++ b/statgpt/admin/routers/dataset.py
@@ -70,7 +70,12 @@ async def update_dataset(
     item_id: int,
     data: schemas.DataSetUpdate,
     session: AsyncSession = Depends(models.get_session),
-) -> schemas.DataSet:
+) -> schemas.DataSetUpdateResponse:
+    """Update a dataset.
+
+    Returns the updated dataset along with the results of propagating config
+    changes to all channel datasets that reference this dataset.
+    """
     return await DataSetService(session).update(item_id, data, auth_context=SystemUserAuthContext())
 
 

--- a/statgpt/admin/routers/dataset.py
+++ b/statgpt/admin/routers/dataset.py
@@ -68,7 +68,7 @@ async def get_dataset_by_id(
 @router.post("/{item_id}")
 async def update_dataset(
     item_id: int,
-    data: schemas.DataSetUpdate,
+    data: schemas.DataSetUpdateRequest,
     session: AsyncSession = Depends(models.get_session),
 ) -> schemas.DataSetUpdateResponse:
     """Update a dataset.

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -18,7 +18,6 @@ from statgpt.admin.settings.exim import ExImSettings, JobsConfig
 from statgpt.common import utils
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.data import base
-from statgpt.common.data.base.config import ConfigHashes
 from statgpt.common.data.base.dataset import DataSetConfigType
 from statgpt.common.hybrid_indexer import Indexer
 from statgpt.common.schemas import ChannelIndexStatusScope, HybridSearchConfig
@@ -807,15 +806,13 @@ class AdminPortalDataSetService(DataSetService):
     async def _set_version_hashes_and_metadata(
         self,
         item: models.ChannelDatasetVersion,
-        config_hashes: ConfigHashes,
+        config_hash: str,
         structure_hash: str,
         structure_metadata: dict,
         data_hashes: _DataHashes,
     ) -> None:
         """Sets the structure and data hashes for the given channel dataset version."""
-        item.indicators_config_hash = config_hashes.indicator_hash
-        item.non_indicators_config_hash = config_hashes.non_indicator_hash
-        item.special_dimensions_config_hash = config_hashes.special_hash
+        item.indexing_config_hash = config_hash
         item.structure_metadata = structure_metadata
         item.structure_hash = structure_hash
         item.indicator_dimensions_hash = data_hashes.indicator_dimensions_hash
@@ -919,9 +916,9 @@ class AdminPortalDataSetService(DataSetService):
             resolved_config=last_completed.resolved_config or {},
         )
 
-        # Calculate new config hashes from the merged config
+        # Calculate new config hash from the merged config
         parsed_config = handler.parse_data_set_config(new_resolved_config)
-        config_hashes = parsed_config.indexing_hashes
+        config_hash = parsed_config.indexing_hash
 
         new_item = models.ChannelDatasetVersion(
             channel_dataset_id=channel_dataset.id,
@@ -930,9 +927,7 @@ class AdminPortalDataSetService(DataSetService):
             pointer_to=last_completed.version_data_id,
             creation_reason="Applied dataset config changes without re-indexing",
             resolved_config=new_resolved_config,
-            indicators_config_hash=config_hashes.indicator_hash,
-            non_indicators_config_hash=config_hashes.non_indicator_hash,
-            special_dimensions_config_hash=config_hashes.special_hash,
+            indexing_config_hash=config_hash,
             structure_metadata=last_completed.structure_metadata,
             structure_hash=last_completed.structure_hash,
             indicator_dimensions_hash=last_completed.indicator_dimensions_hash,
@@ -967,7 +962,7 @@ class AdminPortalDataSetService(DataSetService):
         handler = await self._get_handler(dataset_db.source_id)
         config = handler.parse_data_set_config(dataset_db.details)
 
-        config_changes = self._get_config_changes(version, config.indexing_hashes)
+        config_changes = self._get_config_changes(version, config.indexing_hash)
 
         structure_hash, meta = await handler.get_structure_hash_and_metadata(
             dataset_config=dataset_db.details, auth_context=auth_context
@@ -1012,26 +1007,17 @@ class AdminPortalDataSetService(DataSetService):
 
     @staticmethod
     def _get_config_changes(
-        version: schemas.ChannelDatasetVersion, config_hashes: ConfigHashes
+        version: schemas.ChannelDatasetVersion, config_hash: str
     ) -> list[schemas.ConfigChange]:
-        iterable = [
-            ('Indicator', version.indicators_config_hash, config_hashes.indicator_hash),
-            ('Special', version.special_dimensions_config_hash, config_hashes.special_hash),
-            (
-                'Non-indicator',
-                version.non_indicators_config_hash,
-                config_hashes.non_indicator_hash,
-            ),
-        ]
-        return [
-            schemas.ConfigChange(
-                message=f"The configuration for the {name} dimensions has changed.",
-                last_version_hash=old_hash,
-                actual_hash=new_hash,
-            )
-            for name, old_hash, new_hash in iterable
-            if old_hash != new_hash
-        ]
+        if version.indexing_config_hash != config_hash:
+            return [
+                schemas.ConfigChange(
+                    message="The dataset configuration (used during indexing) has changed.",
+                    last_version_hash=version.indexing_config_hash,
+                    actual_hash=config_hash,
+                )
+            ]
+        return []
 
     @staticmethod
     def _get_data_changes(
@@ -1584,13 +1570,13 @@ class AdminPortalDataSetService(DataSetService):
             await self._set_resolved_config(version, resolved_config)
 
             if reindex_dimensions or (reindex_indicators and not harmonize_indicator):
-                config_hashes = dataset.config.indexing_hashes
+                config_hash = dataset.config.indexing_hash
                 structure_hash, meta = await handler.get_structure_hash_and_metadata(
                     dataset_config=db_dataset.details, auth_context=auth_context
                 )
                 data_hashes = await self._get_data_hashes(dataset, auth_context, allow_cached=True)
                 await self._set_version_hashes_and_metadata(
-                    version, config_hashes, structure_hash, meta, data_hashes
+                    version, config_hash, structure_hash, meta, data_hashes
                 )
 
             vector_store_factory = VectorStoreFactory(session=self._session)

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -296,9 +296,10 @@ class AdminPortalDataSetService(DataSetService):
                         }
                         if data:
                             _log.info(f"Updating dataset '{dataset_cfg['title']}' with {data}")
-                            dataset = await self.update(
+                            update_response = await self.update(
                                 dataset.id, schemas.DataSetUpdate(**data), auth_context=auth_context
                             )
+                            dataset = update_response.dataset
                         else:
                             _log.info(f"Dataset '{dataset_cfg['title']}' exists and is up to date")
                     else:
@@ -609,7 +610,7 @@ class AdminPortalDataSetService(DataSetService):
 
     async def update(
         self, item_id: int, data: schemas.DataSetUpdate, auth_context: AuthContext
-    ) -> schemas.DataSet:
+    ) -> schemas.DataSetUpdateResponse:
         item = await self.get_model_by_id(item_id, expand=True)
 
         for attr, value in data.model_dump(exclude_unset=True, exclude={'details'}).items():
@@ -631,7 +632,15 @@ class AdminPortalDataSetService(DataSetService):
             auth_context=auth_context,
             allow_offline=True,
         )
-        return DataSetSerializer.db_to_schema(item, dataset, expand=True)
+        dataset_schema = DataSetSerializer.db_to_schema(item, dataset, expand=True)
+
+        # Propagate config changes to channel datasets
+        channel_results = await self._propagate_config_to_channel_datasets(item, handler)
+
+        return schemas.DataSetUpdateResponse(
+            dataset=dataset_schema,
+            channel_results=channel_results,
+        )
 
     async def delete(self, item_id: int) -> None:
         item = await self.get_model_by_id(item_id)
@@ -652,6 +661,143 @@ class AdminPortalDataSetService(DataSetService):
         _log.info(f"Deleting dataset(id={item.id}): {item.title!r}")
         await self._session.delete(item)
         await self._session.commit()
+
+    async def _propagate_config_to_channel_datasets(
+        self,
+        dataset: models.DataSet,
+        handler: base.DataSourceHandler,
+    ) -> list[schemas.ChannelDatasetUpdateResult]:
+        """Propagate config changes to all channel datasets that reference this dataset.
+
+        For each channel dataset:
+        - If indexing is in progress -> INDEXING_IN_PROGRESS
+        - If no completed version exists -> NO_VERSION
+        - If indexing hash matches -> AUTO_UPDATED (creates new version)
+        - If indexing hash differs -> NEEDS_REINDEX
+        """
+        await self._session.refresh(dataset, attribute_names=["mapped_channels"])
+
+        if not dataset.mapped_channels:
+            return []
+
+        results: list[schemas.ChannelDatasetUpdateResult] = []
+
+        channel_dataset_ids = [cd.id for cd in dataset.mapped_channels]
+
+        latest_versions = await self._get_latest_channel_dataset_versions(channel_dataset_ids)
+        last_completed_mapping = await self._get_latest_successful_channel_dataset_versions(
+            channel_dataset_ids=channel_dataset_ids
+        )
+
+        parsed_config = handler.parse_data_set_config(dataset.details)
+        new_config_hash = parsed_config.indexing_hash
+
+        for channel_dataset in dataset.mapped_channels:
+            await self._session.refresh(channel_dataset, attribute_names=["channel"])
+            channel = channel_dataset.channel
+
+            latest_version = latest_versions.get(channel_dataset.id)
+            last_completed_versions = last_completed_mapping.get(channel_dataset.id)
+            last_completed = (
+                last_completed_versions.last_completed_version if last_completed_versions else None
+            )
+
+            if (
+                latest_version
+                and latest_version.preprocessing_status not in StatusEnum.final_statuses()
+            ):
+                results.append(
+                    schemas.ChannelDatasetUpdateResult(
+                        channel_id=channel.id,
+                        channel_title=channel.title,
+                        channel_deployment_id=channel.deployment_id,
+                        status=schemas.ChannelDatasetUpdateStatus.INDEXING_IN_PROGRESS,
+                        message="Cannot apply config while indexing is in progress.",
+                    )
+                )
+                continue
+
+            if last_completed is None:
+                results.append(
+                    schemas.ChannelDatasetUpdateResult(
+                        channel_id=channel.id,
+                        channel_title=channel.title,
+                        channel_deployment_id=channel.deployment_id,
+                        status=schemas.ChannelDatasetUpdateStatus.NO_VERSION,
+                        message="No completed version exists to apply config to.",
+                    )
+                )
+                continue
+
+            if new_config_hash == last_completed.indexing_config_hash:
+                new_version = await self._apply_config_internal(
+                    channel_dataset, last_completed, handler, dataset.details
+                )
+                results.append(
+                    schemas.ChannelDatasetUpdateResult(
+                        channel_id=channel.id,
+                        channel_title=channel.title,
+                        channel_deployment_id=channel.deployment_id,
+                        status=schemas.ChannelDatasetUpdateStatus.AUTO_UPDATED,
+                        message="Config applied without re-indexing.",
+                        new_version_id=new_version.id,
+                        new_version_number=new_version.version,
+                    )
+                )
+            else:
+                results.append(
+                    schemas.ChannelDatasetUpdateResult(
+                        channel_id=channel.id,
+                        channel_title=channel.title,
+                        channel_deployment_id=channel.deployment_id,
+                        status=schemas.ChannelDatasetUpdateStatus.NEEDS_REINDEX,
+                        message="Indexing-related config has changed. Reindexing required.",
+                    )
+                )
+
+        return results
+
+    async def _apply_config_internal(
+        self,
+        channel_dataset: models.ChannelDataset,
+        last_completed: schemas.ChannelDatasetVersion,
+        handler: base.DataSourceHandler,
+        current_config: dict[str, Any],
+    ) -> schemas.ChannelDatasetVersion:
+        """Apply config changes to a channel dataset without re-indexing.
+
+        Creates a new COMPLETED version that reuses indexed data from the
+        last completed version.
+        """
+        if last_completed.resolved_config is None:
+            new_resolved_config = current_config
+        else:
+            new_resolved_config = handler.merge_config_with_resolved(
+                current_config=current_config,
+                resolved_config=last_completed.resolved_config,
+            )
+
+        parsed_config = handler.parse_data_set_config(new_resolved_config)
+
+        new_item = models.ChannelDatasetVersion(
+            channel_dataset_id=channel_dataset.id,
+            # `version` will be set by the DB trigger automatically
+            preprocessing_status=StatusEnum.COMPLETED,
+            pointer_to=last_completed.version_data_id,
+            creation_reason="Applied dataset config changes without re-indexing",
+            resolved_config=new_resolved_config,
+            indexing_config_hash=parsed_config.indexing_hash,
+            structure_metadata=last_completed.structure_metadata,
+            structure_hash=last_completed.structure_hash,
+            indicator_dimensions_hash=last_completed.indicator_dimensions_hash,
+            non_indicator_dimensions_hash=last_completed.non_indicator_dimensions_hash,
+            special_dimensions_hash=last_completed.special_dimensions_hash,
+        )
+
+        self._session.add(new_item)
+        await self._session.commit()
+        await self._session.refresh(new_item)
+        return schemas.ChannelDatasetVersion.model_validate(new_item, from_attributes=True)
 
     async def add_dataset_to_channel(
         self, channel_id: int, dataset_id: int
@@ -871,88 +1017,6 @@ class AdminPortalDataSetService(DataSetService):
             creation_reason=f"Rolled back to previous version={previous_version.version}",
             **{f: getattr(previous_version, f) for f in JobsConfig.VERSIONS_FIELDS},
         )
-        self._session.add(new_item)
-        await self._session.commit()
-        await self._session.refresh(new_item)
-        return schemas.ChannelDatasetVersion.model_validate(new_item, from_attributes=True)
-
-    async def apply_config_to_channel_dataset(
-        self, channel_id: int, dataset_id: int
-    ) -> schemas.ChannelDatasetVersion:
-        """Create a new version with updated config but existing indexed data.
-
-        This allows applying non-indexing config changes (citation, pinned_columns,
-        is_required, defaultQueries, etc.) without re-indexing the dataset.
-        """
-        channel: models.Channel = await ChannelService(self._session).get_model_by_id(channel_id)
-        dataset: models.DataSet = await self.get_model_by_id(dataset_id)
-        channel_dataset = await self.get_channel_dataset_model_or_raise(
-            channel_id=channel.id, dataset_id=dataset.id
-        )
-
-        last_version = await self._get_latest_channel_dataset_version_schema(
-            channel_dataset_id=channel_dataset.id
-        )
-        if last_version and last_version.preprocessing_status not in StatusEnum.final_statuses():
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="Cannot apply config while the indexing is in progress.",
-            )
-
-        last_completed_versions = await self._get_latest_successful_channel_dataset_versions(
-            channel_dataset_ids=[channel_dataset.id]
-        )
-        last_completed = last_completed_versions[channel_dataset.id].last_completed_version
-        if last_completed is None:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="No completed version exists to apply config to.",
-            )
-
-        handler = await self._get_handler(dataset.source_id)
-
-        if last_completed.resolved_config is None:
-            new_resolved_config = dataset.details
-        else:
-            new_resolved_config = handler.merge_config_with_resolved(
-                current_config=dataset.details,
-                resolved_config=last_completed.resolved_config,
-            )
-
-        # Calculate new config hash from the merged config
-        parsed_config = handler.parse_data_set_config(new_resolved_config)
-        config_hash = parsed_config.indexing_hash
-
-        last_indexing_hash = last_completed.indexing_config_hash
-        if last_indexing_hash is not None and config_hash != last_indexing_hash:
-            # This might happen if:
-            # 1) the merging logic is faulty, or
-            # 2) resolved_config was missing and current config has indexing-related changes.
-            _log.warning(
-                f"Indexing-related config has changed for dataset {dataset.id_!r} "
-                f"(id={dataset.id}) in channel {channel.deployment_id!r} (id={channel.id}): "
-                f"{last_indexing_hash!r} -> {config_hash!r}"
-            )
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="The indexing-related config has changed. Please reindex the dataset.",
-            )
-
-        new_item = models.ChannelDatasetVersion(
-            channel_dataset_id=channel_dataset.id,
-            # `version` will be set by the DB trigger automatically
-            preprocessing_status=StatusEnum.COMPLETED,
-            pointer_to=last_completed.version_data_id,
-            creation_reason="Applied dataset config changes without re-indexing",
-            resolved_config=new_resolved_config,
-            indexing_config_hash=config_hash,
-            structure_metadata=last_completed.structure_metadata,
-            structure_hash=last_completed.structure_hash,
-            indicator_dimensions_hash=last_completed.indicator_dimensions_hash,
-            non_indicator_dimensions_hash=last_completed.non_indicator_dimensions_hash,
-            special_dimensions_hash=last_completed.special_dimensions_hash,
-        )
-
         self._session.add(new_item)
         await self._session.commit()
         await self._session.refresh(new_item)

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -22,7 +22,12 @@ from statgpt.common.data.base.dataset import DataSetConfigType
 from statgpt.common.hybrid_indexer import Indexer
 from statgpt.common.schemas import ChannelIndexStatusScope, HybridSearchConfig
 from statgpt.common.schemas import PreprocessingStatusEnum as StatusEnum
-from statgpt.common.services import ChannelDataSetSerializer, DataSetSerializer, DataSetService
+from statgpt.common.services import (
+    ChannelDataSetSerializer,
+    ChannelSerializer,
+    DataSetSerializer,
+    DataSetService,
+)
 from statgpt.common.services.dataset import LastCompletedVersions
 from statgpt.common.settings.document import (
     DimensionValueDocumentMetadataFields,
@@ -291,13 +296,15 @@ class AdminPortalDataSetService(DataSetService):
                     if update_datasets:
                         data = {
                             field: getattr(parsed_dataset, field)
-                            for field in schemas.DataSetUpdate.model_fields.keys()
+                            for field in schemas.DataSetUpdateRequest.model_fields.keys()
                             if getattr(parsed_dataset, field) != getattr(dataset, field)
                         }
                         if data:
                             _log.info(f"Updating dataset '{dataset_cfg['title']}' with {data}")
                             update_response = await self.update(
-                                dataset.id, schemas.DataSetUpdate(**data), auth_context=auth_context
+                                dataset.id,
+                                schemas.DataSetUpdateRequest.model_validate(data),
+                                auth_context=auth_context,
                             )
                             dataset = update_response.dataset
                         else:
@@ -609,7 +616,7 @@ class AdminPortalDataSetService(DataSetService):
         return datasets
 
     async def update(
-        self, item_id: int, data: schemas.DataSetUpdate, auth_context: AuthContext
+        self, item_id: int, data: schemas.DataSetUpdateRequest, auth_context: AuthContext
     ) -> schemas.DataSetUpdateResponse:
         item = await self.get_model_by_id(item_id, expand=True)
 
@@ -634,9 +641,7 @@ class AdminPortalDataSetService(DataSetService):
         )
         dataset_schema = DataSetSerializer.db_to_schema(item, dataset, expand=True)
 
-        # Propagate config changes to channel datasets
         channel_results = await self._propagate_config_to_channel_datasets(item, handler)
-
         return schemas.DataSetUpdateResponse(
             dataset=dataset_schema,
             channel_results=channel_results,
@@ -702,58 +707,31 @@ class AdminPortalDataSetService(DataSetService):
                 last_completed_versions.last_completed_version if last_completed_versions else None
             )
 
+            other_fields = {}
             if (
                 latest_version
                 and latest_version.preprocessing_status not in StatusEnum.final_statuses()
             ):
-                results.append(
-                    schemas.ChannelDatasetUpdateResult(
-                        channel_id=channel.id,
-                        channel_title=channel.title,
-                        channel_deployment_id=channel.deployment_id,
-                        status=schemas.ChannelDatasetUpdateStatus.INDEXING_IN_PROGRESS,
-                        message="Cannot apply config while indexing is in progress.",
-                    )
-                )
-                continue
-
-            if last_completed is None:
-                results.append(
-                    schemas.ChannelDatasetUpdateResult(
-                        channel_id=channel.id,
-                        channel_title=channel.title,
-                        channel_deployment_id=channel.deployment_id,
-                        status=schemas.ChannelDatasetUpdateStatus.NO_VERSION,
-                        message="No completed version exists to apply config to.",
-                    )
-                )
-                continue
-
-            if new_config_hash == last_completed.indexing_config_hash:
+                status = schemas.ChannelDatasetUpdateStatus.INDEXING_IN_PROGRESS
+            elif last_completed is None:
+                status = schemas.ChannelDatasetUpdateStatus.NO_VERSION
+            elif new_config_hash == last_completed.indexing_config_hash:
                 new_version = await self._apply_config_internal(
                     channel_dataset, last_completed, handler, dataset.details
                 )
-                results.append(
-                    schemas.ChannelDatasetUpdateResult(
-                        channel_id=channel.id,
-                        channel_title=channel.title,
-                        channel_deployment_id=channel.deployment_id,
-                        status=schemas.ChannelDatasetUpdateStatus.AUTO_UPDATED,
-                        message="Config applied without re-indexing.",
-                        new_version_id=new_version.id,
-                        new_version_number=new_version.version,
-                    )
-                )
+                other_fields['new_version'] = new_version
+                status = schemas.ChannelDatasetUpdateStatus.AUTO_UPDATED
             else:
-                results.append(
-                    schemas.ChannelDatasetUpdateResult(
-                        channel_id=channel.id,
-                        channel_title=channel.title,
-                        channel_deployment_id=channel.deployment_id,
-                        status=schemas.ChannelDatasetUpdateStatus.NEEDS_REINDEX,
-                        message="Indexing-related config has changed. Reindexing required.",
-                    )
+                status = schemas.ChannelDatasetUpdateStatus.NEEDS_REINDEX
+
+            results.append(
+                schemas.ChannelDatasetUpdateResult(
+                    channel_dataset_id=channel_dataset.id,
+                    status=status,
+                    channel=ChannelSerializer.db_to_schema(channel),
+                    **other_fields,
                 )
+            )
 
         return results
 

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -879,6 +879,72 @@ class AdminPortalDataSetService(DataSetService):
         await self._session.refresh(new_item)
         return schemas.ChannelDatasetVersion.model_validate(new_item, from_attributes=True)
 
+    async def apply_config_to_channel_dataset(
+        self, channel_id: int, dataset_id: int
+    ) -> schemas.ChannelDatasetVersion:
+        """Create a new version with updated config but existing indexed data.
+
+        This allows applying non-indexing config changes (citation, pinned_columns,
+        is_required, defaultQueries, etc.) without re-indexing the dataset.
+        """
+        channel: models.Channel = await ChannelService(self._session).get_model_by_id(channel_id)
+        dataset: models.DataSet = await self.get_model_by_id(dataset_id)
+        channel_dataset = await self.get_channel_dataset_model_or_raise(
+            channel_id=channel.id, dataset_id=dataset.id
+        )
+
+        last_version = await self._get_latest_channel_dataset_version_schema(
+            channel_dataset_id=channel_dataset.id
+        )
+        if last_version and last_version.preprocessing_status not in StatusEnum.final_statuses():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Cannot apply config while the indexing is in progress.",
+            )
+
+        last_completed_versions = await self._get_latest_successful_channel_dataset_versions(
+            channel_dataset_ids=[channel_dataset.id]
+        )
+        last_completed = last_completed_versions[channel_dataset.id].last_completed_version
+        if last_completed is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No completed version exists to apply config to.",
+            )
+
+        # Use handler to merge configs (preserves resolved URN for SDMX)
+        handler = await self._get_handler(dataset.source_id)
+        new_resolved_config = handler.merge_config_with_resolved(
+            current_config=dataset.details,
+            resolved_config=last_completed.resolved_config or {},
+        )
+
+        # Calculate new config hashes from the merged config
+        parsed_config = handler.parse_data_set_config(new_resolved_config)
+        config_hashes = parsed_config.indexing_hashes
+
+        new_item = models.ChannelDatasetVersion(
+            channel_dataset_id=channel_dataset.id,
+            # `version` will be set by the DB trigger automatically
+            preprocessing_status=StatusEnum.COMPLETED,
+            pointer_to=last_completed.version_data_id,
+            creation_reason="Applied dataset config changes without re-indexing",
+            resolved_config=new_resolved_config,
+            indicators_config_hash=config_hashes.indicator_hash,
+            non_indicators_config_hash=config_hashes.non_indicator_hash,
+            special_dimensions_config_hash=config_hashes.special_hash,
+            structure_metadata=last_completed.structure_metadata,
+            structure_hash=last_completed.structure_hash,
+            indicator_dimensions_hash=last_completed.indicator_dimensions_hash,
+            non_indicator_dimensions_hash=last_completed.non_indicator_dimensions_hash,
+            special_dimensions_hash=last_completed.special_dimensions_hash,
+        )
+
+        self._session.add(new_item)
+        await self._session.commit()
+        await self._session.refresh(new_item)
+        return schemas.ChannelDatasetVersion.model_validate(new_item, from_attributes=True)
+
     async def is_channel_dataset_latest_version_up_to_date(
         self, channel_id: int, dataset_id: int, auth_context: AuthContext
     ) -> schemas.ChangesBetweenVersionAndActualData:

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -909,16 +909,32 @@ class AdminPortalDataSetService(DataSetService):
                 detail="No completed version exists to apply config to.",
             )
 
-        # Use handler to merge configs (preserves resolved URN for SDMX)
         handler = await self._get_handler(dataset.source_id)
-        new_resolved_config = handler.merge_config_with_resolved(
-            current_config=dataset.details,
-            resolved_config=last_completed.resolved_config or {},
-        )
+
+        if last_completed.resolved_config is None:
+            new_resolved_config = dataset.details
+        else:
+            new_resolved_config = handler.merge_config_with_resolved(
+                current_config=dataset.details,
+                resolved_config=last_completed.resolved_config,
+            )
 
         # Calculate new config hash from the merged config
         parsed_config = handler.parse_data_set_config(new_resolved_config)
         config_hash = parsed_config.indexing_hash
+
+        last_indexing_hash = last_completed.indexing_config_hash
+        if last_indexing_hash is not None and config_hash != last_indexing_hash:
+            # This might happen if:
+            # 1) the merging logic is faulty, or
+            # 2) resolved_config was missing and current config has indexing-related changes.
+            _log.warning(
+                f"Indexing-related config has changed: {last_indexing_hash!r} -> {config_hash!r}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="The indexing-related config has changed. Please reindex the dataset.",
+            )
 
         new_item = models.ChannelDatasetVersion(
             channel_dataset_id=channel_dataset.id,

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -826,6 +826,18 @@ class AdminPortalDataSetService(DataSetService):
         await self._session.commit()
         await self._session.refresh(item)
 
+    async def _set_resolved_config(
+        self,
+        item: models.ChannelDatasetVersion,
+        resolved_config: dict | None,
+    ) -> None:
+        """Sets the resolved configuration for the given channel dataset version."""
+        if resolved_config is not None:
+            item.resolved_config = resolved_config
+            item.updated_at = func.now()
+            await self._session.commit()
+            await self._session.refresh(item)
+
     async def rollback_channel_dataset_to_previous_version(
         self, channel_id: int, dataset_id: int
     ) -> schemas.ChannelDatasetVersion:
@@ -1500,6 +1512,10 @@ class AdminPortalDataSetService(DataSetService):
                 auth_context=auth_context,
                 allow_offline=False,  # Unable to reindex offline dataset
             )
+
+            # Extract and store resolved config from loaded dataset
+            resolved_config = dataset.get_resolved_config()
+            await self._set_resolved_config(version, resolved_config)
 
             if reindex_dimensions or (reindex_indicators and not harmonize_indicator):
                 config_hashes = dataset.config.indexing_hashes

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -929,7 +929,9 @@ class AdminPortalDataSetService(DataSetService):
             # 1) the merging logic is faulty, or
             # 2) resolved_config was missing and current config has indexing-related changes.
             _log.warning(
-                f"Indexing-related config has changed: {last_indexing_hash!r} -> {config_hash!r}"
+                f"Indexing-related config has changed for dataset {dataset.id_!r} "
+                f"(id={dataset.id}) in channel {channel.deployment_id!r} (id={channel.id}): "
+                f"{last_indexing_hash!r} -> {config_hash!r}"
             )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/statgpt/admin/settings/exim.py
+++ b/statgpt/admin/settings/exim.py
@@ -48,9 +48,7 @@ class JobsConfig:
     DATASET_FIELDS = {"id_", "title", "details"}  # and dynamic 'dataSource' field
     DATA_SOURCE_FIELDS = {"title", "description", "type_id", "details"}
     VERSIONS_FIELDS = {
-        'indicators_config_hash',
-        'non_indicators_config_hash',
-        'special_dimensions_config_hash',
+        'indexing_config_hash',
         'structure_metadata',
         'structure_hash',
         'indicator_dimensions_hash',

--- a/statgpt/admin/settings/exim.py
+++ b/statgpt/admin/settings/exim.py
@@ -56,4 +56,5 @@ class JobsConfig:
         'indicator_dimensions_hash',
         'non_indicator_dimensions_hash',
         'special_dimensions_hash',
+        'resolved_config',
     }

--- a/statgpt/app/application/application.py
+++ b/statgpt/app/application/application.py
@@ -24,7 +24,7 @@ async def lifespan(app: "StatGPTApp"):
         await DatabaseHealthChecker().check()
 
         # Start data preloading in the background
-        asyncio.create_task(preload_data(allow_cached_datasets=True))
+        asyncio.create_task(preload_data(allow_cached_datasets=True, use_resolved_config=True))
 
         yield
         # Clean up

--- a/statgpt/app/services/chat_facade.py
+++ b/statgpt/app/services/chat_facade.py
@@ -355,6 +355,16 @@ class ChannelServiceFacade(DbServiceBase):
             result.append(await handler.document_to_dimension_category(doc))
         return result
 
+    @staticmethod
+    def _get_config_for_query(
+        db_dataset: models.DataSet,
+        version: ChannelDatasetVersion,
+    ) -> dict:
+        """Get config for querying - prefer resolved_config if available."""
+        if version.resolved_config is not None:
+            return version.resolved_config
+        return db_dataset.details
+
     async def _load_datasets(self, auth_context: AuthContext) -> list[VersionedDataSet]:
         dataset_service = DataSetService(self._session, session_lock=self._session_lock)
         data_source_service = DataSourceService(self._session, session_lock=self._session_lock)
@@ -381,11 +391,12 @@ class ChannelServiceFacade(DbServiceBase):
         for db_dataset in dataset_models:
             data_source = data_sources[db_dataset.source_id]
             handler = await self._get_handler_class(data_source.type, config=data_source.details)
-            if await handler.is_dataset_available(db_dataset.details, auth_context):
+            config_to_use = self._get_config_for_query(db_dataset, versions[db_dataset.id])
+            if await handler.is_dataset_available(config_to_use, auth_context):
                 ds = await handler.get_dataset(
                     entity_id=db_dataset.id_,
                     title=db_dataset.title,
-                    config=db_dataset.details,
+                    config=config_to_use,
                     auth_context=auth_context,
                     allow_offline=True,
                     allow_cached=True,

--- a/statgpt/cli/commands/channel.py
+++ b/statgpt/cli/commands/channel.py
@@ -561,6 +561,71 @@ async def reindex_handler(
         print_success("Reindex operation started")
 
 
+async def apply_config_handler(
+    channel: str | None = None,
+    dataset_urn: str | None = None,
+) -> None:
+    """Apply current dataset config to channel without re-indexing."""
+    async with get_admin_client() as client:
+        if not await client.health_check():
+            print_error("Admin API is not available.")
+            return
+
+        # Fetch channels
+        channels = await client.get_channels()
+        if not channels:
+            print_error("No channels found.")
+            return
+
+        # Select channel
+        if channel:
+            selected_channel = next((ch for ch in channels if ch.deployment_id == channel), None)
+            if not selected_channel:
+                print_error(f"Channel not found: {channel}")
+                return
+        else:
+            selected_channel = await _select_channel_interactive(channels)
+            if not selected_channel:
+                return
+
+        # Fetch datasets for channel
+        datasets = await client.get_datasets(channel_id=selected_channel.id)
+        if not datasets:
+            print_error("No datasets found in channel.")
+            return
+
+        # Select dataset
+        if dataset_urn:
+            selected_ds = next(
+                (ds for ds in datasets if _get_urn_display(ds) == dataset_urn),
+                None,
+            )
+            if not selected_ds:
+                print_error(f"Dataset not found: {dataset_urn}")
+                return
+        else:
+            selected_ds_urn = await _select_dataset_interactive(datasets)
+            if not selected_ds_urn:
+                return
+            selected_ds = next(
+                (ds for ds in datasets if _get_urn_display(ds) == selected_ds_urn),
+                None,
+            )
+            if not selected_ds:
+                return
+
+        print_info(f"Applying config for dataset: {_get_urn_display(selected_ds)}")
+
+        # Apply config
+        with spinner_status("Applying dataset config..."):
+            version = await client.apply_config_to_channel_dataset(
+                channel_id=selected_channel.id,
+                dataset_id=selected_ds.id,
+            )
+
+        print_success(f"Config applied! New version: {version.version}")
+
+
 list_command = Command(
     name="list",
     description="List all available channels",
@@ -653,6 +718,25 @@ reindex_command = Command(
     ],
 )
 
+
+apply_config_command = Command(
+    name="apply-config",
+    description="Apply current dataset config to channel without re-indexing",
+    handler=apply_config_handler,
+    args=[
+        CommandArg(
+            name="channel",
+            short_name="c",
+            description="Channel deployment ID",
+        ),
+        CommandArg(
+            name="dataset-urn",
+            description="Dataset URN (e.g., IMF.RES:WEO:1.0.0)",
+        ),
+    ],
+)
+
+
 # Command group
 channel_group = CommandGroup(
     name="channel",
@@ -663,3 +747,4 @@ channel_group.add_command(import_command)
 channel_group.add_command(status_command)
 channel_group.add_command(deduplicate_command)
 channel_group.add_command(reindex_command)
+channel_group.add_command(apply_config_command)

--- a/statgpt/cli/commands/channel.py
+++ b/statgpt/cli/commands/channel.py
@@ -484,6 +484,44 @@ async def _select_dataset_interactive(datasets: list[DataSet]) -> str | None:
         ) from None
 
 
+async def _select_apply_config_mode_interactive(
+    datasets: list[DataSet], channel: Channel
+) -> str | None:
+    """Interactive mode selection for apply-config command."""
+    # Show datasets info
+    console.print(f"\n[bold]Datasets in {channel.title}:[/bold]")
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("URN", ratio=2)
+    table.add_column("Title", ratio=2)
+    table.add_column("Status", width=12)
+
+    for ds in datasets:
+        urn = _get_urn_display(ds)
+        status = ds.status.status if ds.status else "UNKNOWN"
+        table.add_row(urn, ds.title, status)
+
+    console.print(table)
+    console.print()
+
+    items = [
+        ("all", "Apply config to all datasets"),
+        ("dataset", "Apply config to specific dataset"),
+    ]
+
+    try:
+        return await select_item_interactive(
+            items,
+            title="Select Apply Config Mode",
+            filter_enabled=False,
+        )
+    except NonInteractiveError:
+        raise NonInteractiveError(
+            "Missing required parameter: --mode\n"
+            "  Available modes: all, dataset\n"
+            "  Usage: statgpt channel apply-config -c <channel> --mode <mode>"
+        ) from None
+
+
 async def reindex_handler(
     channel: str | None = None,
     mode: str | None = None,
@@ -563,6 +601,7 @@ async def reindex_handler(
 
 async def apply_config_handler(
     channel: str | None = None,
+    mode: str | None = None,
     dataset_urn: str | None = None,
 ) -> None:
     """Apply current dataset config to channel without re-indexing."""
@@ -588,42 +627,78 @@ async def apply_config_handler(
             if not selected_channel:
                 return
 
+        print_info(f"Selected channel: {selected_channel.title}")
+
         # Fetch datasets for channel
         datasets = await client.get_datasets(channel_id=selected_channel.id)
         if not datasets:
             print_error("No datasets found in channel.")
             return
 
-        # Select dataset
-        if dataset_urn:
-            selected_ds = next(
-                (ds for ds in datasets if _get_urn_display(ds) == dataset_urn),
-                None,
-            )
-            if not selected_ds:
-                print_error(f"Dataset not found: {dataset_urn}")
+        # Select mode
+        if not mode:
+            mode = await _select_apply_config_mode_interactive(datasets, selected_channel)
+            if not mode:
                 return
+
+        if mode == "all":
+            # Apply config to all datasets
+            success_count = 0
+            failed_datasets: list[str] = []
+
+            for ds in datasets:
+                urn = _get_urn_display(ds)
+                print_info(f"Applying config for: {urn}")
+                try:
+                    with spinner_status(f"Applying config to {urn}..."):
+                        await client.apply_config_to_channel_dataset(
+                            channel_id=selected_channel.id,
+                            dataset_id=ds.id,
+                        )
+                    success_count += 1
+                except Exception as e:
+                    print_error(f"Failed to apply config to {urn}: {e}")
+                    failed_datasets.append(urn)
+
+            # Report results
+            total = len(datasets)
+            if failed_datasets:
+                print_error(
+                    f"Config applied to {success_count}/{total} datasets. "
+                    f"Failed: {', '.join(failed_datasets)}"
+                )
+            else:
+                print_success(f"Config applied to all {total} datasets.")
         else:
-            selected_ds_urn = await _select_dataset_interactive(datasets)
-            if not selected_ds_urn:
-                return
-            selected_ds = next(
-                (ds for ds in datasets if _get_urn_display(ds) == selected_ds_urn),
-                None,
-            )
-            if not selected_ds:
-                return
+            # Apply to single dataset
+            if dataset_urn:
+                selected_ds = next(
+                    (ds for ds in datasets if _get_urn_display(ds) == dataset_urn),
+                    None,
+                )
+                if not selected_ds:
+                    print_error(f"Dataset not found: {dataset_urn}")
+                    return
+            else:
+                selected_ds_urn = await _select_dataset_interactive(datasets)
+                if not selected_ds_urn:
+                    return
+                selected_ds = next(
+                    (ds for ds in datasets if _get_urn_display(ds) == selected_ds_urn),
+                    None,
+                )
+                if not selected_ds:
+                    return
 
-        print_info(f"Applying config for dataset: {_get_urn_display(selected_ds)}")
+            print_info(f"Applying config for dataset: {_get_urn_display(selected_ds)}")
 
-        # Apply config
-        with spinner_status("Applying dataset config..."):
-            version = await client.apply_config_to_channel_dataset(
-                channel_id=selected_channel.id,
-                dataset_id=selected_ds.id,
-            )
+            with spinner_status("Applying dataset config..."):
+                version = await client.apply_config_to_channel_dataset(
+                    channel_id=selected_channel.id,
+                    dataset_id=selected_ds.id,
+                )
 
-        print_success(f"Config applied! New version: {version.version}")
+            print_success(f"Config applied! New version: {version.version}")
 
 
 list_command = Command(
@@ -730,8 +805,13 @@ apply_config_command = Command(
             description="Channel deployment ID",
         ),
         CommandArg(
+            name="mode",
+            description="Apply mode (all/dataset)",
+            choices=["all", "dataset"],
+        ),
+        CommandArg(
             name="dataset-urn",
-            description="Dataset URN (e.g., IMF.RES:WEO:1.0.0)",
+            description="Dataset URN (required when mode=dataset)",
         ),
     ],
 )

--- a/statgpt/cli/commands/channel.py
+++ b/statgpt/cli/commands/channel.py
@@ -484,44 +484,6 @@ async def _select_dataset_interactive(datasets: list[DataSet]) -> str | None:
         ) from None
 
 
-async def _select_apply_config_mode_interactive(
-    datasets: list[DataSet], channel: Channel
-) -> str | None:
-    """Interactive mode selection for apply-config command."""
-    # Show datasets info
-    console.print(f"\n[bold]Datasets in {channel.title}:[/bold]")
-    table = Table(show_header=True, header_style="bold")
-    table.add_column("URN", ratio=2)
-    table.add_column("Title", ratio=2)
-    table.add_column("Status", width=12)
-
-    for ds in datasets:
-        urn = _get_urn_display(ds)
-        status = ds.status.status if ds.status else "UNKNOWN"
-        table.add_row(urn, ds.title, status)
-
-    console.print(table)
-    console.print()
-
-    items = [
-        ("all", "Apply config to all datasets"),
-        ("dataset", "Apply config to specific dataset"),
-    ]
-
-    try:
-        return await select_item_interactive(
-            items,
-            title="Select Apply Config Mode",
-            filter_enabled=False,
-        )
-    except NonInteractiveError:
-        raise NonInteractiveError(
-            "Missing required parameter: --mode\n"
-            "  Available modes: all, dataset\n"
-            "  Usage: statgpt channel apply-config -c <channel> --mode <mode>"
-        ) from None
-
-
 async def reindex_handler(
     channel: str | None = None,
     mode: str | None = None,
@@ -597,108 +559,6 @@ async def reindex_handler(
             )
 
         print_success("Reindex operation started")
-
-
-async def apply_config_handler(
-    channel: str | None = None,
-    mode: str | None = None,
-    dataset_urn: str | None = None,
-) -> None:
-    """Apply current dataset config to channel without re-indexing."""
-    async with get_admin_client() as client:
-        if not await client.health_check():
-            print_error("Admin API is not available.")
-            return
-
-        # Fetch channels
-        channels = await client.get_channels()
-        if not channels:
-            print_error("No channels found.")
-            return
-
-        # Select channel
-        if channel:
-            selected_channel = next((ch for ch in channels if ch.deployment_id == channel), None)
-            if not selected_channel:
-                print_error(f"Channel not found: {channel}")
-                return
-        else:
-            selected_channel = await _select_channel_interactive(channels)
-            if not selected_channel:
-                return
-
-        print_info(f"Selected channel: {selected_channel.title}")
-
-        # Fetch datasets for channel
-        datasets = await client.get_datasets(channel_id=selected_channel.id)
-        if not datasets:
-            print_error("No datasets found in channel.")
-            return
-
-        # Select mode
-        if not mode:
-            mode = await _select_apply_config_mode_interactive(datasets, selected_channel)
-            if not mode:
-                return
-
-        if mode == "all":
-            # Apply config to all datasets
-            success_count = 0
-            failed_datasets: list[str] = []
-
-            for ds in datasets:
-                urn = _get_urn_display(ds)
-                print_info(f"Applying config for: {urn}")
-                try:
-                    with spinner_status(f"Applying config to {urn}..."):
-                        await client.apply_config_to_channel_dataset(
-                            channel_id=selected_channel.id,
-                            dataset_id=ds.id,
-                        )
-                    success_count += 1
-                except Exception as e:
-                    print_error(f"Failed to apply config to {urn}: {e}")
-                    failed_datasets.append(urn)
-
-            # Report results
-            total = len(datasets)
-            if failed_datasets:
-                print_error(
-                    f"Config applied to {success_count}/{total} datasets. "
-                    f"Failed: {', '.join(failed_datasets)}"
-                )
-            else:
-                print_success(f"Config applied to all {total} datasets.")
-        else:
-            # Apply to single dataset
-            if dataset_urn:
-                selected_ds = next(
-                    (ds for ds in datasets if _get_urn_display(ds) == dataset_urn),
-                    None,
-                )
-                if not selected_ds:
-                    print_error(f"Dataset not found: {dataset_urn}")
-                    return
-            else:
-                selected_ds_urn = await _select_dataset_interactive(datasets)
-                if not selected_ds_urn:
-                    return
-                selected_ds = next(
-                    (ds for ds in datasets if _get_urn_display(ds) == selected_ds_urn),
-                    None,
-                )
-                if not selected_ds:
-                    return
-
-            print_info(f"Applying config for dataset: {_get_urn_display(selected_ds)}")
-
-            with spinner_status("Applying dataset config..."):
-                version = await client.apply_config_to_channel_dataset(
-                    channel_id=selected_channel.id,
-                    dataset_id=selected_ds.id,
-                )
-
-            print_success(f"Config applied! New version: {version.version}")
 
 
 list_command = Command(
@@ -794,29 +654,6 @@ reindex_command = Command(
 )
 
 
-apply_config_command = Command(
-    name="apply-config",
-    description="Apply current dataset config to channel without re-indexing",
-    handler=apply_config_handler,
-    args=[
-        CommandArg(
-            name="channel",
-            short_name="c",
-            description="Channel deployment ID",
-        ),
-        CommandArg(
-            name="mode",
-            description="Apply mode (all/dataset)",
-            choices=["all", "dataset"],
-        ),
-        CommandArg(
-            name="dataset-urn",
-            description="Dataset URN (required when mode=dataset)",
-        ),
-    ],
-)
-
-
 # Command group
 channel_group = CommandGroup(
     name="channel",
@@ -827,4 +664,3 @@ channel_group.add_command(import_command)
 channel_group.add_command(status_command)
 channel_group.add_command(deduplicate_command)
 channel_group.add_command(reindex_command)
-channel_group.add_command(apply_config_command)

--- a/statgpt/cli/commands/content.py
+++ b/statgpt/cli/commands/content.py
@@ -1,6 +1,7 @@
 """Content management commands for StatGPT CLI."""
 
 import os
+from collections import defaultdict
 from typing import Any
 
 from rich.panel import Panel
@@ -24,6 +25,8 @@ from statgpt.common.data.sdmx.common import UrnReference
 from statgpt.common.schemas import (
     Channel,
     ChannelDatasetExpanded,
+    ChannelDatasetUpdateResult,
+    ChannelDatasetUpdateStatus,
     DataSet,
     DataSource,
     GlossaryTerm,
@@ -474,6 +477,34 @@ async def _process_data_sources(
     return data_sources
 
 
+def _display_channel_results(results: list[ChannelDatasetUpdateResult]) -> None:
+    """Display results of config propagation to channels."""
+    if not results:
+        return
+
+    auto_updated = [r for r in results if r.status == ChannelDatasetUpdateStatus.AUTO_UPDATED]
+    needs_reindex = [r for r in results if r.status == ChannelDatasetUpdateStatus.NEEDS_REINDEX]
+    no_version = [r for r in results if r.status == ChannelDatasetUpdateStatus.NO_VERSION]
+    in_progress = [
+        r for r in results if r.status == ChannelDatasetUpdateStatus.INDEXING_IN_PROGRESS
+    ]
+
+    if auto_updated:
+        channels_str = ", ".join(
+            f"{r.channel_deployment_id} (new version: {r.new_version_number})" for r in auto_updated
+        )
+        print_success(f"    Auto-updated in: {channels_str}")
+    if needs_reindex:
+        channels_str = ", ".join(r.channel_deployment_id for r in needs_reindex)
+        print_warning(f"    Needs reindex in: {channels_str}")
+    if no_version:
+        channels_str = ", ".join(r.channel_deployment_id for r in no_version)
+        print_info(f"    No indexed version in: {channels_str}")
+    if in_progress:
+        channels_str = ", ".join(r.channel_deployment_id for r in in_progress)
+        print_info(f"    Indexing in progress in: {channels_str}")
+
+
 async def _process_datasets(
     client: AdminClient,
     client_id: str,
@@ -500,6 +531,7 @@ async def _process_datasets(
         datasets_cfg.extend(cfg.get("dataSets", []))
 
     channel_datasets: dict[int, list[ChannelDatasetExpanded]] = {}
+    datasets_needing_reindex: dict[str, list[str]] = defaultdict(list)
 
     for ds_cfg in datasets_cfg:
         urn_data = ds_cfg.get("details", {}).get("urn")
@@ -517,8 +549,17 @@ async def _process_datasets(
         dataset_id_str = ds_cfg.get("id_")
 
         if dataset_id_str and dataset_id_str in existing_datasets:
-            dataset = await client.update_dataset(existing_datasets[dataset_id_str].id, ds_cfg)
+            response = await client.update_dataset(existing_datasets[dataset_id_str].id, ds_cfg)
+            dataset = response.dataset
             print_info(f"  Updated dataset: {urn}")
+
+            # Display channel datasets update results
+            _display_channel_results(response.channel_results)
+
+            # Collect datasets needing reindex for summary
+            for r in response.channel_results:
+                if r.status == ChannelDatasetUpdateStatus.NEEDS_REINDEX:
+                    datasets_needing_reindex[r.channel_deployment_id].append(urn)
         else:
             dataset = await client.create_dataset(ds_cfg)
             print_info(f"  Created dataset: {urn}")
@@ -537,6 +578,13 @@ async def _process_datasets(
             if not any(cd.dataset_id == dataset.id for cd in channel_datasets[ch_id]):
                 await client.add_dataset_to_channel(ch_id, dataset.id)
                 print_info(f"    Linked to channel: {ch_name}")
+
+    if datasets_needing_reindex:
+        print_info("-" * 50)
+        print_warning("Datasets requiring reindexing:")
+        for ch_deployment_id, ds_urns in datasets_needing_reindex.items():
+            ds_list = ", ".join(ds_urns)
+            print_warning(f"    {ch_deployment_id}: {ds_list}")
 
 
 init_command = Command(

--- a/statgpt/cli/commands/content.py
+++ b/statgpt/cli/commands/content.py
@@ -491,17 +491,18 @@ def _display_channel_results(results: list[ChannelDatasetUpdateResult]) -> None:
 
     if auto_updated:
         channels_str = ", ".join(
-            f"{r.channel_deployment_id} (new version: {r.new_version_number})" for r in auto_updated
+            f"{r.channel.deployment_id} (new version: {r.new_version.version if r.new_version else 'N/A'})"
+            for r in auto_updated
         )
         print_success(f"    Auto-updated in: {channels_str}")
     if needs_reindex:
-        channels_str = ", ".join(r.channel_deployment_id for r in needs_reindex)
+        channels_str = ", ".join(r.channel.deployment_id for r in needs_reindex)
         print_warning(f"    Needs reindex in: {channels_str}")
     if no_version:
-        channels_str = ", ".join(r.channel_deployment_id for r in no_version)
+        channels_str = ", ".join(r.channel.deployment_id for r in no_version)
         print_info(f"    No indexed version in: {channels_str}")
     if in_progress:
-        channels_str = ", ".join(r.channel_deployment_id for r in in_progress)
+        channels_str = ", ".join(r.channel.deployment_id for r in in_progress)
         print_info(f"    Indexing in progress in: {channels_str}")
 
 
@@ -559,7 +560,7 @@ async def _process_datasets(
             # Collect datasets needing reindex for summary
             for r in response.channel_results:
                 if r.status == ChannelDatasetUpdateStatus.NEEDS_REINDEX:
-                    datasets_needing_reindex[r.channel_deployment_id].append(urn or "None")
+                    datasets_needing_reindex[r.channel.deployment_id].append(urn or "None")
         else:
             dataset = await client.create_dataset(ds_cfg)
             print_info(f"  Created dataset: {urn}")

--- a/statgpt/cli/commands/content.py
+++ b/statgpt/cli/commands/content.py
@@ -559,7 +559,7 @@ async def _process_datasets(
             # Collect datasets needing reindex for summary
             for r in response.channel_results:
                 if r.status == ChannelDatasetUpdateStatus.NEEDS_REINDEX:
-                    datasets_needing_reindex[r.channel_deployment_id].append(urn)
+                    datasets_needing_reindex[r.channel_deployment_id].append(urn or "None")
         else:
             dataset = await client.create_dataset(ds_cfg)
             print_info(f"  Created dataset: {urn}")

--- a/statgpt/cli/shared/admin_client.py
+++ b/statgpt/cli/shared/admin_client.py
@@ -13,6 +13,7 @@ from statgpt.common.schemas import (
     Channel,
     ChannelDatasetBase,
     ChannelDatasetExpanded,
+    ChannelDatasetVersion,
     ChannelIndexStatus,
     DataSet,
     DataSource,
@@ -220,6 +221,18 @@ class AdminClient:
         """Deduplicate channel embeddings."""
         resp = await self._client.post(self._url(f"/channels/{channel_id}/datasets/deduplicate"))
         resp.raise_for_status()
+
+    async def apply_config_to_channel_dataset(
+        self,
+        channel_id: int,
+        dataset_id: int,
+    ) -> ChannelDatasetVersion:
+        """Apply current dataset config to channel without re-indexing."""
+        resp = await self._client.post(
+            self._url(f"/channels/{channel_id}/datasets/{dataset_id}/versions/apply-config")
+        )
+        resp.raise_for_status()
+        return ChannelDatasetVersion.model_validate(resp.json())
 
     async def create_channel(self, channel_data: dict[str, Any]) -> Channel:
         """Create a new channel."""

--- a/statgpt/cli/shared/admin_client.py
+++ b/statgpt/cli/shared/admin_client.py
@@ -13,9 +13,9 @@ from statgpt.common.schemas import (
     Channel,
     ChannelDatasetBase,
     ChannelDatasetExpanded,
-    ChannelDatasetVersion,
     ChannelIndexStatus,
     DataSet,
+    DataSetUpdateResponse,
     DataSource,
     DataSourceType,
     GlossaryTerm,
@@ -222,18 +222,6 @@ class AdminClient:
         resp = await self._client.post(self._url(f"/channels/{channel_id}/datasets/deduplicate"))
         resp.raise_for_status()
 
-    async def apply_config_to_channel_dataset(
-        self,
-        channel_id: int,
-        dataset_id: int,
-    ) -> ChannelDatasetVersion:
-        """Apply current dataset config to channel without re-indexing."""
-        resp = await self._client.post(
-            self._url(f"/channels/{channel_id}/datasets/{dataset_id}/versions/apply-config")
-        )
-        resp.raise_for_status()
-        return ChannelDatasetVersion.model_validate(resp.json())
-
     async def create_channel(self, channel_data: dict[str, Any]) -> Channel:
         """Create a new channel."""
         resp = await self._client.post(self._url("/channels"), json=channel_data)
@@ -268,11 +256,17 @@ class AdminClient:
         resp.raise_for_status()
         return DataSet.model_validate(resp.json())
 
-    async def update_dataset(self, dataset_id: int, dataset_data: dict[str, Any]) -> DataSet:
-        """Update an existing dataset."""
+    async def update_dataset(
+        self, dataset_id: int, dataset_data: dict[str, Any]
+    ) -> DataSetUpdateResponse:
+        """Update an existing dataset.
+
+        Returns the updated dataset along with the results of propagating config
+        changes to all channel datasets that reference this dataset.
+        """
         resp = await self._client.post(self._url(f"/datasets/{dataset_id}"), json=dataset_data)
         resp.raise_for_status()
-        return DataSet.model_validate(resp.json())
+        return DataSetUpdateResponse.model_validate(resp.json())
 
     async def add_dataset_to_channel(self, channel_id: int, dataset_id: int) -> ChannelDatasetBase:
         """Add a dataset to a channel."""

--- a/statgpt/common/config/versions.py
+++ b/statgpt/common/config/versions.py
@@ -7,4 +7,4 @@ class Versions:
     # Please update this version when you create a new alembic revision.
     # Needed because alembic folder exist only in the statgpt.admin package.
     # (statgpt Dockerfile doesn't copy statgpt.admin package to the container)
-    ALEMBIC_TARGET_VERSION = '77c67d91641c'
+    ALEMBIC_TARGET_VERSION = 'a1b2c3d4e5f6'

--- a/statgpt/common/config/versions.py
+++ b/statgpt/common/config/versions.py
@@ -7,4 +7,4 @@ class Versions:
     # Please update this version when you create a new alembic revision.
     # Needed because alembic folder exist only in the statgpt.admin package.
     # (statgpt Dockerfile doesn't copy statgpt.admin package to the container)
-    ALEMBIC_TARGET_VERSION = 'a1b2c3d4e5f6'
+    ALEMBIC_TARGET_VERSION = 'c7f068b2d47d'

--- a/statgpt/common/config/versions.py
+++ b/statgpt/common/config/versions.py
@@ -7,4 +7,4 @@ class Versions:
     # Please update this version when you create a new alembic revision.
     # Needed because alembic folder exist only in the statgpt.admin package.
     # (statgpt Dockerfile doesn't copy statgpt.admin package to the container)
-    ALEMBIC_TARGET_VERSION = '109220bfa072'
+    ALEMBIC_TARGET_VERSION = '77c67d91641c'

--- a/statgpt/common/data/base/__init__.py
+++ b/statgpt/common/data/base/__init__.py
@@ -35,5 +35,6 @@ from .enums import (
     QueryOperator,
     SpecialNonIndicatorDimensions,
 )
+from .indexing import IndexingField, IndexingHashMixin
 from .indicator import BaseIndicator
 from .query import DataSetAvailabilityQuery, DataSetQuery, DimensionQuery, Query  # , IndicatorQuery

--- a/statgpt/common/data/base/__init__.py
+++ b/statgpt/common/data/base/__init__.py
@@ -1,5 +1,5 @@
 from .attribute import Attribute, CategoricalAttribute, StringAttribute
-from .base import BaseEntity
+from .base import BaseEntity, BaseModel
 from .category import Category, DimensionCategory, VirtualDimensionCategory
 from .config import (
     BaseDimensionConfig,

--- a/statgpt/common/data/base/base.py
+++ b/statgpt/common/data/base/base.py
@@ -2,7 +2,20 @@ import re
 import typing as t
 from abc import ABC, abstractmethod
 
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ConfigDict, alias_generators
+
 from .enums import EntityType
+
+
+class BaseModel(PydanticBaseModel):
+    """Base Pydantic model with camelCase serialization for config files."""
+
+    model_config = ConfigDict(
+        alias_generator=alias_generators.to_camel,
+        populate_by_name=True,
+        extra='allow',
+    )
 
 
 class BaseEntity(ABC):

--- a/statgpt/common/data/base/config.py
+++ b/statgpt/common/data/base/config.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC
-from collections.abc import Generator, Iterable
-from typing import Annotated, Any, Literal, NamedTuple, Self
+from collections.abc import Generator
+from typing import Annotated, Any, Literal, Self
 
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import (
@@ -16,9 +16,9 @@ from pydantic import (
 )
 
 from statgpt.common.config.utils import replace_env
-from statgpt.common.utils import crc32_hash, crc32_hash_incremental
 
 from .enums import DimensionType, SpecialNonIndicatorDimensions
+from .indexing import IndexingField, IndexingHashMixin
 from .query import Query
 
 _log = logging.getLogger(__name__)
@@ -28,28 +28,18 @@ class BaseModel(PydanticBaseModel):
     model_config = ConfigDict(alias_generator=alias_generators.to_camel, populate_by_name=True)
 
 
-class ConfigHashes(NamedTuple):
-    indicator_hash: str
-    non_indicator_hash: str
-    special_hash: str
-
-
 class VirtualDimensionValue(BaseModel):
-    id: str
-    name: str
+    id: Annotated[str, IndexingField()]
+    name: Annotated[str, IndexingField()]
     description: str | None
 
 
-class VirtualDimensionConfig(BaseModel):
-    name: str = Field(description="The name of the virtual dimension")
+class VirtualDimensionConfig(BaseModel, IndexingHashMixin):
+    name: Annotated[str, IndexingField()] = Field(description="The name of the virtual dimension")
     description: str | None = Field(description="The description of the virtual dimension")
-    value: VirtualDimensionValue = Field(description="The value of the virtual dimension")
-
-    @property
-    def indexing_hash(self) -> str:
-        """A calculated hash based on the fields used for indexing."""
-        data = (self.name, self.value.id, self.value.name)
-        return str(crc32_hash(str(data)))
+    value: Annotated[VirtualDimensionValue, IndexingField()] = Field(
+        description="The value of the virtual dimension"
+    )
 
 
 class DatasetCitation(BaseModel):
@@ -65,39 +55,34 @@ class DatasetCitation(BaseModel):
 
 
 class IndexerIndicatorAnnotationConfig(BaseModel):
-    description: str = Field(description="annotation name to get indicator description", default="")
+    description: Annotated[str, IndexingField()] = Field(
+        description="annotation name to get indicator description", default=""
+    )
 
 
 class IndexerIndicatorConfig(BaseModel):
-    unpack: bool = Field(default=False)
-    use_code_list_description: bool = Field(default=False)
-    super_primary: bool = Field(default=False)
+    unpack: Annotated[bool, IndexingField()] = Field(default=False)
+    use_code_list_description: Annotated[bool, IndexingField()] = Field(default=False)
+    super_primary: Annotated[bool, IndexingField()] = Field(default=False)
 
-    annotations: IndexerIndicatorAnnotationConfig | None = Field(default=None)
+    annotations: Annotated[IndexerIndicatorAnnotationConfig | None, IndexingField()] = Field(
+        default=None
+    )
 
 
-class IndexerConfig(BaseModel):
-    description: str = Field(description="dataset_description", default="")
+class IndexerConfig(BaseModel, IndexingHashMixin):
+    description: Annotated[str, IndexingField()] = Field(
+        description="dataset_description", default=""
+    )
 
-    indicator: IndexerIndicatorConfig = Field(
+    indicator: Annotated[IndexerIndicatorConfig, IndexingField()] = Field(
         description="indicator_config", default_factory=IndexerIndicatorConfig
     )
 
-    @property
-    def indexing_hash(self) -> str:
-        """A calculated hash based on the fields used for indexing."""
-        data = self.model_dump(
-            include={
-                "description",
-                "indicator",
-            }
-        )
-        return str(crc32_hash(str(data)))
 
-
-class BaseDimensionConfig(BaseModel):
-    dimension_type: str | None
-    alias: str | None = Field(default=None)
+class BaseDimensionConfig(BaseModel, IndexingHashMixin):
+    dimension_type: Annotated[str | None, IndexingField()]
+    alias: Annotated[str | None, IndexingField()] = Field(default=None)
     is_required: bool = Field(
         default=False,
         description=(
@@ -105,7 +90,7 @@ class BaseDimensionConfig(BaseModel):
             "Used to filter out queries without these dimensions. See the detailed logic in the code"
         ),
     )
-    virtual: VirtualDimensionConfig | None = Field(
+    virtual: Annotated[VirtualDimensionConfig | None, IndexingField()] = Field(
         default=None,
         description=(
             "If set, defines a virtual dimension to be added to the dataset. "
@@ -128,24 +113,14 @@ class BaseDimensionConfig(BaseModel):
             raise ValueError("dimension_type is not set")
         return DimensionType(self.dimension_type)
 
-    @property
-    def indexing_hash(self) -> str:
-        """A calculated hash based on the fields used for indexing."""
-        data = (
-            self.dimension_type,
-            self.alias,
-            None if self.virtual is None else self.virtual.indexing_hash,
-        )
-        return str(crc32_hash(str(data)))
-
 
 class IndicatorDimensionConfig(BaseDimensionConfig):
-    dimension_type: Literal["INDICATOR"] = Field(default="INDICATOR")
+    dimension_type: Annotated[Literal["INDICATOR"], IndexingField()] = "INDICATOR"
 
 
 class SpecialDimensionConfig(BaseDimensionConfig):
-    dimension_type: Literal["SPECIAL"] = Field(default="SPECIAL")
-    processor_id: str = Field(
+    dimension_type: Annotated[Literal["SPECIAL"], IndexingField()] = "SPECIAL"
+    processor_id: Annotated[str, IndexingField()] = Field(
         description=(
             "The ID of the processor to handle this special dimension. "
             "NOTE: processors are defined in the channel configuration."
@@ -154,13 +129,13 @@ class SpecialDimensionConfig(BaseDimensionConfig):
 
 
 class NonIndicatorDimensionConfig(BaseDimensionConfig):
-    dimension_type: Literal["NON_INDICATOR"] = Field(default="NON_INDICATOR")
-    subtype: SpecialNonIndicatorDimensions | None = Field(default=None)
+    dimension_type: Annotated[Literal["NON_INDICATOR"], IndexingField()] = "NON_INDICATOR"
+    subtype: Annotated[SpecialNonIndicatorDimensions | None, IndexingField()] = Field(default=None)
     # named_entity: str  # TODO
 
 
 class TimePeriodDimensionConfig(BaseDimensionConfig):
-    dimension_type: Literal["TIME_PERIOD"] = Field(default="TIME_PERIOD")
+    dimension_type: Annotated[Literal["TIME_PERIOD"], IndexingField()] = "TIME_PERIOD"
 
 
 DIMENSION_CONFIG_TYPES = Annotated[
@@ -177,7 +152,7 @@ DIMENSION_CONFIG_TYPES = Annotated[
 class BaseDataSetConfig(BaseModel):
     is_official: bool = Field(default=False)
     citation: DatasetCitation | None = Field(default=None)
-    indexer: IndexerConfig | None = Field(default=None)
+    indexer: Annotated[IndexerConfig | None, IndexingField()] = Field(default=None)
     pinned_columns: list[str] = Field(
         description="Column names and order to pin in the data in grid", default_factory=list
     )
@@ -211,35 +186,12 @@ class DataSetConfigTemplate(BaseDataSetConfig):
         }
 
 
-class DataSetConfig(BaseDataSetConfig, ABC):
+class DataSetConfig(BaseDataSetConfig, ABC, IndexingHashMixin):
 
-    dimensions: dict[str, DIMENSION_CONFIG_TYPES] = Field(
+    dimensions: Annotated[dict[str, DIMENSION_CONFIG_TYPES], IndexingField()] = Field(
         description="The configuration of the each dimension in the dataset by its ID",
         default_factory=dict,
     )
-
-    @property
-    def indexing_hashes(self) -> ConfigHashes:
-        """A calculated hash based on the fields used for indexing."""
-
-        def get_dimensions_hash(dimensions: Iterable[tuple[str, BaseDimensionConfig]]) -> int:
-            # Sort dimensions by their IDs to ensure consistent ordering
-            sorted_dims = sorted(dimensions, key=lambda item: item[0])
-            return crc32_hash_incremental(
-                (dim_id + dim.indexing_hash) for dim_id, dim in sorted_dims
-            )
-
-        indicator_data = (
-            None if self.indexer is None else self.indexer.indexing_hash,
-            get_dimensions_hash(
-                (i, d) for i, d in self.dimensions.items() if d.type is DimensionType.INDICATOR
-            ),
-        )
-        return ConfigHashes(
-            indicator_hash=str(crc32_hash(str(indicator_data))),
-            non_indicator_hash=str(get_dimensions_hash(self.non_indicator_dimensions)),
-            special_hash=str(get_dimensions_hash(self.special_dimensions)),
-        )
 
     def get_dimension_aliases(self) -> dict[str, str]:
         return {

--- a/statgpt/common/data/base/config.py
+++ b/statgpt/common/data/base/config.py
@@ -3,29 +3,23 @@ from abc import ABC
 from collections.abc import Generator
 from typing import Annotated, Any, Literal, Self
 
-from pydantic import BaseModel as PydanticBaseModel
 from pydantic import (
-    ConfigDict,
     Field,
     SerializationInfo,
     SkipValidation,
     StrictStr,
-    alias_generators,
     field_serializer,
     model_validator,
 )
 
 from statgpt.common.config.utils import replace_env
 
+from .base import BaseModel
 from .enums import DimensionType, SpecialNonIndicatorDimensions
 from .indexing import IndexingField, IndexingHashMixin
 from .query import Query
 
 _log = logging.getLogger(__name__)
-
-
-class BaseModel(PydanticBaseModel):
-    model_config = ConfigDict(alias_generator=alias_generators.to_camel, populate_by_name=True)
 
 
 class VirtualDimensionValue(BaseModel):

--- a/statgpt/common/data/base/dataset.py
+++ b/statgpt/common/data/base/dataset.py
@@ -199,6 +199,20 @@ class DataSet(BaseEntity, Generic[DataSetConfigType, DataSourceHandlerType], ABC
     def config(self) -> DataSetConfigType:
         return self._config
 
+    def get_resolved_config(self) -> dict | None:
+        """
+        Return the resolved dataset configuration with concrete values.
+
+        For SDMX, this extracts the actual URN from the loaded dataflow
+        (resolving dynamic values like "latest" to concrete versions).
+
+        For other providers, this may resolve other dynamic references.
+
+        Returns:
+            Resolved config dict, or None if no resolution needed/possible.
+        """
+        return None
+
     @property
     @abstractmethod
     def status(self) -> Status:

--- a/statgpt/common/data/base/datasource.py
+++ b/statgpt/common/data/base/datasource.py
@@ -3,11 +3,11 @@ import uuid
 from abc import ABC, abstractmethod
 
 from langchain_core.documents import Document
-from pydantic import BaseModel, ConfigDict, Field, SkipValidation, alias_generators
+from pydantic import Field, SkipValidation
 
 from statgpt.common.auth.auth_context import AuthContext
 
-from .base import BaseEntity, EntityType
+from .base import BaseEntity, BaseModel, EntityType
 from .category import DimensionCategory
 from .config import DataSetConfigTemplate
 from .dataset import DataSet, DataSetConfig
@@ -31,7 +31,7 @@ class DataSetHierarchyConfig(BaseModel):
 
 
 class DataSourceConfig(BaseModel, ABC):
-    model_config = ConfigDict(alias_generator=alias_generators.to_camel, populate_by_name=True)
+    pass
 
 
 DataSourceConfigType = t.TypeVar("DataSourceConfigType", bound=DataSourceConfig)

--- a/statgpt/common/data/base/datasource.py
+++ b/statgpt/common/data/base/datasource.py
@@ -130,3 +130,15 @@ class DataSourceHandler(
 
     async def get_dataset_hierarchy(self, auth_context: AuthContext) -> DatasetHierarchy | None:
         return None
+
+    @abstractmethod
+    def merge_config_with_resolved(
+        self,
+        current_config: dict,
+        resolved_config: dict,
+    ) -> dict:
+        """Merge current config with resolved config from indexing time.
+
+        Takes current_config and merges with resolved_config to preserve
+        any dynamically resolved values (implementation-specific).
+        """

--- a/statgpt/common/data/base/indexing.py
+++ b/statgpt/common/data/base/indexing.py
@@ -1,11 +1,13 @@
 import json
 from collections.abc import Generator
-from typing import Any
+from typing import Any, Self, TypeVar
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 
 from statgpt.common.utils import crc32_hash
+
+_T = TypeVar("_T", bound=BaseModel)
 
 
 class IndexingField:
@@ -114,7 +116,7 @@ def compute_indexing_hash(model: BaseModel) -> str:
 
 
 class IndexingHashMixin:
-    """Mixin that provides indexing_hash property for Pydantic models.
+    """Mixin that provides indexing hash and config merging for Pydantic models.
 
     Classes using this mixin should mark fields with IndexingField() in Annotated.
     The mixin recursively collects all marked fields and computes a unified hash.
@@ -134,3 +136,62 @@ class IndexingHashMixin:
         if not isinstance(self, BaseModel):
             raise TypeError("IndexingHashMixin must be used with Pydantic BaseModel")
         return compute_indexing_hash(self)
+
+    def with_non_indexing_fields_from(self, source: Self) -> Self:
+        """Return a new instance with non-indexing fields taken from source.
+
+        Creates a copy of this model where:
+        - IndexingField-marked fields: preserved from self
+        - Non-marked fields: taken from source
+        - Nested structures: recursively merged
+
+        Args:
+            source: Model instance to take non-indexing field values from
+
+        Returns:
+            New model instance with merged fields
+        """
+        if not isinstance(self, BaseModel):
+            raise TypeError("IndexingHashMixin must be used with Pydantic BaseModel")
+        return _merge_models(resolved=self, current=source)  # type: ignore[return-value]
+
+
+def _merge_models(*, resolved: _T, current: _T) -> _T:
+    """Merge two model instances based on IndexingField markers.
+
+    - IndexingField-marked fields: taken from resolved
+    - Non-marked fields: taken from current
+    - Nested BaseModel fields: recursively merged
+    - dict[str, BaseModel] fields: merged per-key using resolved keys
+    """
+    model_class = type(resolved)
+    updates: dict[str, Any] = {}
+
+    for field_name, field_info in model_class.model_fields.items():
+        current_val = getattr(current, field_name)
+        resolved_val = getattr(resolved, field_name)
+
+        if _has_indexing_marker(field_info):
+            if resolved_val is None:
+                updates[field_name] = None
+            elif isinstance(resolved_val, BaseModel):
+                updates[field_name] = _merge_models(resolved=resolved_val, current=current_val)
+            elif isinstance(resolved_val, dict):
+                # dict[str, BaseModel] like dimensions - merge per key
+                merged_dict: dict[str, Any] = {}
+                for k, v in resolved_val.items():
+                    if isinstance(v, BaseModel):
+                        current_item = current_val.get(k) if current_val else None
+                        if current_item is not None:
+                            merged_dict[k] = _merge_models(resolved=v, current=current_item)
+                        else:
+                            merged_dict[k] = v
+                    else:
+                        merged_dict[k] = v
+                updates[field_name] = merged_dict
+            else:
+                updates[field_name] = resolved_val
+        else:
+            updates[field_name] = current_val
+
+    return model_class.model_construct(**updates)

--- a/statgpt/common/data/base/indexing.py
+++ b/statgpt/common/data/base/indexing.py
@@ -1,0 +1,136 @@
+import json
+from collections.abc import Generator
+from typing import Any
+
+from pydantic import BaseModel
+from pydantic.fields import FieldInfo
+
+from statgpt.common.utils import crc32_hash
+
+
+class IndexingField:
+    """Marker class to indicate a field should be included in indexing hash computation.
+
+    Use with Annotated to mark fields:
+    ```
+        name: Annotated[str, IndexingField()] = Field(...)
+    ```
+
+    Marked fields are recursively collected when computing the indexing hash.
+    For nested `BaseModel` fields, only their marked fields are included.
+
+    IMPORTANT: When a child class redefines a field, it must explicitly include
+    the `IndexingField` marker - markers are NOT inherited through field redefinition:
+    ```
+        class Parent(BaseModel):
+            field: Annotated[str, IndexingField()] = "value"
+
+        class Child(Parent):
+            # WRONG - marker is lost:
+            field: str = "other"
+
+            # CORRECT - marker preserved:
+            field: Annotated[str, IndexingField()] = "other"
+    ```
+    """
+
+    def __repr__(self) -> str:
+        return "IndexingField()"
+
+
+def _has_indexing_marker(field_info: FieldInfo) -> bool:
+    """Check if a field has the IndexingField marker in its metadata."""
+    return any(isinstance(meta, IndexingField) for meta in field_info.metadata)
+
+
+def _collect_indexing_fields(model: BaseModel) -> Generator[tuple[str, Any], None, None]:
+    """Recursively collect all fields marked for indexing from a model.
+
+    Yields tuples of `(field_path, value)` for deterministic serialization.
+
+    For nested `BaseModel` fields that are marked:
+    - Recursively collect their marked fields (granular control)
+    - If nested model has no marked fields, include full model dump
+
+    For `dict[str, BaseModel]` fields (like dimensions):
+    - Sort by key for determinism
+    - Recursively collect marked fields from each value
+    """
+    for field_name, field_info in type(model).model_fields.items():
+        if not _has_indexing_marker(field_info):
+            continue
+
+        value = getattr(model, field_name)
+
+        if value is None:
+            yield field_name, None
+        elif isinstance(value, BaseModel):
+            # Recursively collect marked fields from nested model
+            nested_fields = list(_collect_indexing_fields(value))
+            for nested_path, nested_value in nested_fields:
+                yield f"{field_name}.{nested_path}", nested_value
+        elif isinstance(value, dict):
+            # Handle dict[str, BaseModel] like dimensions
+            dict_items = {}
+            for k, v in sorted(value.items()):  # Sort keys for determinism
+                if isinstance(v, BaseModel):
+                    nested = dict(_collect_indexing_fields(v))
+                    dict_items[k] = nested if nested else v.model_dump(mode="json")
+                else:
+                    dict_items[k] = v
+            yield field_name, dict_items
+        elif isinstance(value, (list, tuple)):
+            # Handle collections of models
+            items = []
+            for item in value:
+                if isinstance(item, BaseModel):
+                    nested = dict(_collect_indexing_fields(item))
+                    items.append(nested if nested else item.model_dump(mode="json"))
+                else:
+                    items.append(item)
+            yield field_name, items
+        else:
+            yield field_name, value
+
+
+def compute_indexing_hash(model: BaseModel) -> str:
+    """Compute a deterministic CRC32 hash from all IndexingField-marked fields.
+
+    The hash is computed by:
+    1. Collecting all marked fields recursively
+    2. Serializing to JSON with sorted keys for determinism
+    3. Computing CRC32 hash of the JSON string
+
+    Args:
+        model: A Pydantic BaseModel instance with IndexingField markers
+
+    Returns:
+        String representation of the CRC32 hash
+    """
+    fields = dict(_collect_indexing_fields(model))
+    # sort_keys=True ensures deterministic ordering at all nesting levels
+    json_str = json.dumps(fields, sort_keys=True)
+    return str(crc32_hash(json_str))
+
+
+class IndexingHashMixin:
+    """Mixin that provides indexing_hash property for Pydantic models.
+
+    Classes using this mixin should mark fields with IndexingField() in Annotated.
+    The mixin recursively collects all marked fields and computes a unified hash.
+
+    Example:
+        class MyConfig(BaseModel, IndexingHashMixin):
+            name: Annotated[str, IndexingField()] = Field(...)
+            description: str = Field(...)  # Not included in hash
+
+        config = MyConfig(name="test", description="ignored")
+        print(config.indexing_hash)  # Computed from 'name' only
+    """
+
+    @property
+    def indexing_hash(self) -> str:
+        """Compute hash from all fields marked with IndexingField."""
+        if not isinstance(self, BaseModel):
+            raise TypeError("IndexingHashMixin must be used with Pydantic BaseModel")
+        return compute_indexing_hash(self)

--- a/statgpt/common/data/sdmx/common/config.py
+++ b/statgpt/common/data/sdmx/common/config.py
@@ -1,10 +1,11 @@
 import logging
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from statgpt.common.config import utils as config_utils
 from statgpt.common.data.base import (
+    BaseModel,
     DataSetConfig,
     DataSetConfigTemplate,
     DataSetHierarchyConfig,

--- a/statgpt/common/data/sdmx/common/config.py
+++ b/statgpt/common/data/sdmx/common/config.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -9,6 +9,7 @@ from statgpt.common.data.base import (
     DataSetConfigTemplate,
     DataSetHierarchyConfig,
     DataSourceConfig,
+    IndexingField,
 )
 
 _log = logging.getLogger(__name__)
@@ -128,9 +129,9 @@ class CategorySchemaDataSetHierarchyConfig(BaseModel):
 class UrnReference(BaseModel):
     """This class represents a URN reference for SDMX datasets and allows dynamic values."""
 
-    agency_id: str
-    resource_id: str
-    version: str = Field(default='latest')
+    agency_id: Annotated[str, IndexingField()]
+    resource_id: Annotated[str, IndexingField()]
+    version: Annotated[str, IndexingField()] = Field(default='latest')
 
     def short_urn(self) -> str:
         """Return a short URN representation."""
@@ -180,7 +181,7 @@ class SdmxDataSetConfigMixin:
     use_title_from_src: bool = Field(
         default=False, description="Whether to use the title obtained from the source"
     )
-    urn: UrnReference = Field(description="The URN of the dataset")
+    urn: Annotated[UrnReference, IndexingField()] = Field(description="The URN of the dataset")
     include_attributes: list[str] | None = Field(
         default=None, description="List of attributes to add to the query results table"
     )

--- a/statgpt/common/data/sdmx/v21/dataset.py
+++ b/statgpt/common/data/sdmx/v21/dataset.py
@@ -46,6 +46,7 @@ from statgpt.common.data.sdmx.common import (
     SdmxCodeListDimension,
     SdmxDataSetConfig,
     SdmxDimension,
+    UrnReference,
 )
 from statgpt.common.schemas.dataset import Status
 from statgpt.common.schemas.enums import DataParsingStatus, DataRequestStatus
@@ -67,6 +68,7 @@ from .query import (
     SdmxQueryReadinessStatus,
     TimeDimensionQuery,
 )
+from .schemas import Urn
 
 if t.TYPE_CHECKING:
     from statgpt.common.data.sdmx.v21.datasource import Sdmx21DataSourceHandler
@@ -445,6 +447,32 @@ class Sdmx21DataSet(
             if self.config.citation.last_updated:
                 return parse(self.config.citation.last_updated)
         return None
+
+    def get_resolved_config(self) -> dict:
+        """
+        Return config with resolved URN from the loaded dataflow.
+
+        Handles dynamic URN values per SDMX standard:
+        - version: "latest", "~" (latest stable), version wildcards
+        - agency_id: "all" wildcard
+        - resource_id: wildcards
+        """
+        actual_urn = Urn.for_artifact(self._artefact)
+
+        if (
+            actual_urn.agency_id == self._config.urn.agency_id
+            and actual_urn.resource_id == self._config.urn.resource_id
+            and actual_urn.version == self._config.urn.version
+        ):
+            return self._config.model_dump(mode='json', by_alias=True)
+
+        resolved_urn = UrnReference(
+            agency_id=actual_urn.agency_id,
+            resource_id=actual_urn.resource_id,
+            version=actual_urn.version,
+        )
+        resolved_config = self._config.model_copy(update={'urn': resolved_urn})
+        return resolved_config.model_dump(mode='json', by_alias=True)
 
     @property
     def status(self) -> Status:

--- a/statgpt/common/data/sdmx/v21/datasource.py
+++ b/statgpt/common/data/sdmx/v21/datasource.py
@@ -392,3 +392,14 @@ class Sdmx21DataSourceHandler(
                 "Failed to create dataset hierarchy. Returning None. See exception details below."
             )
             return None
+
+    def merge_config_with_resolved(
+        self,
+        current_config: dict,
+        resolved_config: dict,
+    ) -> dict:
+        """Uses the new configuration except for the resolved URN."""
+        result = current_config.copy()
+        if 'urn' in resolved_config:
+            result['urn'] = resolved_config['urn']
+        return result

--- a/statgpt/common/data/sdmx/v21/datasource.py
+++ b/statgpt/common/data/sdmx/v21/datasource.py
@@ -398,8 +398,14 @@ class Sdmx21DataSourceHandler(
         current_config: dict,
         resolved_config: dict,
     ) -> dict:
-        """Uses the new configuration except for the resolved URN."""
-        result = current_config.copy()
-        if 'urn' in resolved_config:
-            result['urn'] = resolved_config['urn']
-        return result
+        """Merge current config with resolved config based on IndexingField markers.
+
+        - Fields marked with IndexingField (urn, dimensions indexing fields, indexer):
+          preserved from resolved_config
+        - Fields NOT marked (is_official, citation, pinned_columns, is_required, etc.):
+          taken from current_config
+        """
+        current = SdmxDataSetConfig.model_validate(current_config)
+        resolved = SdmxDataSetConfig.model_validate(resolved_config)
+        merged = resolved.with_non_indexing_fields_from(current)
+        return merged.model_dump(mode="json", by_alias=True)

--- a/statgpt/common/models/models.py
+++ b/statgpt/common/models/models.py
@@ -172,6 +172,9 @@ class ChannelDatasetVersion(DefaultBase):
         type_=String(10), default=None
     )
 
+    # Resolved configuration at indexing time (dynamic URN values resolved to concrete values)
+    resolved_config: Mapped[dict | None] = mapped_column(type_=postgresql.JSONB, default=None)
+
     # relationships
     channel_dataset: Mapped[ChannelDataset] = relationship(back_populates="versions")
     pointer = relationship(

--- a/statgpt/common/models/models.py
+++ b/statgpt/common/models/models.py
@@ -165,14 +165,9 @@ class ChannelDatasetVersion(DefaultBase):
         type_=String(10), default=None
     )
     special_dimensions_hash: Mapped[str | None] = mapped_column(type_=String(10), default=None)
-    # Config hashes:
-    indicators_config_hash: Mapped[str | None] = mapped_column(type_=String(10), default=None)
-    non_indicators_config_hash: Mapped[str | None] = mapped_column(type_=String(10), default=None)
-    special_dimensions_config_hash: Mapped[str | None] = mapped_column(
-        type_=String(10), default=None
-    )
-
-    # Resolved configuration at indexing time (dynamic URN values resolved to concrete values)
+    # Config hash:
+    indexing_config_hash: Mapped[str | None] = mapped_column(type_=String(10), default=None)
+    # Resolved configuration at indexing time (e.g. dynamic URN version resolved to concrete version)
     resolved_config: Mapped[dict | None] = mapped_column(type_=postgresql.JSONB, default=None)
 
     # relationships

--- a/statgpt/common/schemas/__init__.py
+++ b/statgpt/common/schemas/__init__.py
@@ -21,8 +21,16 @@ from .channel_dataset import (
 )
 from .data_query_tool import DataQueryDetails, HybridSearchConfig
 from .data_source import DataSource, DataSourceBase, DataSourceType, DataSourceUpdate
-from .dataset import DataSet, DataSetBase, DataSetDescriptor, DataSetUpdate
+from .dataset import (
+    ChannelDatasetUpdateResult,
+    DataSet,
+    DataSetBase,
+    DataSetDescriptor,
+    DataSetUpdate,
+    DataSetUpdateResponse,
+)
 from .enums import (
+    ChannelDatasetUpdateStatus,
     ChannelIndexStatusScope,
     DecoderOfLatestEnum,
     ExportScope,

--- a/statgpt/common/schemas/__init__.py
+++ b/statgpt/common/schemas/__init__.py
@@ -19,16 +19,10 @@ from .channel_dataset import (
     DataChange,
     StructureChange,
 )
+from .composite import ChannelDatasetUpdateResult, DataSetUpdateResponse
 from .data_query_tool import DataQueryDetails, HybridSearchConfig
 from .data_source import DataSource, DataSourceBase, DataSourceType, DataSourceUpdate
-from .dataset import (
-    ChannelDatasetUpdateResult,
-    DataSet,
-    DataSetBase,
-    DataSetDescriptor,
-    DataSetUpdate,
-    DataSetUpdateResponse,
-)
+from .dataset import DataSet, DataSetBase, DataSetDescriptor, DataSetUpdateRequest
 from .enums import (
     ChannelDatasetUpdateStatus,
     ChannelIndexStatusScope,

--- a/statgpt/common/schemas/channel_dataset.py
+++ b/statgpt/common/schemas/channel_dataset.py
@@ -36,6 +36,10 @@ class ChannelDatasetVersion(DbDefaultBase):
     indicator_dimensions_hash: str | None
     non_indicator_dimensions_hash: str | None
     special_dimensions_hash: str | None
+    resolved_config: dict | None = Field(
+        default=None,
+        description="Resolved dataset configuration at indexing time (dynamic URN values resolved to concrete values)",
+    )
 
     @property
     def all_hashes_dict(self) -> dict[str, str | None]:

--- a/statgpt/common/schemas/channel_dataset.py
+++ b/statgpt/common/schemas/channel_dataset.py
@@ -28,28 +28,15 @@ class ChannelDatasetVersion(DbDefaultBase):
             " if the rollback version was also a rollback to a previous version."
         )
     )
-    indicators_config_hash: str | None
-    non_indicators_config_hash: str | None
-    special_dimensions_config_hash: str | None
+    indexing_config_hash: str | None
     structure_metadata: dict | None
     structure_hash: str | None
     indicator_dimensions_hash: str | None
     non_indicator_dimensions_hash: str | None
     special_dimensions_hash: str | None
     resolved_config: dict | None = Field(
-        default=None,
         description="Resolved dataset configuration at indexing time (dynamic URN values resolved to concrete values)",
     )
-
-    @property
-    def all_hashes_dict(self) -> dict[str, str | None]:
-        parts = {
-            'structure': self.structure_hash,
-            'indicator_dims': self.indicator_dimensions_hash,
-            'non_indicator_dims': self.non_indicator_dimensions_hash,
-            'special_dims': self.special_dimensions_hash,
-        }
-        return parts
 
     @property
     def version_data_id(self) -> int:

--- a/statgpt/common/schemas/composite.py
+++ b/statgpt/common/schemas/composite.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel, Field
+
+from .channel import Channel
+from .channel_dataset import ChannelDatasetVersion
+from .dataset import DataSet
+from .enums import ChannelDatasetUpdateStatus
+
+
+class ChannelDatasetUpdateResult(BaseModel):
+    channel_dataset_id: int
+    status: ChannelDatasetUpdateStatus
+    channel: Channel
+    new_version: ChannelDatasetVersion | None = Field(default=None)
+
+
+class DataSetUpdateResponse(BaseModel):
+    dataset: DataSet
+    channel_results: list[ChannelDatasetUpdateResult] = Field(default_factory=list)

--- a/statgpt/common/schemas/dataset.py
+++ b/statgpt/common/schemas/dataset.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field, computed_field
 
 from .base import DbDefaultBase
 from .data_source import DataSource
+from .enums import ChannelDatasetUpdateStatus
 
 
 class Status(BaseModel):
@@ -48,3 +49,18 @@ class DataSetUpdate(BaseModel):
     title: str | None = Field(default=None)
     data_source_id: int | None = Field(default=None)
     details: dict[str, Any] | None = Field(default=None, description="Details as a JSON object")
+
+
+class ChannelDatasetUpdateResult(BaseModel):
+    channel_id: int
+    channel_title: str
+    channel_deployment_id: str
+    status: ChannelDatasetUpdateStatus
+    message: str | None = Field(default=None)
+    new_version_id: int | None = Field(default=None)
+    new_version_number: int | None = Field(default=None)
+
+
+class DataSetUpdateResponse(BaseModel):
+    dataset: DataSet
+    channel_results: list[ChannelDatasetUpdateResult] = Field(default_factory=list)

--- a/statgpt/common/schemas/dataset.py
+++ b/statgpt/common/schemas/dataset.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel, Field, computed_field
 
 from .base import DbDefaultBase
 from .data_source import DataSource
-from .enums import ChannelDatasetUpdateStatus
 
 
 class Status(BaseModel):
@@ -19,7 +18,13 @@ class DataSetBase(BaseModel):
     id_: uuid.UUID = Field(default_factory=uuid.uuid4, description="The uuid of the dataset")
     title: str
     data_source_id: int
-    details: dict[str, Any] = Field(default_factory=dict, description="Details as a JSON object")
+    details: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Dataset config as a JSON object. "
+            "The particular schema depends on the specific implementation of the data source."
+        ),
+    )
 
 
 class DataSetDescriptor(BaseModel):
@@ -45,22 +50,13 @@ class DataSet(DataSetBase, DbDefaultBase):
         return self.status.status
 
 
-class DataSetUpdate(BaseModel):
+class DataSetUpdateRequest(BaseModel):
     title: str | None = Field(default=None)
     data_source_id: int | None = Field(default=None)
-    details: dict[str, Any] | None = Field(default=None, description="Details as a JSON object")
-
-
-class ChannelDatasetUpdateResult(BaseModel):
-    channel_id: int
-    channel_title: str
-    channel_deployment_id: str
-    status: ChannelDatasetUpdateStatus
-    message: str | None = Field(default=None)
-    new_version_id: int | None = Field(default=None)
-    new_version_number: int | None = Field(default=None)
-
-
-class DataSetUpdateResponse(BaseModel):
-    dataset: DataSet
-    channel_results: list[ChannelDatasetUpdateResult] = Field(default_factory=list)
+    details: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Dataset config as a JSON object. "
+            "The particular schema depends on the specific implementation of the data source."
+        ),
+    )

--- a/statgpt/common/schemas/enums.py
+++ b/statgpt/common/schemas/enums.py
@@ -123,3 +123,10 @@ class DataParsingStatus(StrEnum):
 class ChannelIndexStatusScope(StrEnum):
     FULL = "full"
     LATEST_COMPLETED_VERSIONS = "latest_completed_versions"
+
+
+class ChannelDatasetUpdateStatus(StrEnum):
+    AUTO_UPDATED = "auto_updated"
+    NEEDS_REINDEX = "needs_reindex"
+    NO_VERSION = "no_version"
+    INDEXING_IN_PROGRESS = "indexing_in_progress"

--- a/statgpt/common/services/data_preloader.py
+++ b/statgpt/common/services/data_preloader.py
@@ -24,20 +24,26 @@ class _DataPreloaderAuthContext(AuthContext):
         return dial_settings.api_key.get_secret_value()
 
 
-async def preload_data(allow_cached_datasets: bool) -> None:
+async def preload_data(allow_cached_datasets: bool, use_resolved_config: bool) -> None:
+    """Preload all datasets into cache.
+
+    Args:
+        allow_cached_datasets: Whether to put dataset classes into cache.
+        use_resolved_config: If True, use resolved_config from completed versions
+            (with concrete URN values). If False, use original dataset config
+            (which may contain dynamic values like 'latest').
+    """
     _log.info('~~~ Data preload ~~~')
 
     _log.info("Loading dataset cache...")
     async with get_session_contex_manager() as session:
         try:
-            datasets = await DataSetService(session).get_datasets_schemas(
-                limit=None,
-                offset=0,
+            count = await DataSetService(session).preload_datasets(
                 auth_context=_DataPreloaderAuthContext(),
                 allow_cached_datasets=allow_cached_datasets,
-                allow_offline=True,
+                use_resolved_config=use_resolved_config,
             )
-            _log.info(f'{len(datasets)} datasets loaded')
+            _log.info(f'{count} datasets preloaded')
         except Exception:
             _log.exception("Error happened while loading dataset cache")
 

--- a/statgpt/common/services/dataset.py
+++ b/statgpt/common/services/dataset.py
@@ -577,3 +577,91 @@ class DataSetService(DbServiceBase):
         channel_datasets = await self.get_channel_dataset_models_with_ds(channel_id)
         channel_dataset_ids = [cd.id for cd in channel_datasets]
         return await self._get_latest_successful_dataset_version(channel_dataset_ids)
+
+    async def _get_resolved_configs_for_all_datasets(self) -> dict[int, dict]:
+        """Get resolved_config for all datasets from their latest completed versions.
+
+        Returns:
+            A dictionary mapping dataset IDs to their resolved_config.
+            Only datasets with a completed version that has resolved_config are included.
+        """
+        # Subquery to rank completed versions by descending order for each dataset
+        ranked_versions = (
+            select(
+                models.ChannelDatasetVersion.resolved_config,
+                models.ChannelDataset.dataset_id,
+                (
+                    func.row_number()
+                    .over(
+                        partition_by=models.ChannelDataset.dataset_id,
+                        order_by=models.ChannelDatasetVersion.version.desc(),
+                    )
+                    .label("rank")
+                ),
+            )
+            .join(models.ChannelDataset)
+            .where(models.ChannelDatasetVersion.preprocessing_status == StatusEnum.COMPLETED)
+            .where(models.ChannelDatasetVersion.resolved_config.is_not(None))
+            .subquery()
+        )
+
+        # Select only the latest version for each dataset
+        query = select(
+            ranked_versions.c.dataset_id,
+            ranked_versions.c.resolved_config,
+        ).where(ranked_versions.c.rank == 1)
+
+        result = await self._session.execute(query)
+        return {row.dataset_id: row.resolved_config for row in result.fetchall()}
+
+    async def preload_datasets(
+        self,
+        auth_context: AuthContext,
+        allow_cached_datasets: bool = False,
+        use_resolved_config: bool = True,
+    ) -> int:
+        """Preload all datasets to warm up the cache.
+
+        Args:
+            auth_context: Authentication context for data access.
+            allow_cached_datasets: Whether to put dataset classes into cache.
+            use_resolved_config: If True, use resolved_config from completed versions
+                (with concrete URN values). If False, use original dataset config
+                (which may contain dynamic values like 'latest').
+
+        Returns:
+            Number of datasets preloaded.
+        """
+        items = await self.get_datasets_models(
+            limit=None, offset=0, expand=True, source_id=None, channel_id=None, ids=None
+        )
+
+        # Get resolved configs when needed
+        resolved_configs: dict[int, dict] = {}
+        if use_resolved_config:
+            resolved_configs = await self._get_resolved_configs_for_all_datasets()
+
+        # Get handlers for each data source
+        sources: set[int] = {i.source_id for i in items}
+        handlers = {source_id: await self._get_handler(source_id) for source_id in sources}
+
+        tasks = []
+        for item in items:
+            handler = handlers[item.source_id]
+            # Use resolved_config if available and enabled, otherwise fall back to original
+            config = resolved_configs.get(item.id) if use_resolved_config else None
+            if config is None:
+                config = item.details
+            tasks.append(
+                handler.get_dataset(
+                    entity_id=item.id_,
+                    title=item.title,
+                    config=config,
+                    auth_context=auth_context,
+                    allow_offline=True,
+                    allow_cached=allow_cached_datasets,
+                )
+            )
+
+        await async_utils.gather_with_concurrency(self._SETTINGS.dataset_concurrency_limit, *tasks)
+        return len(items)

--- a/tests/integration/services/test_data_sources.py
+++ b/tests/integration/services/test_data_sources.py
@@ -86,7 +86,7 @@ async def test_add_data_source_with_defaults(session):
     assert data_source.details.get('locale') == 'en'
 
     assert data_source.details.get('sdmxConfig', {}).get('id') == 'test_id'
-    assert data_source.details.get('sdmxConfig', {}).get('data_content_type') == 'JSON'
+    assert data_source.details.get('sdmxConfig', {}).get('dataContentType') == 'JSON'
     assert data_source.details.get('sdmxConfig', {}).get('name') == 'test_name'
     assert data_source.details.get('sdmxConfig', {}).get('url') == 'https://example.com/sdmx.url'
     assert isinstance(data_source.details.get('sdmxConfig', {}).get('headers'), dict)

--- a/tests/integration/services/test_sdmx_datasets.py
+++ b/tests/integration/services/test_sdmx_datasets.py
@@ -173,7 +173,7 @@ async def test_update_dataset(session, clear_all, sdmx_clint_mock):
 
     response = await dataset_service.update(
         dataset.id,
-        schemas.DataSetUpdate(
+        schemas.DataSetUpdateRequest(
             title='CPI Updated',
             details={
                 'urn': URN_CPI_3_0_1,

--- a/tests/integration/services/test_sdmx_datasets.py
+++ b/tests/integration/services/test_sdmx_datasets.py
@@ -81,8 +81,8 @@ DIMENSIONS = {
 }
 
 
-URN_CPI_4_0_0 = {'agency_id': 'IMF.STA', 'resource_id': 'CPI', 'version': '4.0.0'}
-URN_CPI_3_0_1 = {'agency_id': 'IMF.STA', 'resource_id': 'CPI', 'version': '3.0.1'}
+URN_CPI_4_0_0 = {'agencyId': 'IMF.STA', 'resourceId': 'CPI', 'version': '4.0.0'}
+URN_CPI_3_0_1 = {'agencyId': 'IMF.STA', 'resourceId': 'CPI', 'version': '3.0.1'}
 
 
 @pytest.mark.asyncio

--- a/tests/integration/services/test_sdmx_datasets.py
+++ b/tests/integration/services/test_sdmx_datasets.py
@@ -171,7 +171,7 @@ async def test_update_dataset(session, clear_all, sdmx_clint_mock):
         indicator=IndexerIndicatorConfig(unpack=True),
     )
 
-    dataset = await dataset_service.update(
+    response = await dataset_service.update(
         dataset.id,
         schemas.DataSetUpdate(
             title='CPI Updated',
@@ -185,6 +185,7 @@ async def test_update_dataset(session, clear_all, sdmx_clint_mock):
         ),
         auth_context=SystemUserAuthContext(),
     )
+    dataset = response.dataset
 
     assert dataset.id_ == random_uuid
     assert dataset.title == 'CPI Updated'

--- a/tests/unit/common/data/base/test_indexing.py
+++ b/tests/unit/common/data/base/test_indexing.py
@@ -3,7 +3,7 @@
 from typing import Annotated
 
 import pytest
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, alias_generators
 
 from statgpt.common.data.base.indexing import (
     IndexingField,
@@ -409,3 +409,275 @@ class TestRealWorldScenarios:
         )
 
         assert config1.indexing_hash != config3.indexing_hash
+
+
+class TestWithNonIndexingFieldsFrom:
+    """Tests for the with_non_indexing_fields_from method."""
+
+    def test_merges_marked_from_resolved_and_unmarked_from_current(self) -> None:
+        """IndexingField-marked fields come from resolved, others from current."""
+
+        class Config(BaseModel, IndexingHashMixin):
+            marked: Annotated[str, IndexingField()] = ""
+            unmarked: str = ""
+
+        current = Config(marked="current_value", unmarked="current_unmarked")
+        resolved = Config(marked="resolved_value", unmarked="resolved_unmarked")
+
+        result = resolved.with_non_indexing_fields_from(current)
+
+        assert result.model_dump() == {
+            "marked": "resolved_value",
+            "unmarked": "current_unmarked",
+        }
+
+    def test_camel_case_aliases_with_model_dump(self) -> None:
+        """Should handle camelCase aliases correctly when using model_dump."""
+
+        class Config(BaseModel, IndexingHashMixin):
+            model_config = ConfigDict(
+                alias_generator=alias_generators.to_camel, populate_by_name=True
+            )
+            is_official: bool = False
+            indexing_field: Annotated[str, IndexingField()] = ""
+
+        current = Config(is_official=True, indexing_field="current")
+        resolved = Config(is_official=False, indexing_field="resolved")
+
+        result = resolved.with_non_indexing_fields_from(current)
+
+        assert result.model_dump(mode="json", by_alias=True) == {
+            "isOfficial": True,  # From current (not marked)
+            "indexingField": "resolved",  # From resolved (marked)
+        }
+
+    def test_nested_model_recursive_merge(self) -> None:
+        """Nested models should be recursively merged."""
+
+        class Inner(BaseModel):
+            marked_inner: Annotated[str, IndexingField()] = ""
+            unmarked_inner: str = ""
+
+        class Outer(BaseModel, IndexingHashMixin):
+            nested: Annotated[Inner, IndexingField()] = Field(default_factory=Inner)
+            outer_unmarked: str = ""
+
+        current = Outer(
+            nested=Inner(marked_inner="current_marked", unmarked_inner="current_unmarked"),
+            outer_unmarked="current_outer",
+        )
+        resolved = Outer(
+            nested=Inner(marked_inner="resolved_marked", unmarked_inner="resolved_unmarked"),
+            outer_unmarked="resolved_outer",
+        )
+
+        result = resolved.with_non_indexing_fields_from(current)
+
+        assert result.model_dump() == {
+            "nested": {
+                "marked_inner": "resolved_marked",  # From resolved (marked)
+                "unmarked_inner": "current_unmarked",  # From current (not marked)
+            },
+            "outer_unmarked": "current_outer",  # From current (not marked)
+        }
+
+    def test_dict_of_models_per_key_merge(self) -> None:
+        """dict[str, BaseModel] fields should merge per-key."""
+
+        class DimensionConfig(BaseModel):
+            dimension_type: Annotated[str, IndexingField()] = "INDICATOR"
+            is_required: bool = False  # Not marked
+
+        class DataSetConfig(BaseModel, IndexingHashMixin):
+            dimensions: Annotated[dict[str, DimensionConfig], IndexingField()] = Field(
+                default_factory=dict
+            )
+            citation: str | None = None  # Not marked
+
+        current = DataSetConfig(
+            dimensions={
+                "DIM1": DimensionConfig(dimension_type="INDICATOR", is_required=True),
+                "DIM2": DimensionConfig(dimension_type="NON_INDICATOR", is_required=True),
+            },
+            citation="Current citation",
+        )
+        resolved = DataSetConfig(
+            dimensions={
+                "DIM1": DimensionConfig(dimension_type="INDICATOR", is_required=False),
+                "DIM2": DimensionConfig(dimension_type="NON_INDICATOR", is_required=False),
+            },
+            citation="Resolved citation",
+        )
+
+        result = resolved.with_non_indexing_fields_from(current)
+
+        assert result.model_dump() == {
+            "dimensions": {
+                "DIM1": {"dimension_type": "INDICATOR", "is_required": True},
+                "DIM2": {"dimension_type": "NON_INDICATOR", "is_required": True},
+            },
+            "citation": "Current citation",
+        }
+
+    def test_preserves_resolved_dimension_keys(self) -> None:
+        """Should preserve dimension keys from resolved, not current."""
+
+        class DimensionConfig(BaseModel):
+            dimension_type: Annotated[str, IndexingField()] = "INDICATOR"
+
+        class DataSetConfig(BaseModel, IndexingHashMixin):
+            dimensions: Annotated[dict[str, DimensionConfig], IndexingField()] = Field(
+                default_factory=dict
+            )
+
+        current = DataSetConfig(
+            dimensions={
+                "DIM1": DimensionConfig(dimension_type="INDICATOR"),
+                "NEW_DIM": DimensionConfig(dimension_type="NON_INDICATOR"),  # New key
+            },
+        )
+        resolved = DataSetConfig(
+            dimensions={
+                "DIM1": DimensionConfig(dimension_type="INDICATOR"),
+                "DIM2": DimensionConfig(dimension_type="TIME_PERIOD"),  # Not in current
+            },
+        )
+
+        result = resolved.with_non_indexing_fields_from(current)
+
+        # Should have keys from resolved only (dimensions is marked)
+        assert result.model_dump() == {
+            "dimensions": {
+                "DIM1": {"dimension_type": "INDICATOR"},
+                "DIM2": {"dimension_type": "TIME_PERIOD"},
+            },
+        }
+
+    def test_handles_none_values(self) -> None:
+        """Should handle None values correctly."""
+
+        class Config(BaseModel, IndexingHashMixin):
+            nullable_marked: Annotated[str | None, IndexingField()] = None
+            nullable_unmarked: str | None = None
+
+        current = Config(nullable_marked="current", nullable_unmarked="current")
+        resolved = Config(nullable_marked=None, nullable_unmarked=None)
+
+        result = resolved.with_non_indexing_fields_from(current)
+
+        assert result.model_dump() == {
+            "nullable_marked": None,  # From resolved (marked)
+            "nullable_unmarked": "current",  # From current (unmarked)
+        }
+
+    def test_realistic_sdmx_like_config(self) -> None:
+        """Test with a realistic SDMX-like configuration structure."""
+
+        class UrnReference(BaseModel):
+            agency_id: Annotated[str, IndexingField()] = ""
+            resource_id: Annotated[str, IndexingField()] = ""
+            version: Annotated[str, IndexingField()] = ""
+
+        class DimensionConfig(BaseModel):
+            model_config = ConfigDict(
+                alias_generator=alias_generators.to_camel, populate_by_name=True
+            )
+            dimension_type: Annotated[str, IndexingField()] = "NON_INDICATOR"
+            alias: Annotated[str | None, IndexingField()] = None
+            is_required: bool = False  # Not marked
+            default_queries: list[dict] | None = None  # Not marked
+
+        class DataSetConfig(BaseModel, IndexingHashMixin):
+            model_config = ConfigDict(
+                alias_generator=alias_generators.to_camel, populate_by_name=True
+            )
+            urn: Annotated[UrnReference, IndexingField()] = Field(default_factory=UrnReference)
+            dimensions: Annotated[dict[str, DimensionConfig], IndexingField()] = Field(
+                default_factory=dict
+            )
+            is_official: bool = False  # Not marked
+            citation: str | None = None  # Not marked
+            pinned_columns: list[str] = Field(default_factory=list)  # Not marked
+
+        current = DataSetConfig(
+            urn=UrnReference(agency_id="CURRENT", resource_id="FLOW", version="2.0"),
+            dimensions={
+                "INDICATOR": DimensionConfig(
+                    dimension_type="INDICATOR",
+                    alias="ind",
+                    is_required=True,
+                    default_queries=[{"value": "GDP"}],
+                ),
+                "COUNTRY": DimensionConfig(
+                    dimension_type="NON_INDICATOR",
+                    alias=None,
+                    is_required=True,
+                    default_queries=None,
+                ),
+            },
+            is_official=True,
+            citation="Updated citation 2024",
+            pinned_columns=["INDICATOR", "COUNTRY"],
+        )
+        resolved = DataSetConfig(
+            urn=UrnReference(agency_id="RESOLVED", resource_id="FLOW", version="1.0"),
+            dimensions={
+                "INDICATOR": DimensionConfig(
+                    dimension_type="INDICATOR",
+                    alias="indicator",
+                    is_required=False,
+                    default_queries=None,
+                ),
+                "COUNTRY": DimensionConfig(
+                    dimension_type="NON_INDICATOR",
+                    alias="country",
+                    is_required=False,
+                    default_queries=None,
+                ),
+            },
+            is_official=False,
+            citation="Original citation",
+            pinned_columns=[],
+        )
+
+        result = resolved.with_non_indexing_fields_from(current)
+
+        assert result.model_dump(mode="json", by_alias=True) == {
+            # URN from resolved (marked)
+            "urn": {
+                "agency_id": "RESOLVED",
+                "resource_id": "FLOW",
+                "version": "1.0",
+            },
+            # Dimensions with merged fields
+            "dimensions": {
+                "INDICATOR": {
+                    "dimensionType": "INDICATOR",  # From resolved (marked)
+                    "alias": "indicator",  # From resolved (marked)
+                    "isRequired": True,  # From current (not marked)
+                    "defaultQueries": [{"value": "GDP"}],  # From current (not marked)
+                },
+                "COUNTRY": {
+                    "dimensionType": "NON_INDICATOR",  # From resolved (marked)
+                    "alias": "country",  # From resolved (marked)
+                    "isRequired": True,  # From current (not marked)
+                    "defaultQueries": None,  # From current (not marked)
+                },
+            },
+            # Non-indexing top-level fields from current
+            "isOfficial": True,
+            "citation": "Updated citation 2024",
+            "pinnedColumns": ["INDICATOR", "COUNTRY"],
+        }
+
+
+class TestIndexingHashMixinWithNonIndexingFieldsFromTypeError:
+    """Tests for the with_non_indexing_fields_from method type error."""
+
+    def test_mixin_requires_base_model_for_merge(self) -> None:
+        class NotAModel(IndexingHashMixin):
+            pass
+
+        obj = NotAModel()
+        with pytest.raises(TypeError, match="must be used with Pydantic BaseModel"):
+            obj.with_non_indexing_fields_from(obj)  # type: ignore[arg-type]

--- a/tests/unit/common/data/base/test_indexing.py
+++ b/tests/unit/common/data/base/test_indexing.py
@@ -1,0 +1,411 @@
+"""Unit tests for the IndexingField marker and hash computation utilities."""
+
+from typing import Annotated
+
+import pytest
+from pydantic import BaseModel, Field
+
+from statgpt.common.data.base.indexing import (
+    IndexingField,
+    IndexingHashMixin,
+    _collect_indexing_fields,
+    _has_indexing_marker,
+    compute_indexing_hash,
+)
+
+
+class TestHasIndexingMarker:
+    """Tests for the _has_indexing_marker function."""
+
+    def test_field_with_marker_returns_true(self) -> None:
+        class Model(BaseModel):
+            marked: Annotated[str, IndexingField()] = ""
+
+        field_info = Model.model_fields["marked"]
+        assert _has_indexing_marker(field_info) is True
+
+    def test_field_without_marker_returns_false(self) -> None:
+        class Model(BaseModel):
+            unmarked: str = ""
+
+        field_info = Model.model_fields["unmarked"]
+        assert _has_indexing_marker(field_info) is False
+
+    def test_field_with_other_annotations_returns_false(self) -> None:
+        class Model(BaseModel):
+            other: Annotated[str, "some_other_marker"] = ""
+
+        field_info = Model.model_fields["other"]
+        assert _has_indexing_marker(field_info) is False
+
+    def test_field_with_multiple_annotations_including_marker(self) -> None:
+        class Model(BaseModel):
+            multi: Annotated[str, "other", IndexingField(), "another"] = ""
+
+        field_info = Model.model_fields["multi"]
+        assert _has_indexing_marker(field_info) is True
+
+
+class TestCollectIndexingFields:
+    """Tests for the _collect_indexing_fields function."""
+
+    def test_collects_marked_fields_only(self) -> None:
+        class Model(BaseModel):
+            marked: Annotated[str, IndexingField()] = "value1"
+            unmarked: str = "value2"
+
+        model = Model()
+        fields = dict(_collect_indexing_fields(model))
+
+        assert fields == {"marked": "value1"}
+
+    def test_handles_none_values(self) -> None:
+        class Model(BaseModel):
+            nullable: Annotated[str | None, IndexingField()] = None
+
+        model = Model()
+        fields = dict(_collect_indexing_fields(model))
+
+        assert fields == {"nullable": None}
+
+    def test_handles_nested_model_with_markers(self) -> None:
+        class Inner(BaseModel):
+            inner_marked: Annotated[str, IndexingField()] = "inner_value"
+            inner_unmarked: str = "ignored"
+
+        class Outer(BaseModel):
+            nested: Annotated[Inner, IndexingField()] = Field(default_factory=Inner)
+
+        model = Outer()
+        fields = dict(_collect_indexing_fields(model))
+
+        assert fields == {"nested.inner_marked": "inner_value"}
+
+    def test_handles_nested_model_without_markers(self) -> None:
+        """When nested model has no markers, nothing is yielded from it.
+
+        This is the expected behavior - fields must be explicitly marked.
+        Note: dict[str, Model] handling includes full dump for unmarked models
+        to support the dimensions pattern where the dict itself is marked.
+        """
+
+        class Inner(BaseModel):
+            field1: str = "a"
+            field2: str = "b"
+
+        class Outer(BaseModel):
+            nested: Annotated[Inner, IndexingField()] = Field(default_factory=Inner)
+
+        model = Outer()
+        fields = dict(_collect_indexing_fields(model))
+
+        assert fields == {}
+
+    def test_handles_dict_of_models(self) -> None:
+        class Item(BaseModel):
+            name: Annotated[str, IndexingField()] = ""
+            ignored: str = ""
+
+        class Container(BaseModel):
+            items: Annotated[dict[str, Item], IndexingField()] = Field(default_factory=dict)
+
+        model = Container(items={"a": Item(name="first"), "b": Item(name="second")})
+        fields = dict(_collect_indexing_fields(model))
+
+        assert fields == {"items": {"a": {"name": "first"}, "b": {"name": "second"}}}
+
+    def test_dict_keys_are_sorted(self) -> None:
+        class Item(BaseModel):
+            value: Annotated[int, IndexingField()] = 0
+
+        class Container(BaseModel):
+            items: Annotated[dict[str, Item], IndexingField()] = Field(default_factory=dict)
+
+        model = Container(items={"z": Item(value=1), "a": Item(value=2), "m": Item(value=3)})
+        fields = dict(_collect_indexing_fields(model))
+
+        # Keys should be sorted for determinism
+        assert list(fields["items"].keys()) == ["a", "m", "z"]
+
+    def test_handles_dict_of_primitives(self) -> None:
+        class Model(BaseModel):
+            mapping: Annotated[dict[str, int], IndexingField()] = Field(default_factory=dict)
+
+        model = Model(mapping={"x": 1, "y": 2})
+        fields = dict(_collect_indexing_fields(model))
+
+        assert fields == {"mapping": {"x": 1, "y": 2}}
+
+    def test_handles_list_of_models(self) -> None:
+        class Item(BaseModel):
+            name: Annotated[str, IndexingField()] = ""
+
+        class Container(BaseModel):
+            items: Annotated[list[Item], IndexingField()] = Field(default_factory=list)
+
+        model = Container(items=[Item(name="first"), Item(name="second")])
+        fields = dict(_collect_indexing_fields(model))
+
+        assert fields == {"items": [{"name": "first"}, {"name": "second"}]}
+
+    def test_handles_list_of_primitives(self) -> None:
+        class Model(BaseModel):
+            values: Annotated[list[int], IndexingField()] = Field(default_factory=list)
+
+        model = Model(values=[1, 2, 3])
+        fields = dict(_collect_indexing_fields(model))
+
+        assert fields == {"values": [1, 2, 3]}
+
+    def test_handles_primitive_types(self) -> None:
+        class Model(BaseModel):
+            string_field: Annotated[str, IndexingField()] = "text"
+            int_field: Annotated[int, IndexingField()] = 42
+            bool_field: Annotated[bool, IndexingField()] = True
+            float_field: Annotated[float, IndexingField()] = 3.14
+
+        model = Model()
+        fields = dict(_collect_indexing_fields(model))
+
+        assert fields == {
+            "string_field": "text",
+            "int_field": 42,
+            "bool_field": True,
+            "float_field": 3.14,
+        }
+
+
+class TestComputeIndexingHash:
+    """Tests for the compute_indexing_hash function."""
+
+    def test_returns_string_hash(self) -> None:
+        class Model(BaseModel):
+            field: Annotated[str, IndexingField()] = "value"
+
+        model = Model()
+        result = compute_indexing_hash(model)
+
+        assert isinstance(result, str)
+        assert result.isdigit() or result.lstrip("-").isdigit()  # CRC32 can be negative
+
+    def test_same_model_produces_same_hash(self) -> None:
+        class Model(BaseModel):
+            field: Annotated[str, IndexingField()] = "value"
+
+        model1 = Model()
+        model2 = Model()
+
+        assert compute_indexing_hash(model1) == compute_indexing_hash(model2)
+
+    def test_different_values_produce_different_hashes(self) -> None:
+        class Model(BaseModel):
+            field: Annotated[str, IndexingField()] = ""
+
+        model1 = Model(field="value1")
+        model2 = Model(field="value2")
+
+        assert compute_indexing_hash(model1) != compute_indexing_hash(model2)
+
+    def test_unmarked_fields_do_not_affect_hash(self) -> None:
+        class Model(BaseModel):
+            marked: Annotated[str, IndexingField()] = "same"
+            unmarked: str = ""
+
+        model1 = Model(unmarked="different1")
+        model2 = Model(unmarked="different2")
+
+        assert compute_indexing_hash(model1) == compute_indexing_hash(model2)
+
+    def test_hash_is_deterministic_with_dict_field(self) -> None:
+        """Dict ordering should not affect hash due to sort_keys=True."""
+
+        class Model(BaseModel):
+            data: Annotated[dict[str, int], IndexingField()] = Field(default_factory=dict)
+
+        # Create dicts with different insertion orders
+        model1 = Model(data={"a": 1, "b": 2, "c": 3})
+        model2 = Model(data={"c": 3, "a": 1, "b": 2})
+
+        assert compute_indexing_hash(model1) == compute_indexing_hash(model2)
+
+    def test_empty_model_produces_consistent_hash(self) -> None:
+        class Model(BaseModel):
+            pass
+
+        model = Model()
+        hash1 = compute_indexing_hash(model)
+        hash2 = compute_indexing_hash(model)
+
+        assert hash1 == hash2
+
+
+class TestIndexingHashMixin:
+    """Tests for the IndexingHashMixin class."""
+
+    def test_provides_indexing_hash_property(self) -> None:
+        class Model(BaseModel, IndexingHashMixin):
+            field: Annotated[str, IndexingField()] = "value"
+
+        model = Model()
+        assert hasattr(model, "indexing_hash")
+        assert isinstance(model.indexing_hash, str)
+
+    def test_indexing_hash_matches_compute_function(self) -> None:
+        class Model(BaseModel, IndexingHashMixin):
+            field: Annotated[str, IndexingField()] = "value"
+
+        model = Model()
+        assert model.indexing_hash == compute_indexing_hash(model)
+
+    def test_mixin_requires_base_model(self) -> None:
+        class NotAModel(IndexingHashMixin):
+            pass
+
+        obj = NotAModel()
+        with pytest.raises(TypeError, match="must be used with Pydantic BaseModel"):
+            _ = obj.indexing_hash
+
+
+class TestInheritance:
+    """Tests for inheritance behavior with IndexingField markers."""
+
+    def test_child_inherits_parent_markers(self) -> None:
+        class Parent(BaseModel, IndexingHashMixin):
+            parent_field: Annotated[str, IndexingField()] = "parent"
+
+        class Child(Parent):
+            child_field: Annotated[str, IndexingField()] = "child"
+
+        model = Child()
+        fields = dict(_collect_indexing_fields(model))
+
+        assert fields == {"parent_field": "parent", "child_field": "child"}
+
+    def test_child_can_add_markers_to_inherited_unmarked_fields(self) -> None:
+        class Parent(BaseModel, IndexingHashMixin):
+            unmarked_in_parent: str = "value"
+
+        class Child(Parent):
+            unmarked_in_parent: Annotated[str, IndexingField()] = "value"
+
+        parent_fields = dict(_collect_indexing_fields(Parent()))
+        child_fields = dict(_collect_indexing_fields(Child()))
+
+        assert parent_fields == {}
+        assert child_fields == {"unmarked_in_parent": "value"}
+
+    def test_different_subclasses_can_have_different_hashes(self) -> None:
+        class Parent(BaseModel, IndexingHashMixin):
+            common: Annotated[str, IndexingField()] = "same"
+
+        class Child1(Parent):
+            unique: Annotated[str, IndexingField()] = "child1"
+
+        class Child2(Parent):
+            unique: Annotated[str, IndexingField()] = "child2"
+
+        model1 = Child1()
+        model2 = Child2()
+
+        assert model1.indexing_hash != model2.indexing_hash
+
+
+class TestRealWorldScenarios:
+    """Tests simulating real-world usage patterns from the codebase."""
+
+    def test_dimension_config_like_structure(self) -> None:
+        """Simulates the DataSetConfig.dimensions structure."""
+
+        class DimensionConfig(BaseModel):
+            dimension_type: Annotated[str, IndexingField()] = "INDICATOR"
+            alias: Annotated[str | None, IndexingField()] = None
+            is_required: bool = False  # Not marked - should not affect hash
+
+        class DataSetConfig(BaseModel, IndexingHashMixin):
+            dimensions: Annotated[dict[str, DimensionConfig], IndexingField()] = Field(
+                default_factory=dict
+            )
+
+        config1 = DataSetConfig(
+            dimensions={
+                "IND1": DimensionConfig(dimension_type="INDICATOR", alias="indicator1"),
+                "DIM1": DimensionConfig(dimension_type="NON_INDICATOR", alias=None),
+            }
+        )
+
+        # Same config with different is_required (unmarked) should have same hash
+        config2 = DataSetConfig(
+            dimensions={
+                "IND1": DimensionConfig(
+                    dimension_type="INDICATOR", alias="indicator1", is_required=True
+                ),
+                "DIM1": DimensionConfig(
+                    dimension_type="NON_INDICATOR", alias=None, is_required=True
+                ),
+            }
+        )
+
+        assert config1.indexing_hash == config2.indexing_hash
+
+    def test_nested_config_hierarchy(self) -> None:
+        """Simulates nested config structures like IndexerConfig -> IndexerIndicatorConfig."""
+
+        class AnnotationConfig(BaseModel):
+            description: Annotated[str, IndexingField()] = ""
+
+        class IndicatorConfig(BaseModel):
+            unpack: Annotated[bool, IndexingField()] = False
+            annotations: Annotated[AnnotationConfig | None, IndexingField()] = None
+
+        class IndexerConfig(BaseModel, IndexingHashMixin):
+            description: Annotated[str, IndexingField()] = ""
+            indicator: Annotated[IndicatorConfig, IndexingField()] = Field(
+                default_factory=IndicatorConfig
+            )
+
+        config1 = IndexerConfig(
+            description="Test",
+            indicator=IndicatorConfig(
+                unpack=True, annotations=AnnotationConfig(description="annotation")
+            ),
+        )
+
+        config2 = IndexerConfig(
+            description="Test",
+            indicator=IndicatorConfig(
+                unpack=True, annotations=AnnotationConfig(description="different")
+            ),
+        )
+
+        # Different annotation description should produce different hash
+        assert config1.indexing_hash != config2.indexing_hash
+
+    def test_urn_reference_like_structure(self) -> None:
+        """Simulates UrnReference from SDMX config."""
+
+        class UrnReference(BaseModel):
+            agency_id: Annotated[str, IndexingField()] = ""
+            resource_id: Annotated[str, IndexingField()] = ""
+            version: Annotated[str, IndexingField()] = "latest"
+
+        class DataSetConfig(BaseModel, IndexingHashMixin):
+            urn: Annotated[UrnReference, IndexingField()] = Field(default_factory=UrnReference)
+            include_attributes: list[str] | None = None  # Not marked
+
+        config1 = DataSetConfig(
+            urn=UrnReference(agency_id="AGENCY", resource_id="FLOW", version="1.0"),
+            include_attributes=["attr1", "attr2"],
+        )
+
+        config2 = DataSetConfig(
+            urn=UrnReference(agency_id="AGENCY", resource_id="FLOW", version="1.0"),
+            include_attributes=None,  # Different but unmarked
+        )
+
+        assert config1.indexing_hash == config2.indexing_hash
+
+        config3 = DataSetConfig(
+            urn=UrnReference(agency_id="AGENCY", resource_id="FLOW", version="2.0"),
+        )
+
+        assert config1.indexing_hash != config3.indexing_hash


### PR DESCRIPTION
### Applicable issues

- resolve #94 

### Description of changes

##### 1. Dynamic URN Resolution                                                              
- Add `resolved_config` JSONB column to `ChannelDatasetVersion` to store concrete URN values resolved during indexing                                                                   
- Ensures consistency between indexed data and queries when dynamic URN values (like "latest") are used                                                                          
- Use resolved config for dataset cache preloading                                          
                                                                                            
##### 2. Indexing Hash System                                                                
- Introduce `IndexingField` marker to annotate fields that affect embedding indexing
- Add `IndexingHashMixin` with `indexing_hash` property computed from marked fields only
- Replace separate `<dimension type>_config_hash` with unified `indexing_config_hash`      
                                                                                            
 ##### 3. Auto-Propagate Config Changes                                               
  - Automatically propagate non-indexing config changes to channel datasets when       
  updating a dataset                                                                   
  - Returns status for each channel dataset: `AUTO_UPDATED`, `NEEDS_REINDEX`, `NO_VERSION`,  
  or `INDEXING_IN_PROGRESS`

##### 4. Refactoring                                                                         
- Centralize `BaseModel` with camelCase config in data package

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>