### PR TITLE
chore: bump python-multipart from 0.0.19 to 0.0.22

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5988,14 +5988,14 @@ requests-toolbelt = ">=0.6.0"
 
 [[package]]
 name = "python-multipart"
-version = "0.0.19"
+version = "0.0.22"
 description = "A streaming multipart parser for Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "python_multipart-0.0.19-py3-none-any.whl", hash = "sha256:f8d5b0b9c618575bf9df01c684ded1d94a338839bdd8223838afacfb4bb2082d"},
-    {file = "python_multipart-0.0.19.tar.gz", hash = "sha256:905502ef39050557b7a6af411f454bc19526529ca46ae6831508438890ce12cc"},
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
 ]
 
 [[package]]
@@ -8094,4 +8094,4 @@ cli = ["httpx", "msal", "prompt-toolkit", "python-keycloak", "questionary", "ric
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "57c3a2e5e2bdf04e3bd334def8530f1fdced29e66416805a0fde76429120d4d1"
+content-hash = "4ca1d065bf81d100e1527c88b849caf5afa5fe973d5c3afd830296b0d7b0e554"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     # Configuration & File handling
     'python-dotenv (>=1.0.1,<2.0.0)',            # Environment variable management
     'pyyaml (>=6.0.1,<7.0.0)',                   # YAML file support
-    'python-multipart (>=0.0.19,<0.0.20)',       # Multipart form data
+    'python-multipart (>=0.0.22,<0.1.0)',        # Multipart form data (for FastAPI file uploads)
 
     # Utilities
     'python-dateutil (>=2.9.0.post0,<3.0.0)',    # Date/time utilities


### PR DESCRIPTION
### Description of changes

Bumped `python-multipart` to address vulnerability.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
