### PR TITLE
feat: hybrid indexer - use json_schema for LLM output #125

### DIFF
--- a/statgpt/common/default_prompts/assets/hybrid_indexer.yaml
+++ b/statgpt/common/default_prompts/assets/hybrid_indexer.yaml
@@ -1,9 +1,7 @@
 normalize:
   systemPrompt: |-
     You are an expert in statistical indicators.
-    As an output provide normalized input together with instruction steps' reasoning as JSON object
-    {{"reasoning": list[str], "normalized": str}}.
-    Only JSON, no markdown
+    Provide step-by-step reasoning for your normalization decisions.
 
   userPrompt: |-
     Instruction steps:
@@ -29,8 +27,7 @@ normalize:
 harmonize:
   systemPrompt: |-
     You are semantic search engine over statistical indicators.
-    As an output provide indicator primary part together with instruction steps' reasoning as JSON object {{"primary": "", "reasoning": []}}.
-    Only JSON, no markdown
+    Provide step-by-step reasoning for extracting the primary part.
 
   userPrompt: |-
     Instruction steps:

--- a/statgpt/common/default_prompts/assets/hybrid_indexer.yaml
+++ b/statgpt/common/default_prompts/assets/hybrid_indexer.yaml
@@ -1,7 +1,7 @@
 normalize:
   systemPrompt: |-
     You are an expert in statistical indicators.
-    Your task is to normalize indicator text, along with step-by-step reasoning for your normalization decisions.
+    Your task is to normalize indicator text and to provide step-by-step reasoning for your normalization decisions.
 
     Instruction steps:
     - resolve all acronyms, keeping original value in round squares if it is not already resolved in input
@@ -27,7 +27,7 @@ normalize:
 harmonize:
   systemPrompt: |-
     You are semantic search engine over statistical indicators.
-    Your task is to provide indicator primary part, along with step-by-step reasoning for extracting the primary part.
+    Your task is to provide indicator primary part and to provide step-by-step reasoning for extracting the primary part.
 
     Instruction steps:
     - review indicators to get some context of how indicator names are built

--- a/statgpt/common/default_prompts/assets/hybrid_indexer.yaml
+++ b/statgpt/common/default_prompts/assets/hybrid_indexer.yaml
@@ -1,9 +1,8 @@
 normalize:
   systemPrompt: |-
     You are an expert in statistical indicators.
-    Provide step-by-step reasoning for your normalization decisions.
+    Your task is to normalize indicator text, along with step-by-step reasoning for your normalization decisions.
 
-  userPrompt: |-
     Instruction steps:
     - resolve all acronyms, keeping original value in round squares if it is not already resolved in input
     - append well-known terms with its well-known acronyms in round squares if it is not present in input
@@ -13,9 +12,6 @@ normalize:
     - you MUST provide output in the SAME LANGUAGE as input.
     This applies to whole "normalized" content, including abbreviations!
 
-    Input:
-    {input}
-
     Examples:
     - if input is exactly "Lending interest rate (%)" then expected normalized "Lending interest rate (percent)"
     - if input contains "consumer price index (cpi)" then normalized should contain "consumer price index (cpi)"
@@ -24,12 +20,15 @@ normalize:
     - if input contains "gross domestic product at market prices" then normalized should contain "gross domestic product (gdp) at market prices"
     - if input is exactly "PPP conversion factor, GDP (LCU per international $)" then expected normalized "Purchasing Power Parity (PPP) conversion factor, Gross Domestic Product (GDP) (Local Currency Units (LCU) per international dollar)"
 
+  userPrompt: |-
+    Input:
+    {input}
+
 harmonize:
   systemPrompt: |-
     You are semantic search engine over statistical indicators.
-    Provide step-by-step reasoning for extracting the primary part.
+    Your task is to provide indicator primary part, along with step-by-step reasoning for extracting the primary part.
 
-  userPrompt: |-
     Instruction steps:
     - review indicators to get some context of how indicator names are built
     - usually primary part is got repeated in multiple indicators
@@ -38,13 +37,14 @@ harmonize:
     - sometimes punctuation like comma or squares is used to separate indicator components. So primary part will ends on a punctuation in this case, potentially last one or just before the last one
     - extract indicator's primary part from the statement
 
+    Examples:
+    - if statement is "Lending interest rate (%)" then expected primary is "lending interest rate"
+    - if statement is "PPP conversion factor, GDP (LCU per international $)" then expected primary is "PPP conversion factor, GDP"
+    - if statement is "Gross domestic product (GDP), Constant prices, Per capita, Purchasing power parity (PPP) international dollar" then expected primary is "Gross domestic product (GDP), Constant prices, Per capita"
+
+  userPrompt: |-
     Statement:
     {statement}
 
     Indicators:
     {indicators}
-
-    Examples:
-    - if statement is "Lending interest rate (%)" then expected primary is "lending interest rate"
-    - if statement is "PPP conversion factor, GDP (LCU per international $)" then expected primary is "PPP conversion factor, GDP"
-    - if statement is "Gross domestic product (GDP), Constant prices, Per capita, Purchasing power parity (PPP) international dollar" then expected primary is "Gross domestic product (GDP), Constant prices, Per capita"

--- a/statgpt/common/hybrid_indexer/indexer.py
+++ b/statgpt/common/hybrid_indexer/indexer.py
@@ -80,13 +80,12 @@ class Indexer:
         self._is_normalize = normalize
         self._is_harmonize = harmonize
 
-        # TODO: use "json_schema" mode
         normalize_llm = get_chat_model(
             api_key=models_api_key, model_config=self._config.normalize_model_config
-        ).with_structured_output(method="json_mode")
+        ).with_structured_output(schema=schemas.NormalizationOutput, method="json_schema")
         harmonize_llm = get_chat_model(
             api_key=models_api_key, model_config=self._config.harmonize_model_config
-        ).with_structured_output(method="json_mode")
+        ).with_structured_output(schema=schemas.HarmonizationOutput, method="json_schema")
 
         normalization_prompt = HybridIndexerDefaultPrompts.get_normalize_prompts()
         self._log_prompt(normalization_prompt, title='normalization prompt')
@@ -95,9 +94,9 @@ class Indexer:
         self._log_prompt(harmonization_prompt, title='harmonization prompt')
 
         self._normalize_chain = (
-            normalization_prompt | normalize_llm | (lambda d: d['normalized'].lower())
+            normalization_prompt | normalize_llm | (lambda d: d.normalized.lower())
         )
-        self._harmonize_chain = harmonization_prompt | harmonize_llm | (lambda d: d['primary'])
+        self._harmonize_chain = harmonization_prompt | harmonize_llm | (lambda d: d.primary)
 
     async def index(
         self,

--- a/statgpt/common/hybrid_indexer/indexer.py
+++ b/statgpt/common/hybrid_indexer/indexer.py
@@ -138,10 +138,7 @@ class Indexer:
             indicators = indicators[:max_n_indicators]
 
         with debug_timer(f"hybrid.normalizing.{dataset.name}"):
-            txt = (
-                f"{len(indicators)} indicators for dataset {dataset.name} "
-                f"({dataset.entity_id}) completed"
-            )
+            txt = f"{len(indicators)} indicators for dataset {dataset.name} ({dataset.entity_id})"
             _log.info(f'Normalizing {txt}')
             index_chain = self._matching_index_chain()
             documents = await index_chain.abatch(

--- a/statgpt/common/hybrid_indexer/schemas.py
+++ b/statgpt/common/hybrid_indexer/schemas.py
@@ -21,3 +21,19 @@ class MatchingIndex(BaseIndex):
 class IndicatorIndex(BaseIndex):
     primary: StrictStr
     primary_normalized: StrictStr
+
+
+class NormalizationOutput(BaseModel):
+    reasoning: list[str] = Field(
+        description="Step-by-step reasoning following the normalization instructions"
+    )
+    normalized: str = Field(
+        description="The normalized indicator text with resolved acronyms and standardized terminology"
+    )
+
+
+class HarmonizationOutput(BaseModel):
+    reasoning: list[str] = Field(
+        description="Step-by-step reasoning for extracting the primary part"
+    )
+    primary: str = Field(description="The primary part of the indicator name")

--- a/statgpt/common/hybrid_indexer/schemas.py
+++ b/statgpt/common/hybrid_indexer/schemas.py
@@ -27,9 +27,7 @@ class NormalizationOutput(BaseModel):
     reasoning: list[str] = Field(
         description="Step-by-step reasoning following the normalization instructions"
     )
-    normalized: str = Field(
-        description="The normalized indicator text with resolved acronyms and standardized terminology"
-    )
+    normalized: str = Field(description="The normalized indicator text")
 
 
 class HarmonizationOutput(BaseModel):


### PR DESCRIPTION
### Description:
Fixes #125 

### Changes:

- Switch from `json_mode` to `json_schema` mode in hybrid indexer
- Add `NormalizationOutput` and `HarmonizationOutput` pydantic models to enforce output schema
- Remove JSON format instructions from prompts (schema now enforces structure)

### Checklist
- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a Review environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.