### PR TITLE
feat: add ability to specify guardrails model #135

### DIFF
--- a/configurations/clients/sample/channels.yaml
+++ b/configurations/clients/sample/channels.yaml
@@ -20,6 +20,8 @@ channels:
         llm_model_config:
           deployment: "gpt-4.1-2025-04-14"
       out_of_scope:
+        llm_model_config:
+          deployment: "gpt-4.1-2025-04-14"
         use_general_topics_blacklist: true
         domain: "Statistics, economics and SDMX."
       token_usage:

--- a/statgpt/app/chains/out_of_scope_checker.py
+++ b/statgpt/app/chains/out_of_scope_checker.py
@@ -136,7 +136,7 @@ class OutOfScopeChecker:
 
         model = get_chat_model(
             api_key=auth_context.api_key,
-            model_config=self._channel_config.supreme_agent.llm_model_config,
+            model_config=self._channel_config.out_of_scope.llm_model_config,
         )
 
         checker_chain = checker_prompt | model.with_structured_output(

--- a/statgpt/common/schemas/channel.py
+++ b/statgpt/common/schemas/channel.py
@@ -47,6 +47,10 @@ class SupremeAgentConfig(BaseYamlModel):
 
 
 class OutOfScopeConfig(BaseYamlModel):
+    llm_model_config: LLMModelConfig = Field(
+        default_factory=LLMModelConfig,
+        description="LLM model configuration for guardrails.",
+    )
     domain: str = Field(
         description="The domain of the chat bot. Other domains are considered out of scope."
     )


### PR DESCRIPTION
### Applicable issues

Resolves #135 

### Description of changes

Add separate `llm_model_config` to `OutOfScopeConfig` for guardrails, allowing independent model configuration from the supreme agent.

**Changes:**
- `statgpt/common/schemas/channel.py`: Added `llm_model_config` field to `OutOfScopeConfig` with default `LLMModelConfig`
- `statgpt/app/chains/out_of_scope_checker.py`: Updated to use `out_of_scope.llm_model_config`
- `configurations/clients/sample/channels.yaml`: Added example config
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
