### PR TITLE
chore: Increase the file upload size limit in DIAL Core

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       'LOG_DIR': '/app/log'
       'STORAGE_DIR': '/app/data'
       'aidial.config.files': '["/opt/config/config.json"]'
+      'aidial.storage.maxUploadedFileSize': '2147483648' # 2 GB
       'aidial.storage.overrides': '{ "jclouds.filesystem.basedir": "data" }'
       'aidial.redis.singleServerConfig.address': 'redis://redis:6379'
     depends_on:


### PR DESCRIPTION
### Applicable issues
N/A

> httpx.HTTPStatusError: Client error '413 Request Entity Too Large' for url 'http://localhost:8080/v1/files/6kCJoJk2Seh6ameHGsw2pe/imports/job-10.zip'

### Description of changes

In DIAL Core, the file upload size limit has been increased to 2 GB. This change only affects local development using docker-compose.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
