### PR TITLE
chore: rm unused response schemas #158

### DIFF
--- a/statgpt/app/schemas/__init__.py
+++ b/statgpt/app/schemas/__init__.py
@@ -5,13 +5,7 @@ from .selection_candidates import (
     LLMSelectionCandidateBase,
     SelectedCandidates,
 )
-from .service import (
-    ChannelDatasetsMetadataResponse,
-    ChannelMetadataResponse,
-    DimTypesResponse,
-    GitVersionResponse,
-    SettingsResponse,
-)
+from .service import ChannelDatasetsMetadataResponse, ChannelMetadataResponse, SettingsResponse
 from .state import ChatState
 from .tool_artifact import (
     BaseFileRagArtifact,

--- a/statgpt/app/schemas/service.py
+++ b/statgpt/app/schemas/service.py
@@ -1,26 +1,13 @@
 from pydantic import BaseModel, Field
 
-from statgpt.common.data.base import DimensionType
 from statgpt.common.schemas.channel_dataset import ChannelDatasetExpanded
 from statgpt.common.schemas.tools import BaseToolConfig
-
-
-class GitVersionResponse(BaseModel):
-    git_commit: str = Field()
 
 
 class SettingsResponse(BaseModel):
     enable_dev_commands: bool = Field()
     enable_direct_tool_calls: bool = Field()
     git_commit: str = Field()
-
-
-class DimTypesResponse(BaseModel):
-    channel_name: str
-    n_datasets: int
-    dataset_dim_types: dict[str, dict[str, DimensionType]] = Field(
-        default_factory=dict, description="dataset -> dimension -> types mapping"
-    )
 
 
 class ChannelMetadataResponse(BaseModel):


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #158

### Description of changes

remove unused `app.schemas.service` previously used in statgpt endpoint responses. these models are no longer used by eval or any other client

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
