### PR TITLE
feat: restrict reasoning_effort=none for GPT-5 Mini

### DIFF
--- a/statgpt/common/schemas/model_config.py
+++ b/statgpt/common/schemas/model_config.py
@@ -70,6 +70,11 @@ class LLMModelConfig(BaseModelConfig):
                 raise ValueError("seed is not supported for GPT-5 models")
             if self.reasoning_effort is None:
                 raise ValueError("reasoning_effort is required for GPT-5 models")
+            if (
+                self.deployment is LLMModelsEnum.GPT_5_MINI_2025_08_07
+                and self.reasoning_effort is ReasoningEffortEnum.NONE
+            ):
+                raise ValueError("reasoning_effort=none is not supported for GPT-5 Mini")
             if self.reasoning_effort is not ReasoningEffortEnum.NONE and self.temperature != 1:
                 raise ValueError(
                     "temperature must be set to 1 when reasoning_effort is enabled for GPT-5 models"

--- a/tests/unit/common/test_model_config.py
+++ b/tests/unit/common/test_model_config.py
@@ -14,9 +14,23 @@ class TestLLMModelConfigValidation:
             (LLMModelsEnum.GPT_4_1_2025_04_14, 42, None, 0, None, False),
             # Valid GPT-5 configs
             (LLMModelsEnum.GPT_5_MINI_2025_08_07, None, ReasoningEffortEnum.MEDIUM, 1, None, False),
-            (LLMModelsEnum.GPT_5_MINI_2025_08_07, None, ReasoningEffortEnum.LOW, 1, VerbosityEnum.HIGH, False),
+            (
+                LLMModelsEnum.GPT_5_MINI_2025_08_07,
+                None,
+                ReasoningEffortEnum.LOW,
+                1,
+                VerbosityEnum.HIGH,
+                False,
+            ),
             (LLMModelsEnum.GPT_5_1_2025_11_13, None, ReasoningEffortEnum.NONE, 0.5, None, False),
-            (LLMModelsEnum.GPT_5_1_2025_11_13, None, ReasoningEffortEnum.HIGH, 1, VerbosityEnum.LOW, False),
+            (
+                LLMModelsEnum.GPT_5_1_2025_11_13,
+                None,
+                ReasoningEffortEnum.HIGH,
+                1,
+                VerbosityEnum.LOW,
+                False,
+            ),
             (LLMModelsEnum.GPT_5_2_2025_12_11, None, ReasoningEffortEnum.NONE, 0, None, False),
             # GPT-5: seed not supported
             (LLMModelsEnum.GPT_5_MINI_2025_08_07, 42, ReasoningEffortEnum.MEDIUM, 1, None, True),
@@ -27,7 +41,14 @@ class TestLLMModelConfigValidation:
             # GPT-5 Mini: reasoning_effort=none not supported
             (LLMModelsEnum.GPT_5_MINI_2025_08_07, None, ReasoningEffortEnum.NONE, 0.5, None, True),
             # GPT-5: temperature must be 1 when reasoning enabled
-            (LLMModelsEnum.GPT_5_MINI_2025_08_07, None, ReasoningEffortEnum.MEDIUM, 0.5, None, True),
+            (
+                LLMModelsEnum.GPT_5_MINI_2025_08_07,
+                None,
+                ReasoningEffortEnum.MEDIUM,
+                0.5,
+                None,
+                True,
+            ),
             (LLMModelsEnum.GPT_5_1_2025_11_13, None, ReasoningEffortEnum.HIGH, 0, None, True),
             # Non-GPT-5: reasoning_effort not supported
             (LLMModelsEnum.GPT_4_O_2024_11_20, None, ReasoningEffortEnum.MEDIUM, 0.5, None, True),

--- a/tests/unit/common/test_model_config.py
+++ b/tests/unit/common/test_model_config.py
@@ -1,0 +1,54 @@
+import pytest
+
+from statgpt.common.config import LLMModelsEnum, ReasoningEffortEnum, VerbosityEnum
+from statgpt.common.schemas.model_config import LLMModelConfig
+
+
+class TestLLMModelConfigValidation:
+    @pytest.mark.parametrize(
+        "deployment, seed, reasoning_effort, temperature, verbosity, should_raise",
+        [
+            # Valid non-GPT-5 configs
+            (LLMModelsEnum.GPT_4_O_2024_11_20, 42, None, 0.5, None, False),
+            (LLMModelsEnum.GPT_4_O_MINI_2024_07_18, None, None, 0, None, False),
+            (LLMModelsEnum.GPT_4_1_2025_04_14, 42, None, 0, None, False),
+            # Valid GPT-5 configs
+            (LLMModelsEnum.GPT_5_MINI_2025_08_07, None, ReasoningEffortEnum.MEDIUM, 1, None, False),
+            (LLMModelsEnum.GPT_5_MINI_2025_08_07, None, ReasoningEffortEnum.LOW, 1, VerbosityEnum.HIGH, False),
+            (LLMModelsEnum.GPT_5_1_2025_11_13, None, ReasoningEffortEnum.NONE, 0.5, None, False),
+            (LLMModelsEnum.GPT_5_1_2025_11_13, None, ReasoningEffortEnum.HIGH, 1, VerbosityEnum.LOW, False),
+            (LLMModelsEnum.GPT_5_2_2025_12_11, None, ReasoningEffortEnum.NONE, 0, None, False),
+            # GPT-5: seed not supported
+            (LLMModelsEnum.GPT_5_MINI_2025_08_07, 42, ReasoningEffortEnum.MEDIUM, 1, None, True),
+            (LLMModelsEnum.GPT_5_1_2025_11_13, 42, ReasoningEffortEnum.MEDIUM, 1, None, True),
+            # GPT-5: reasoning_effort required
+            (LLMModelsEnum.GPT_5_MINI_2025_08_07, None, None, 1, None, True),
+            (LLMModelsEnum.GPT_5_1_2025_11_13, None, None, 1, None, True),
+            # GPT-5 Mini: reasoning_effort=none not supported
+            (LLMModelsEnum.GPT_5_MINI_2025_08_07, None, ReasoningEffortEnum.NONE, 0.5, None, True),
+            # GPT-5: temperature must be 1 when reasoning enabled
+            (LLMModelsEnum.GPT_5_MINI_2025_08_07, None, ReasoningEffortEnum.MEDIUM, 0.5, None, True),
+            (LLMModelsEnum.GPT_5_1_2025_11_13, None, ReasoningEffortEnum.HIGH, 0, None, True),
+            # Non-GPT-5: reasoning_effort not supported
+            (LLMModelsEnum.GPT_4_O_2024_11_20, None, ReasoningEffortEnum.MEDIUM, 0.5, None, True),
+            # Non-GPT-5: verbosity not supported
+            (LLMModelsEnum.GPT_4_O_2024_11_20, None, None, 0.5, VerbosityEnum.MEDIUM, True),
+        ],
+    )
+    def test_llm_model_config_validation(
+        self, deployment, seed, reasoning_effort, temperature, verbosity, should_raise
+    ):
+        kwargs = {
+            "deployment": deployment,
+            "seed": seed,
+            "reasoning_effort": reasoning_effort,
+            "temperature": temperature,
+            "verbosity": verbosity,
+        }
+        if should_raise:
+            with pytest.raises(ValueError):
+                LLMModelConfig(**kwargs)
+        else:
+            config = LLMModelConfig(**kwargs)
+            assert config.deployment is deployment
+            assert config.reasoning_effort is reasoning_effort


### PR DESCRIPTION
### Applicable issues

No

### Description of changes

GPT-5 Mini does not support `reasoning_effort=none` (unlike GPT-5.1+ models which do). This PR adds an explicit validation rule to `LLMModelConfig` that rejects this combination early with a clear error message.

**Changes:**
- Added model-specific validation in `_validate_model_family_params` that raises `ValueError` when `GPT_5_MINI_2025_08_07` is used with `reasoning_effort=none`
- Added parametrized unit tests (`tests/unit/common/test_model_config.py`) covering all 17 validation scenarios for `LLMModelConfig`:
  - Valid non-GPT-5 and GPT-5 configurations
  - Seed restriction for GPT-5 family
  - Required reasoning_effort for GPT-5 family
  - **reasoning_effort=none restriction for GPT-5 Mini (new)**
  - Temperature constraint when reasoning is enabled
  - reasoning_effort/verbosity restriction for non-GPT-5 models

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
