### PR TITLE
chore: minor refactoring of the audit log

### DIFF
--- a/statgpt/admin/services/import_export_jobs.py
+++ b/statgpt/admin/services/import_export_jobs.py
@@ -137,16 +137,12 @@ class JobsService:
         return schemas.Job.model_validate(job, from_attributes=True)
 
     async def _update_job_status(
-        self,
-        job: models.Job,
-        new_status: schemas.PreprocessingStatusEnum,
-        do_commit: bool = True,
+        self, job: models.Job, new_status: schemas.PreprocessingStatusEnum
     ) -> None:
         job.status = new_status
-        job.updated_at = datetime.now()
-        if do_commit:
-            await self._session.commit()
-            await self._session.refresh(job)
+        job.updated_at = func.now()
+        await self._session.commit()
+        await self._session.refresh(job)
 
     async def create_export_job(
         self,
@@ -203,29 +199,28 @@ class JobsService:
                     content=file.file,  # type: ignore
                 )
                 job.file = resp.url
+
+            _log.info(
+                f"Creating import job with args: {clean_up=}, {update_datasets=}, {update_data_sources=}"
+            )
+            background_tasks.add_task(
+                import_channel_in_background_task,
+                job.id,
+                clean_up,
+                update_datasets,
+                update_data_sources,
+                auth_context,
+                get_audit_context(),
+            )
+            job.status = schemas.PreprocessingStatusEnum.QUEUED
         except Exception as e:
             _log.exception(e)
             job.reason_for_failure = str(e)
-            await self._update_job_status(
-                job, schemas.PreprocessingStatusEnum.FAILED, do_commit=False
-            )
-            return schemas.Job.model_validate(job, from_attributes=True)
+            job.status = schemas.PreprocessingStatusEnum.FAILED
 
-        _log.info(
-            f"Creating import job with args: {clean_up=}, {update_datasets=}, {update_data_sources=}"
-        )
-        background_tasks.add_task(
-            import_channel_in_background_task,
-            job.id,
-            clean_up,
-            update_datasets,
-            update_data_sources,
-            auth_context,
-            get_audit_context(),
-        )
-        # TODO: inspect do we need to update job status in this method
-        await self._update_job_status(job, schemas.PreprocessingStatusEnum.QUEUED, do_commit=False)
-
+        job.updated_at = func.now()
+        await self._session.flush()
+        await self._session.refresh(job)
         return schemas.Job.model_validate(job, from_attributes=True)
 
     @staticmethod


### PR DESCRIPTION
### Description of changes

  - Remove `do_commit` flag from `_update_job_status` — it was only used to skip commit/refresh, which led to unresolved `func.now()` expressions
  - Inline job status updates in `create_import_job` and unify the success/failure paths into a single `flush` + `refresh` at the end
  - Replace `datetime.now()` with `func.now()` in `_update_job_status` for consistent server-side timestamps
  - Add `refresh(job)` after `flush` to ensure all server-side values are resolved before Pydantic validation

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
