### PR TITLE
fix: initialize MSI token manager in fix_statuses script #169

### DIFF
--- a/statgpt/admin/fix_statuses.py
+++ b/statgpt/admin/fix_statuses.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 
 from statgpt.admin.services import AdminPortalDataSetService
-from statgpt.common.models import get_session_contex_manager
+from statgpt.common.models import get_session_contex_manager, optional_msi_token_manager_context
 
 _log = logging.getLogger(__name__)
 
@@ -23,7 +23,8 @@ async def fix_statuses():
 async def main():
     try:
         _log.info("Starting fix_statuses script...")
-        await fix_statuses()
+        async with optional_msi_token_manager_context():
+            await fix_statuses()
         _log.info("fix_statuses script completed successfully")
     except Exception:
         _log.exception("Error in fix_statuses script:")


### PR DESCRIPTION
### Applicable issues

- fixes #169

### Description of changes

Wrap `fix_statuses()` call with `optional_msi_token_manager_context()` to ensure the MSI token manager is initialized before database engine creation, matching the pattern used by other entry points.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
