### PR TITLE
fix: handle updated OpenAI content filter error behavior #175

### DIFF
--- a/statgpt/app/application/channel_completion.py
+++ b/statgpt/app/application/channel_completion.py
@@ -135,14 +135,20 @@ class ChannelCompletion(ChatCompletion):
                         )
                     state = ChainParameters.get_state(chains_response)
                     state[StateVarsConfig.ERROR] = None
-                except openai.ContentFilterFinishReasonError as e:
-                    _log.exception(e)
-                    choice.append_content(
-                        "The query was blocked by the LLM provider content filter for violating safety guidelines."
-                    )
+                except openai.BadRequestError as e:
+                    _log.exception("openai.BadRequestError")
+                    if isinstance(error := e.body, dict) and error.get("code") == "content_filter":
+                        raise DIALException(status_code=400, **error) from None
+
+                    choice.append_content("An error occurred while processing your request.")
                     state[StateVarsConfig.ERROR] = str(e)
+                except openai.ContentFilterFinishReasonError as e:
+                    _log.exception("openai.ContentFilterFinishReasonError")
+                    raise DIALException(
+                        message=str(e), status_code=400, param="prompt", code="content_filter"
+                    ) from None
                 except Exception as e:
-                    _log.exception(e)
+                    _log.exception("Exception")
                     choice.append_content("An error occurred while processing your request.")
                     state[StateVarsConfig.ERROR] = str(e)
 

--- a/statgpt/common/config/llm_models.py
+++ b/statgpt/common/config/llm_models.py
@@ -50,6 +50,9 @@ class LLMModelsEnum(StrEnum):
     GPT_4_1_MINI_2025_04_14 = "gpt-4.1-mini-2025-04-14"
     GPT_4_1_NANO_2025_04_14 = "gpt-4.1-nano-2025-04-14"
 
+    GPT_4_1_2025_04_14_HF = "gpt-4.1-2025-04-14-hf"
+    """GPT-4.1 models with high content filters."""
+
     # GPT-5 models
     GPT_5_MINI_2025_08_07 = "gpt-5-mini-2025-08-07"
     GPT_5_1_2025_11_13 = "gpt-5.1-2025-11-13"

--- a/statgpt/common/config/llm_models.py
+++ b/statgpt/common/config/llm_models.py
@@ -69,6 +69,7 @@ class LLMModelsEnum(StrEnum):
             LLMModelsEnum.GPT_4_1_2025_04_14,
             LLMModelsEnum.GPT_4_1_MINI_2025_04_14,
             LLMModelsEnum.GPT_4_1_NANO_2025_04_14,
+            LLMModelsEnum.GPT_4_1_2025_04_14_HF,
         }
 
     @property

--- a/statgpt/common/utils/cancel_dependency.py
+++ b/statgpt/common/utils/cancel_dependency.py
@@ -48,6 +48,7 @@ async def _watcher(request: Request, handler_task: asyncio.Task, interval: float
         if await request.is_disconnected():
             _log.info(f"Cancelling handler task for {request.url}")
             handler_task.cancel()
+            return
         else:
             _log.debug(f"Request {request.url} still connected")
         await asyncio.sleep(interval)


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #175 

### Description of changes

- Handle `openai.BadRequestError` with `content_filter` code by raising `DIALException` to propagate the error to the client.
- Re-raise `ContentFilterFinishReasonError` as `DIALException` instead of silently appending a message to the response.
- Add GPT-4.1 high content filter model variant.
- Fix watcher loop not exiting after cancelling a disconnected request.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
