### PR TITLE
feat: add auto update script for all datasets in marked channels #178

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,12 @@ statgpt_cli: install_dev
 statgpt_admin:
 	poetry run python -m statgpt.admin.app $(ARGS)
 
+statgpt_fix_statuses:
+	poetry run python -m statgpt.admin.fix_statuses
+
+statgpt_auto_update:
+	poetry run python -m statgpt.admin.auto_update
+
 statgpt_app:
 	poetry run python -m statgpt.app.app $(ARGS)
 

--- a/statgpt/admin/admin.sh
+++ b/statgpt/admin/admin.sh
@@ -26,12 +26,17 @@ case "${ADMIN_MODE:-}" in
     python -m statgpt.admin.fix_statuses
     ;;
 
+  AUTO_UPDATE)
+    python -m statgpt.admin.auto_update
+    ;;
+
   *)
     echo "Unknown ADMIN_MODE = '${ADMIN_MODE:-}'. Possible values:"
     echo "  APP - start the admin application"
     echo "  ALEMBIC_UPGRADE - run alembic migrations to upgrade the database"
     echo "  FIX_STATUSES - fix inconsistent statuses in the database"
     echo "  INIT - run alembic migrations and fix inconsistent statuses"
+    echo "  AUTO_UPDATE - run batch auto-update for all eligible channels"
     exit 1
     ;;
 esac

--- a/statgpt/admin/auto_update.py
+++ b/statgpt/admin/auto_update.py
@@ -1,0 +1,63 @@
+"""
+Batch auto-update script for all datasets in channels with allow_auto_update enabled.
+"""
+
+import asyncio
+import logging
+import sys
+
+from statgpt.admin.auth.auth_context import SystemUserAuthContext
+from statgpt.admin.services.channel import AdminPortalChannelService
+from statgpt.admin.services.dataset import AdminPortalDataSetService, auto_update_in_background_task
+from statgpt.common.models import get_session_contex_manager, optional_msi_token_manager_context
+
+_log = logging.getLogger(__name__)
+
+
+async def run_auto_update() -> bool:
+    """Run batch auto-update for all eligible channels.
+
+    Returns True if all jobs succeeded, False otherwise.
+    """
+    auth_context = SystemUserAuthContext()
+
+    async with get_session_contex_manager() as session:
+        channels = await AdminPortalChannelService(session).get_auto_update_channels()
+        _log.info(f"Found {len(channels)} channel(s) with auto-update enabled")
+
+        if not channels:
+            return True
+
+        job_ids = await AdminPortalDataSetService(session).create_auto_update_jobs(channels)
+
+    _log.info(f"Created {len(job_ids)} auto-update job(s), starting processing...")
+
+    # Process all jobs concurrently — @background_task semaphore controls concurrency
+    await asyncio.gather(
+        *(
+            auto_update_in_background_task(auto_update_job_id=job_id, auth_context=auth_context)
+            for job_id in job_ids
+        ),
+        return_exceptions=True,
+    )
+
+    async with get_session_contex_manager() as session:
+        return await AdminPortalDataSetService(session).check_auto_update_results(job_ids)
+
+
+async def main() -> None:
+    try:
+        _log.info("Starting batch auto-update script...")
+        async with optional_msi_token_manager_context():
+            success = await run_auto_update()
+        if not success:
+            _log.error("Batch auto-update finished with failures")
+            sys.exit(1)
+        _log.info("Batch auto-update script completed successfully")
+    except Exception:
+        _log.exception("Error in batch auto-update script:")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/statgpt/admin/auto_update.py
+++ b/statgpt/admin/auto_update.py
@@ -85,20 +85,18 @@ async def _log_results(job_ids: list[int]) -> bool:
 async def _deduplicate_channels(channel_ids: set[int], auth_context: AuthContext) -> None:
     """Run deduplication for channels that had a reindex."""
     _log.info(_SEPARATOR)
-    _log.info(
-        f"Running deduplication for {len(channel_ids)} channel(s) "
-        f"with reindex: {sorted(channel_ids)}"
-    )
+    sorted_ids = sorted(channel_ids)
+    _log.info(f"Running deduplication for {len(sorted_ids)} channel(s) with reindex: {sorted_ids}")
     results = await asyncio.gather(
         *(
             deduplicate_dimensions_in_background_task(
                 channel_id=channel_id, auth_context=auth_context
             )
-            for channel_id in channel_ids
+            for channel_id in sorted_ids
         ),
         return_exceptions=True,
     )
-    for channel_id, result in zip(channel_ids, results):
+    for channel_id, result in zip(sorted_ids, results):
         if isinstance(result, Exception):
             _log.error(
                 f"Deduplication for channel {channel_id} failed with exception:", exc_info=result

--- a/statgpt/admin/auto_update.py
+++ b/statgpt/admin/auto_update.py
@@ -6,12 +6,72 @@ import asyncio
 import logging
 import sys
 
+import statgpt.common.schemas as schemas
 from statgpt.admin.auth.auth_context import SystemUserAuthContext
-from statgpt.admin.services.channel import AdminPortalChannelService
+from statgpt.admin.services.channel import (
+    AdminPortalChannelService,
+    deduplicate_dimensions_in_background_task,
+)
 from statgpt.admin.services.dataset import AdminPortalDataSetService, auto_update_in_background_task
+from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.models import get_session_contex_manager, optional_msi_token_manager_context
 
 _log = logging.getLogger(__name__)
+_SEPARATOR = "-" * 50
+
+
+async def _discover_and_create_jobs() -> list[schemas.AutoUpdateJob]:
+    """Find auto-update channels and create jobs for their datasets."""
+    _log.info(_SEPARATOR)
+    async with get_session_contex_manager() as session:
+        channels = await AdminPortalChannelService(session).get_auto_update_channels()
+        _log.info(f"Found {len(channels)} channel(s) with auto-update enabled")
+
+        if not channels:
+            return []
+
+        channel_ids = [ch.id for ch in channels]
+        return await AdminPortalDataSetService(session).create_auto_update_jobs(channel_ids)
+
+
+async def _process_jobs(jobs: list[schemas.AutoUpdateJob], auth_context: AuthContext) -> None:
+    """Run all auto-update jobs concurrently."""
+    _log.info(_SEPARATOR)
+    _log.info(f"Created {len(jobs)} auto-update job(s), starting processing...")
+
+    await asyncio.gather(
+        *(
+            auto_update_in_background_task(auto_update_job_id=job.id, auth_context=auth_context)
+            for job in jobs
+        ),
+        return_exceptions=True,
+    )
+
+
+async def _check_results(job_ids: list[int]) -> tuple[bool, set[int]]:
+    """Check job results and return (all_succeeded, channel_ids_with_reindex)."""
+    _log.info(_SEPARATOR)
+    async with get_session_contex_manager() as session:
+        return await AdminPortalDataSetService(session).check_auto_update_results(job_ids)
+
+
+async def _deduplicate_channels(channel_ids: set[int], auth_context: AuthContext) -> None:
+    """Run deduplication for channels that had a reindex."""
+    _log.info(_SEPARATOR)
+    _log.info(
+        f"Running deduplication for {len(channel_ids)} channel(s) "
+        f"with reindex: {sorted(channel_ids)}"
+    )
+    await asyncio.gather(
+        *(
+            deduplicate_dimensions_in_background_task(
+                channel_id=channel_id, auth_context=auth_context
+            )
+            for channel_id in channel_ids
+        ),
+        return_exceptions=True,
+    )
+    _log.info("Deduplication complete")
 
 
 async def run_auto_update() -> bool:
@@ -21,28 +81,18 @@ async def run_auto_update() -> bool:
     """
     auth_context = SystemUserAuthContext()
 
-    async with get_session_contex_manager() as session:
-        channels = await AdminPortalChannelService(session).get_auto_update_channels()
-        _log.info(f"Found {len(channels)} channel(s) with auto-update enabled")
+    jobs = await _discover_and_create_jobs()
+    if not jobs:
+        return True
 
-        if not channels:
-            return True
+    await _process_jobs(jobs, auth_context)
+    job_ids = [j.id for j in jobs]
+    success, reindex_channel_ids = await _check_results(job_ids)
 
-        job_ids = await AdminPortalDataSetService(session).create_auto_update_jobs(channels)
+    if reindex_channel_ids:
+        await _deduplicate_channels(reindex_channel_ids, auth_context)
 
-    _log.info(f"Created {len(job_ids)} auto-update job(s), starting processing...")
-
-    # Process all jobs concurrently — @background_task semaphore controls concurrency
-    await asyncio.gather(
-        *(
-            auto_update_in_background_task(auto_update_job_id=job_id, auth_context=auth_context)
-            for job_id in job_ids
-        ),
-        return_exceptions=True,
-    )
-
-    async with get_session_contex_manager() as session:
-        return await AdminPortalDataSetService(session).check_auto_update_results(job_ids)
+    return success
 
 
 async def main() -> None:
@@ -50,6 +100,8 @@ async def main() -> None:
         _log.info("Starting batch auto-update script...")
         async with optional_msi_token_manager_context():
             success = await run_auto_update()
+
+        _log.info(_SEPARATOR)
         if not success:
             _log.error("Batch auto-update finished with failures")
             sys.exit(1)

--- a/statgpt/admin/auto_update.py
+++ b/statgpt/admin/auto_update.py
@@ -48,11 +48,30 @@ async def _process_jobs(jobs: list[schemas.AutoUpdateJob], auth_context: AuthCon
     )
 
 
-async def _check_results(job_ids: list[int]) -> tuple[bool, set[int]]:
-    """Check job results and return (all_succeeded, channel_ids_with_reindex)."""
+async def _get_reindex_channel_ids(job_ids: list[int]) -> set[int]:
+    """Get channel IDs that had at least one reindex triggered."""
+    async with get_session_contex_manager() as session:
+        return await AdminPortalDataSetService(session).get_reindex_channel_ids(job_ids)
+
+
+async def _log_results(job_ids: list[int]) -> bool:
+    """Log per-channel summary and return True if all jobs succeeded."""
     _log.info(_SEPARATOR)
     async with get_session_contex_manager() as session:
-        return await AdminPortalDataSetService(session).check_auto_update_results(job_ids)
+        results = await AdminPortalDataSetService(session).get_auto_update_results(job_ids)
+
+    for r in results:
+        _log.info(f"channel '{r.deployment_id}' (id={r.channel_id}): {r.summary}")
+        for reason in r.failed_reasons:
+            _log.error(f"  {reason}")
+
+    total = sum(r.total for r in results)
+    failed = sum(r.failed for r in results)
+    _log.info(
+        f"Auto-update complete: {total - failed} succeeded, {failed} failed "
+        f"out of {total} total"
+    )
+    return failed == 0
 
 
 async def _deduplicate_channels(channel_ids: set[int], auth_context: AuthContext) -> None:
@@ -87,12 +106,12 @@ async def run_auto_update() -> bool:
 
     await _process_jobs(jobs, auth_context)
     job_ids = [j.id for j in jobs]
-    success, reindex_channel_ids = await _check_results(job_ids)
 
+    reindex_channel_ids = await _get_reindex_channel_ids(job_ids)
     if reindex_channel_ids:
         await _deduplicate_channels(reindex_channel_ids, auth_context)
 
-    return success
+    return await _log_results(job_ids)
 
 
 async def main() -> None:

--- a/statgpt/admin/auto_update.py
+++ b/statgpt/admin/auto_update.py
@@ -24,13 +24,18 @@ async def _discover_and_create_jobs() -> list[schemas.AutoUpdateJob]:
     """Find auto-update channels and create jobs for their datasets."""
     _log.info(_SEPARATOR)
     async with get_session_contex_manager() as session:
-        channels = await AdminPortalChannelService(session).get_auto_update_channels()
-        _log.info(f"Found {len(channels)} channel(s) with auto-update enabled")
+        channel_service = AdminPortalChannelService(session)
+        all_channels = await channel_service.get_channels_schemas(limit=None, offset=0)
+        channel_ids = [
+            ch.id
+            for ch in all_channels
+            if (dq := ch.details.data_query) is not None and dq.details.allow_auto_update
+        ]
+        _log.info(f"Found {len(channel_ids)} channel(s) with auto-update enabled")
 
-        if not channels:
+        if not channel_ids:
             return []
 
-        channel_ids = [ch.id for ch in channels]
         return await AdminPortalDataSetService(session).create_auto_update_jobs(channel_ids)
 
 
@@ -39,13 +44,16 @@ async def _process_jobs(jobs: list[schemas.AutoUpdateJob], auth_context: AuthCon
     _log.info(_SEPARATOR)
     _log.info(f"Created {len(jobs)} auto-update job(s), starting processing...")
 
-    await asyncio.gather(
+    results = await asyncio.gather(
         *(
             auto_update_in_background_task(auto_update_job_id=job.id, auth_context=auth_context)
             for job in jobs
         ),
         return_exceptions=True,
     )
+    for job, result in zip(jobs, results):
+        if isinstance(result, Exception):
+            _log.error(f"Auto-update job {job.id} failed with exception:", exc_info=result)
 
 
 async def _get_reindex_channel_ids(job_ids: list[int]) -> set[int]:
@@ -81,7 +89,7 @@ async def _deduplicate_channels(channel_ids: set[int], auth_context: AuthContext
         f"Running deduplication for {len(channel_ids)} channel(s) "
         f"with reindex: {sorted(channel_ids)}"
     )
-    await asyncio.gather(
+    results = await asyncio.gather(
         *(
             deduplicate_dimensions_in_background_task(
                 channel_id=channel_id, auth_context=auth_context
@@ -90,6 +98,11 @@ async def _deduplicate_channels(channel_ids: set[int], auth_context: AuthContext
         ),
         return_exceptions=True,
     )
+    for channel_id, result in zip(channel_ids, results):
+        if isinstance(result, Exception):
+            _log.error(
+                f"Deduplication for channel {channel_id} failed with exception:", exc_info=result
+            )
     _log.info("Deduplication complete")
 
 

--- a/statgpt/admin/auto_update.py
+++ b/statgpt/admin/auto_update.py
@@ -1,5 +1,5 @@
 """
-Batch auto-update script for all datasets in channels with allow_auto_update enabled.
+Batch auto-update script for all datasets in channels with `allow_auto_update` enabled.
 """
 
 import asyncio
@@ -40,7 +40,11 @@ async def _discover_and_create_jobs() -> list[schemas.AutoUpdateJob]:
 
 
 async def _process_jobs(jobs: list[schemas.AutoUpdateJob], auth_context: AuthContext) -> None:
-    """Run all auto-update jobs concurrently."""
+    """Run all auto-update jobs concurrently.
+
+    NOTE: The number of concurrent executions is limited by the semaphore
+    in the ``@background_task`` decorator applied to ``auto_update_in_background_task``.
+    """
     _log.info(_SEPARATOR)
     _log.info(f"Created {len(jobs)} auto-update job(s), starting processing...")
 
@@ -63,7 +67,7 @@ async def _get_reindex_channel_ids(job_ids: list[int]) -> set[int]:
 
 
 async def _log_results(job_ids: list[int]) -> bool:
-    """Log per-channel summary and return True if all jobs succeeded."""
+    """Log per-channel summary and return `True` if all jobs succeeded."""
     _log.info(_SEPARATOR)
     async with get_session_contex_manager() as session:
         results = await AdminPortalDataSetService(session).get_auto_update_results(job_ids)
@@ -83,7 +87,11 @@ async def _log_results(job_ids: list[int]) -> bool:
 
 
 async def _deduplicate_channels(channel_ids: set[int], auth_context: AuthContext) -> None:
-    """Run deduplication for channels that had a reindex."""
+    """Run deduplication for channels that had a reindex.
+
+    NOTE: The number of concurrent executions is limited by the semaphore
+    in the ``@background_task`` decorator applied to ``deduplicate_dimensions_in_background_task``.
+    """
     _log.info(_SEPARATOR)
     sorted_ids = sorted(channel_ids)
     _log.info(f"Running deduplication for {len(sorted_ids)} channel(s) with reindex: {sorted_ids}")
@@ -107,7 +115,8 @@ async def _deduplicate_channels(channel_ids: set[int], auth_context: AuthContext
 async def run_auto_update() -> bool:
     """Run batch auto-update for all eligible channels.
 
-    Returns True if all jobs succeeded, False otherwise.
+    Returns:
+         `True` if all jobs succeeded, `False` otherwise.
     """
     auth_context = SystemUserAuthContext()
 

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -2015,10 +2015,7 @@ class AdminPortalDataSetService(DataSetService):
 
         jobs: list[models.AutoUpdateJob] = []
         for cd in channel_datasets:
-            job = models.AutoUpdateJob(
-                channel_dataset_id=cd.id,
-                status=StatusEnum.QUEUED,
-            )
+            job = models.AutoUpdateJob(channel_dataset_id=cd.id, status=StatusEnum.QUEUED)
             self._session.add(job)
             jobs.append(job)
         await self._session.commit()
@@ -2029,8 +2026,7 @@ class AdminPortalDataSetService(DataSetService):
         for ch_id, count in counts.items():
             ch = channels_by_id[ch_id]
             _log.info(
-                f"Created {count} auto-update job(s) for channel "
-                f"'{ch.deployment_id}' (id={ch_id})"
+                f"Created {count} auto-update job(s) for channel '{ch.deployment_id}' (id={ch_id})"
             )
 
         return [schemas.AutoUpdateJob.model_validate(job, from_attributes=True) for job in jobs]

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -3,6 +3,7 @@ import logging
 import os.path
 import uuid
 import zipfile
+from collections import Counter
 from collections.abc import Generator, Iterable
 from typing import Any, NamedTuple
 
@@ -10,6 +11,7 @@ import yaml
 from fastapi import BackgroundTasks, HTTPException, status
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.expression import func, select, text, update
 
 import statgpt.common.models as models
@@ -25,6 +27,7 @@ from statgpt.common.hybrid_indexer import Indexer
 from statgpt.common.schemas import (
     AuditActionType,
     AuditEntityType,
+    AutoUpdateResult,
     ChannelIndexStatusScope,
     HybridSearchConfig,
 )
@@ -1989,37 +1992,54 @@ class AdminPortalDataSetService(DataSetService):
         )
         return await self._session.scalar(query) or 0
 
-    async def create_auto_update_jobs(self, channels: list[models.Channel]) -> list[int]:
+    async def create_auto_update_jobs(self, channel_ids: list[int]) -> list[schemas.AutoUpdateJob]:
         """Create AutoUpdateJob records for all datasets in the given channels.
 
-        Returns a list of created job IDs.
-        """
-        job_ids: list[int] = []
-        for channel in channels:
-            channel_job_ids: list[int] = []
-            for channel_dataset in channel.mapped_datasets:
-                job = models.AutoUpdateJob(
-                    channel_dataset_id=channel_dataset.id,
-                    status=StatusEnum.QUEUED,
-                )
-                self._session.add(job)
-                await self._session.flush()
-                channel_job_ids.append(job.id)
-            job_ids.extend(channel_job_ids)
-            _log.info(
-                f"Created {len(channel_job_ids)} auto-update job(s) for channel "
-                f"'{channel.title}' (id={channel.id})"
-            )
-        await self._session.commit()
-        return job_ids
-
-    async def check_auto_update_results(self, job_ids: list[int]) -> bool:
-        """Check final statuses of auto-update jobs and log a summary.
-
-        Returns True if all jobs succeeded, False otherwise.
+        Returns a list of created job schemas.
         """
         result = await self._session.execute(
-            select(models.AutoUpdateJob).where(models.AutoUpdateJob.id.in_(job_ids))
+            select(models.ChannelDataset)
+            .where(models.ChannelDataset.channel_id.in_(channel_ids))
+            .options(selectinload(models.ChannelDataset.channel))
+        )
+        channel_datasets = list(result.scalars().all())
+
+        jobs: list[models.AutoUpdateJob] = []
+        for cd in channel_datasets:
+            job = models.AutoUpdateJob(
+                channel_dataset_id=cd.id,
+                status=StatusEnum.QUEUED,
+            )
+            self._session.add(job)
+            await self._session.flush()
+            jobs.append(job)
+
+        # Log per-channel summary
+        channels_by_id = {cd.channel.id: cd.channel for cd in channel_datasets}
+        counts = Counter(cd.channel_id for cd in channel_datasets)
+        for ch_id, count in counts.items():
+            ch = channels_by_id[ch_id]
+            _log.info(
+                f"Created {count} auto-update job(s) for channel "
+                f"'{ch.deployment_id}' (id={ch_id})"
+            )
+
+        await self._session.commit()
+        return [schemas.AutoUpdateJob.model_validate(job, from_attributes=True) for job in jobs]
+
+    async def check_auto_update_results(self, job_ids: list[int]) -> tuple[bool, set[int]]:
+        """Check final statuses of auto-update jobs and log a per-channel summary.
+
+        Returns a tuple of (all_succeeded, channel_ids_with_reindex).
+        """
+        result = await self._session.execute(
+            select(models.AutoUpdateJob)
+            .where(models.AutoUpdateJob.id.in_(job_ids))
+            .options(
+                selectinload(models.AutoUpdateJob.channel_dataset).selectinload(
+                    models.ChannelDataset.channel
+                )
+            )
         )
         jobs = list(result.scalars().all())
 
@@ -2027,12 +2047,27 @@ class AdminPortalDataSetService(DataSetService):
         for job in failed_jobs:
             _log.error(f"Auto-update job {job.id} failed: {job.reason_for_failure}")
 
+        channel_jobs: dict[int, list[models.AutoUpdateJob]] = {}
+        for job in jobs:
+            ch = job.channel_dataset.channel
+            channel_jobs.setdefault(ch.id, []).append(job)
+
+        reindex_channel_ids: set[int] = set()
+        for channel_id, ch_jobs in channel_jobs.items():
+            ch = ch_jobs[0].channel_dataset.channel
+            result_counts = Counter(j.result.value if j.result else j.status.value for j in ch_jobs)
+            summary = ", ".join(f"{count} {res}" for res, count in result_counts.items())
+            _log.info(f"channel '{ch.deployment_id}' (id={channel_id}): {summary}")
+
+            if any(j.result == AutoUpdateResult.REINDEX_TRIGGERED for j in ch_jobs):
+                reindex_channel_ids.add(channel_id)
+
         succeeded = len(jobs) - len(failed_jobs)
         _log.info(
             f"Auto-update complete: {succeeded} succeeded, {len(failed_jobs)} failed "
             f"out of {len(job_ids)} total"
         )
-        return len(failed_jobs) == 0
+        return len(failed_jobs) == 0, reindex_channel_ids
 
     async def _set_auto_update_job_status(
         self,

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -1989,6 +1989,51 @@ class AdminPortalDataSetService(DataSetService):
         )
         return await self._session.scalar(query) or 0
 
+    async def create_auto_update_jobs(self, channels: list[models.Channel]) -> list[int]:
+        """Create AutoUpdateJob records for all datasets in the given channels.
+
+        Returns a list of created job IDs.
+        """
+        job_ids: list[int] = []
+        for channel in channels:
+            channel_job_ids: list[int] = []
+            for channel_dataset in channel.mapped_datasets:
+                job = models.AutoUpdateJob(
+                    channel_dataset_id=channel_dataset.id,
+                    status=StatusEnum.QUEUED,
+                )
+                self._session.add(job)
+                await self._session.flush()
+                channel_job_ids.append(job.id)
+            job_ids.extend(channel_job_ids)
+            _log.info(
+                f"Created {len(channel_job_ids)} auto-update job(s) for channel "
+                f"'{channel.title}' (id={channel.id})"
+            )
+        await self._session.commit()
+        return job_ids
+
+    async def check_auto_update_results(self, job_ids: list[int]) -> bool:
+        """Check final statuses of auto-update jobs and log a summary.
+
+        Returns True if all jobs succeeded, False otherwise.
+        """
+        result = await self._session.execute(
+            select(models.AutoUpdateJob).where(models.AutoUpdateJob.id.in_(job_ids))
+        )
+        jobs = list(result.scalars().all())
+
+        failed_jobs = [j for j in jobs if j.status == StatusEnum.FAILED]
+        for job in failed_jobs:
+            _log.error(f"Auto-update job {job.id} failed: {job.reason_for_failure}")
+
+        succeeded = len(jobs) - len(failed_jobs)
+        _log.info(
+            f"Auto-update complete: {succeeded} succeeded, {len(failed_jobs)} failed "
+            f"out of {len(job_ids)} total"
+        )
+        return len(failed_jobs) == 0
+
     async def _set_auto_update_job_status(
         self,
         job: models.AutoUpdateJob,

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -2020,8 +2020,8 @@ class AdminPortalDataSetService(DataSetService):
                 status=StatusEnum.QUEUED,
             )
             self._session.add(job)
-            await self._session.flush()
             jobs.append(job)
+        await self._session.commit()
 
         # Log per-channel summary
         channels_by_id = {cd.channel.id: cd.channel for cd in channel_datasets}
@@ -2033,7 +2033,6 @@ class AdminPortalDataSetService(DataSetService):
                 f"'{ch.deployment_id}' (id={ch_id})"
             )
 
-        await self._session.commit()
         return [schemas.AutoUpdateJob.model_validate(job, from_attributes=True) for job in jobs]
 
     async def get_reindex_channel_ids(self, job_ids: list[int]) -> set[int]:
@@ -2097,7 +2096,7 @@ class AdminPortalDataSetService(DataSetService):
         result_counts = Counter(job_statuses)
 
         parts: list[str] = []
-        for job_status, count in result_counts.items():
+        for job_status, count in result_counts.most_common():
             part = f"{count} {job_status}"
             if job_status in reindex_statuses:
                 breakdown = ", ".join(f"{c} {s}" for s, c in reindex_statuses[job_status].items())

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -3,7 +3,7 @@ import logging
 import os.path
 import uuid
 import zipfile
-from collections import Counter
+from collections import Counter, defaultdict
 from collections.abc import Generator, Iterable
 from typing import Any, NamedTuple
 
@@ -60,6 +60,15 @@ class _DataHashes(NamedTuple):
     indicator_dimensions_hash: str
     non_indicator_dimensions_hash: str
     special_dimensions_hash: str | None
+
+
+class AutoUpdateChannelResult(NamedTuple):
+    channel_id: int
+    deployment_id: str
+    total: int
+    failed: int
+    summary: str
+    failed_reasons: list[str]
 
 
 class AdminPortalDataSetService(DataSetService):
@@ -2027,47 +2036,74 @@ class AdminPortalDataSetService(DataSetService):
         await self._session.commit()
         return [schemas.AutoUpdateJob.model_validate(job, from_attributes=True) for job in jobs]
 
-    async def check_auto_update_results(self, job_ids: list[int]) -> tuple[bool, set[int]]:
-        """Check final statuses of auto-update jobs and log a per-channel summary.
+    async def get_reindex_channel_ids(self, job_ids: list[int]) -> set[int]:
+        """Get channel IDs that had at least one REINDEX_TRIGGERED result."""
+        result = await self._session.execute(
+            select(models.AutoUpdateJob)
+            .where(models.AutoUpdateJob.id.in_(job_ids))
+            .where(models.AutoUpdateJob.result == AutoUpdateResult.REINDEX_TRIGGERED)
+            .options(selectinload(models.AutoUpdateJob.channel_dataset))
+        )
+        jobs = list(result.scalars().all())
+        return {j.channel_dataset.channel_id for j in jobs}
 
-        Returns a tuple of (all_succeeded, channel_ids_with_reindex).
-        """
+    async def get_auto_update_results(self, job_ids: list[int]) -> list[AutoUpdateChannelResult]:
+        """Collect per-channel auto-update results."""
         result = await self._session.execute(
             select(models.AutoUpdateJob)
             .where(models.AutoUpdateJob.id.in_(job_ids))
             .options(
                 selectinload(models.AutoUpdateJob.channel_dataset).selectinload(
                     models.ChannelDataset.channel
-                )
+                ),
+                selectinload(models.AutoUpdateJob.created_version),
             )
         )
         jobs = list(result.scalars().all())
 
-        failed_jobs = [j for j in jobs if j.status == StatusEnum.FAILED]
-        for job in failed_jobs:
-            _log.error(f"Auto-update job {job.id} failed: {job.reason_for_failure}")
-
-        channel_jobs: dict[int, list[models.AutoUpdateJob]] = {}
+        channel_jobs: defaultdict[int, list[models.AutoUpdateJob]] = defaultdict(list)
         for job in jobs:
-            ch = job.channel_dataset.channel
-            channel_jobs.setdefault(ch.id, []).append(job)
+            channel_jobs[job.channel_dataset.channel.id].append(job)
 
-        reindex_channel_ids: set[int] = set()
+        results: list[AutoUpdateChannelResult] = []
         for channel_id, ch_jobs in channel_jobs.items():
             ch = ch_jobs[0].channel_dataset.channel
-            result_counts = Counter(j.result.value if j.result else j.status.value for j in ch_jobs)
-            summary = ", ".join(f"{count} {res}" for res, count in result_counts.items())
-            _log.info(f"channel '{ch.deployment_id}' (id={channel_id}): {summary}")
+            results.append(
+                AutoUpdateChannelResult(
+                    channel_id=channel_id,
+                    deployment_id=ch.deployment_id,
+                    total=len(ch_jobs),
+                    failed=sum(1 for j in ch_jobs if j.status == StatusEnum.FAILED),
+                    summary=self._format_result_summary(ch_jobs),
+                    failed_reasons=[
+                        f"job {j.id}: {j.reason_for_failure}"
+                        for j in ch_jobs
+                        if j.status == StatusEnum.FAILED
+                    ],
+                )
+            )
+        return results
 
-            if any(j.result == AutoUpdateResult.REINDEX_TRIGGERED for j in ch_jobs):
-                reindex_channel_ids.add(channel_id)
+    @staticmethod
+    def _format_result_summary(jobs: list[models.AutoUpdateJob]) -> str:
+        """Build a human-readable summary of auto-update results."""
+        reindex_statuses: dict[str, Counter[str]] = defaultdict(Counter)
+        job_statuses: list[str] = []
+        for job in jobs:
+            job_status = job.result.value if job.result else job.status.value
+            job_statuses.append(job_status)
+            if job.created_version is not None:
+                reindex_statuses[job_status][job.created_version.preprocessing_status.value] += 1
+        result_counts = Counter(job_statuses)
 
-        succeeded = len(jobs) - len(failed_jobs)
-        _log.info(
-            f"Auto-update complete: {succeeded} succeeded, {len(failed_jobs)} failed "
-            f"out of {len(job_ids)} total"
-        )
-        return len(failed_jobs) == 0, reindex_channel_ids
+        parts: list[str] = []
+        for job_status, count in result_counts.items():
+            part = f"{count} {job_status}"
+            if job_status in reindex_statuses:
+                breakdown = ", ".join(f"{c} {s}" for s, c in reindex_statuses[job_status].items())
+                part += f" ({breakdown})"
+            parts.append(part)
+        return ", ".join(parts)
 
     async def _set_auto_update_job_status(
         self,

--- a/statgpt/common/schemas/data_query_tool.py
+++ b/statgpt/common/schemas/data_query_tool.py
@@ -268,6 +268,10 @@ class DataQueryDetails(BaseToolDetails):
     prompts: DataQueryPrompts = Field(default_factory=DataQueryPrompts)  # type: ignore
     messages: DataQueryMessages = Field(default_factory=DataQueryMessages)  # type: ignore
     attachments: DataQueryAttachments = Field(default_factory=DataQueryAttachments)  # type: ignore
+    allow_auto_update: bool = Field(
+        default=False,
+        description="Whether datasets in this channel should be auto-updated by the batch auto-update script.",
+    )
     tool_response_max_cells: PositiveInt = Field(
         default=300,
         description=(

--- a/statgpt/common/services/channel.py
+++ b/statgpt/common/services/channel.py
@@ -1,7 +1,6 @@
 from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.expression import func
 
 import statgpt.common.models as models
@@ -28,7 +27,7 @@ class ChannelService:
         q_result = await self._session.execute(query)
         return [item for item in q_result.scalars().all()]
 
-    async def get_channels_schemas(self, limit: int, offset: int) -> list[schemas.Channel]:
+    async def get_channels_schemas(self, limit: int | None, offset: int) -> list[schemas.Channel]:
         channels = await self.get_channels_db(limit, offset)
         return [ChannelSerializer.db_to_schema(item) for item in channels]
 
@@ -60,19 +59,3 @@ class ChannelService:
             return False
         indexer_version = channel_config.data_query.details.indexer_version
         return indexer_version == schemas.IndexerVersion.hybrid
-
-    @staticmethod
-    def _is_auto_update_enabled(channel: models.Channel) -> bool:
-        """Returns `True` if the channel has auto-update enabled in data_query config."""
-        config = schemas.ChannelConfig.model_validate(channel.details)
-        if config.data_query is None:
-            return False
-        return config.data_query.details.allow_auto_update
-
-    async def get_auto_update_channels(self) -> list[models.Channel]:
-        """Get all channels with auto-update enabled, with mapped_datasets eager-loaded."""
-        result = await self._session.execute(
-            select(models.Channel).options(selectinload(models.Channel.mapped_datasets))
-        )
-        channels = list(result.scalars().all())
-        return [ch for ch in channels if self._is_auto_update_enabled(ch)]

--- a/statgpt/common/services/channel.py
+++ b/statgpt/common/services/channel.py
@@ -1,6 +1,7 @@
 from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.expression import func
 
 import statgpt.common.models as models
@@ -59,3 +60,19 @@ class ChannelService:
             return False
         indexer_version = channel_config.data_query.details.indexer_version
         return indexer_version == schemas.IndexerVersion.hybrid
+
+    @staticmethod
+    def _is_auto_update_enabled(channel: models.Channel) -> bool:
+        """Returns `True` if the channel has auto-update enabled in data_query config."""
+        config = schemas.ChannelConfig.model_validate(channel.details)
+        if config.data_query is None:
+            return False
+        return config.data_query.details.allow_auto_update
+
+    async def get_auto_update_channels(self) -> list[models.Channel]:
+        """Get all channels with auto-update enabled, with mapped_datasets eager-loaded."""
+        result = await self._session.execute(
+            select(models.Channel).options(selectinload(models.Channel.mapped_datasets))
+        )
+        channels = list(result.scalars().all())
+        return [ch for ch in channels if self._is_auto_update_enabled(ch)]


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- closes #178 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Adds a new `ADMIN_MODE=AUTO_UPDATE` container mode that runs a batch auto-update script for all datasets in channels with `allow_auto_update` enabled.

The script (`statgpt/admin/auto_update.py`) performs four stages:

1. **Discovery** — finds eligible channels and creates auto-update jobs for their datasets
2. **Processing** — runs all jobs concurrently (respecting the `@background_task` semaphore)
3. **Deduplication** — deduplicates dimensions for channels that triggered a reindex
4. **Results** — logs per-channel summary with reindex status breakdown, e.g. `channel 'statgpt-sample' (id=1): 3 NO_CHANGES, 2 REINDEX_TRIGGERED (1 COMPLETED, 1 FAILED)`

Also adds `make statgpt_auto_update` and `make statgpt_fix_statuses` targets.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
