### PR TITLE
fix: make RAG state model fields optional with defaults #189

### DIFF
--- a/statgpt/app/schemas/file_rags/base.py
+++ b/statgpt/app/schemas/file_rags/base.py
@@ -4,7 +4,7 @@ from statgpt.common.schemas import RAGVersion, ToolTypes
 
 class BaseRagState(ToolMessageState):
     type: ToolTypes = ToolTypes.FILE_RAG
-    version: RAGVersion
+    version: RAGVersion = RAGVersion.DIAL
 
-    response: str  # This is not needed since we have content field
-    answered_by: str
+    response: str | None = None  # This is not needed since we have content field
+    answered_by: str | None = None

--- a/statgpt/app/schemas/file_rags/base.py
+++ b/statgpt/app/schemas/file_rags/base.py
@@ -4,7 +4,7 @@ from statgpt.common.schemas import RAGVersion, ToolTypes
 
 class BaseRagState(ToolMessageState):
     type: ToolTypes = ToolTypes.FILE_RAG
-    version: RAGVersion = RAGVersion.DIAL
+    version: RAGVersion
 
-    response: str | None = None  # This is not needed since we have content field
-    answered_by: str | None = None
+    response: str = ""  # This is not needed since we have content field
+    answered_by: str = ""

--- a/statgpt/app/schemas/file_rags/dial_rag.py
+++ b/statgpt/app/schemas/file_rags/dial_rag.py
@@ -292,18 +292,18 @@ class DialRagMetadata(BaseModel):
 
 
 class PreFilterResponse(BaseModel):
-    user_friendly_error: str | None = Field(default=None)
-    detailed_error: str | None = Field(default=None)
-    llm_output: RagFilterLLMOutput | None = Field(default=None)
+    user_friendly_error: str | None = None
+    detailed_error: str | None = None
+    llm_output: RagFilterLLMOutput | None = None
     # NOTE: Currently None means no filter applied; but RagFilterDial can also contain an empty list;
     # NOTE: Should we replace all the None logic with just an empty list?
-    rag_filter: RagFilterDial | None = Field(default=None)
+    rag_filter: RagFilterDial | None = None
 
 
 class DialRagState(BaseRagState):
     version: RAGVersion = RAGVersion.DIAL
-    pre_filter: PreFilterResponse
-    metadata: DialRagMetadata | None
+    pre_filter: PreFilterResponse | None = None
+    metadata: DialRagMetadata | None = None
     prefilter_decoder_of_latest: dict[str, str] = Field(
         default_factory=dict,
         description="Mapping the publication type to a function that generates a time range "


### PR DESCRIPTION
### Applicable issues

- fixes #189 

### Description of changes

Update `BaseRagState` and `DialRagState` Pydantic models to make fields optional with sensible defaults:

- `BaseRagState`:  make `response` and `answered_by` optional (`str  = ""`)
- `DialRagState`: make `pre_filter` and `metadata` optional with `None` defaults
- `PreFilterResponse`: simplify field declarations by replacing `Field(default=None)` with plain `= None`

This allows partial construction of RAG state objects without requiring all fields upfront.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

