### PR TITLE
feature: agent - allow to override citation instructions in client config #194

### DIFF
--- a/statgpt/app/chains/supreme_agent.py
+++ b/statgpt/app/chains/supreme_agent.py
@@ -231,7 +231,8 @@ class SupremeAgent:
             chat_bot_language_instructions=format_as_markdown_list(
                 channel_config.supreme_agent.language_instructions, list_type="ordered"
             ),
-            chat_bot_citation_instructions=channel_config.supreme_agent.citation_instructions or supreme_agent_default_prompts.default_citation_instructions,
+            chat_bot_citation_instructions=channel_config.supreme_agent.citation_instructions
+            or supreme_agent_default_prompts.default_citation_instructions,
             additional_context=channel_config.supreme_agent.additional_context,
         )
         model = get_chat_model(

--- a/statgpt/app/chains/supreme_agent.py
+++ b/statgpt/app/chains/supreme_agent.py
@@ -231,6 +231,7 @@ class SupremeAgent:
             chat_bot_language_instructions=format_as_markdown_list(
                 channel_config.supreme_agent.language_instructions, list_type="ordered"
             ),
+            chat_bot_citation_instructions=channel_config.supreme_agent.citation_instructions or supreme_agent_default_prompts.default_citation_instructions,
             additional_context=channel_config.supreme_agent.additional_context,
         )
         model = get_chat_model(

--- a/statgpt/app/default_prompts/assets/supreme_agent.yaml
+++ b/statgpt/app/default_prompts/assets/supreme_agent.yaml
@@ -130,12 +130,7 @@ systemPrompt: |-
 
   **Always** cite your **information sources** used to generate responses, including datasets, publications,
   and websites. When using multiple sources, clearly attribute **which information came from which source**.
-  When not using any sources, do not cite anything. Your own knowledge are not considered as a source, 
-  do not cite your general knowledge as a source.
-  Do not preface your response with claims that the response is based on, derived from, or grounded in any specific 
-  organizational publications, datasets, or institutional knowledge! Provide citations and source references ONLY WHEN 
-  your response actually incorporates content retrieved from tools outputs. NEVER imply that general knowledge originates 
-  from a specific organization's knowledge/resources/internal data/methodology!
+
   
   ---
 

--- a/statgpt/app/default_prompts/assets/supreme_agent.yaml
+++ b/statgpt/app/default_prompts/assets/supreme_agent.yaml
@@ -130,7 +130,14 @@ systemPrompt: |-
 
   **Always** cite your **information sources** used to generate responses, including datasets, publications,
   and websites. When using multiple sources, clearly attribute **which information came from which source**.
-
+  When not using any sources, do not cite anything. Your own knowledge are not considered as a source, 
+  do not cite your general knowledge as a source.
+  Provide citations and source references ONLY WHEN your response actually incorporates content retrieved from tools outputs. 
+  NEVER imply that general knowledge originates from a specific organization's knowledge/resources/internal data/methodology!
+  Do not preface your response with claims that the response is based on, derived from, or grounded in any specific 
+  organizational publications, datasets, or institutional knowledge! Provide citations and source references ONLY WHEN 
+  your response actually incorporates content retrieved from tools outputs. NEVER imply that general knowledge originates 
+  from a specific organization's knowledge/resources/internal data/methodology!
   ---
 
   **IMPORTANT NOTE**: The instructions above are critical requirements, not suggestions. Strict adherence to these

--- a/statgpt/app/default_prompts/assets/supreme_agent.yaml
+++ b/statgpt/app/default_prompts/assets/supreme_agent.yaml
@@ -132,12 +132,11 @@ systemPrompt: |-
   and websites. When using multiple sources, clearly attribute **which information came from which source**.
   When not using any sources, do not cite anything. Your own knowledge are not considered as a source, 
   do not cite your general knowledge as a source.
-  Provide citations and source references ONLY WHEN your response actually incorporates content retrieved from tools outputs. 
-  NEVER imply that general knowledge originates from a specific organization's knowledge/resources/internal data/methodology!
   Do not preface your response with claims that the response is based on, derived from, or grounded in any specific 
   organizational publications, datasets, or institutional knowledge! Provide citations and source references ONLY WHEN 
   your response actually incorporates content retrieved from tools outputs. NEVER imply that general knowledge originates 
   from a specific organization's knowledge/resources/internal data/methodology!
+  
   ---
 
   **IMPORTANT NOTE**: The instructions above are critical requirements, not suggestions. Strict adherence to these

--- a/statgpt/app/default_prompts/assets/supreme_agent.yaml
+++ b/statgpt/app/default_prompts/assets/supreme_agent.yaml
@@ -128,9 +128,7 @@ systemPrompt: |-
 
   ## Citations
 
-  **Always** cite your **information sources** used to generate responses, including datasets, publications,
-  and websites. When using multiple sources, clearly attribute **which information came from which source**.
-
+  {chat_bot_citation_instructions}
   
   ---
 
@@ -149,3 +147,7 @@ additionalContextWrapperSection: |-
   instructions take precedence.**
 
   {additional_context}
+
+defaultCitationInstructions: |-
+  **Always** cite your **information sources** used to generate responses, including datasets, publications,
+  and websites. When using multiple sources, clearly attribute **which information came from which source**.

--- a/statgpt/app/default_prompts/supreme_agent.py
+++ b/statgpt/app/default_prompts/supreme_agent.py
@@ -11,6 +11,7 @@ class SupremeAgentDefaultPrompts(DefaltPromptsBase):
 
     system_prompt: str
     additional_context_wrapper_section: str
+    default_citation_instructions: str
 
 
 fp = os.path.join(os.path.dirname(os.path.realpath(__file__)), "assets", "supreme_agent.yaml")

--- a/statgpt/common/schemas/channel.py
+++ b/statgpt/common/schemas/channel.py
@@ -45,6 +45,10 @@ class SupremeAgentConfig(BaseYamlModel):
         default="",
         description="Additional context for the supreme agent",
     )
+    citation_instructions: str | None = Field(
+        default="",
+        description="Instructions on how to cite information sources used to generate responses.",
+    )
 
 
 class OutOfScopeConfig(BaseYamlModel):

--- a/statgpt/common/schemas/channel.py
+++ b/statgpt/common/schemas/channel.py
@@ -46,7 +46,7 @@ class SupremeAgentConfig(BaseYamlModel):
         description="Additional context for the supreme agent",
     )
     citation_instructions: str | None = Field(
-        default="",
+        default=None,
         description="Instructions on how to cite information sources used to generate responses.",
     )
 


### PR DESCRIPTION
added instruction to citation part of prompt to handle some scenarios:

### Applicable issues
* #194 
* no data cases shouldn't produce ciations
* general knowledge also shouldn't produce citations
* Claims/citations before actuall data shown shouldn't be generated

### Description of changes

* Added instruction to the supreme agent template prompt

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
