### PR TITLE
fix: database connection pool exhaustion during concurrent operations #174

### DIFF
--- a/statgpt/admin/routers/channel.py
+++ b/statgpt/admin/routers/channel.py
@@ -15,6 +15,7 @@ from statgpt.admin.services import AdminPortalChannelService as ChannelService
 from statgpt.admin.services import AdminPortalDataSetService as DataSetService
 from statgpt.admin.services import JobsService
 from statgpt.admin.settings.exim import JobsConfig
+from statgpt.common.data.sdmx.v21.dataset import InvalidConfigurationError
 from statgpt.common.settings.dial import dial_settings
 from statgpt.common.utils.cancel_dependency import cancel_on_disconnect
 
@@ -285,12 +286,16 @@ async def reload_indicators_for_all_channel_datasets(
     This endpoint only starts background jobs.
     """
 
-    channel_datasets = await DataSetService(session).reload_all_indicators(
-        background_tasks=background_tasks,
-        channel_id=channel_id,
-        max_n_embeddings=max_n_embeddings,
-        auth_context=SystemUserAuthContext(),
-    )
+    try:
+        channel_datasets = await DataSetService(session).reload_all_indicators(
+            background_tasks=background_tasks,
+            channel_id=channel_id,
+            max_n_embeddings=max_n_embeddings,
+            auth_context=SystemUserAuthContext(),
+        )
+    except InvalidConfigurationError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
     return schemas.ListResponse[schemas.ChannelDatasetExpanded](
         data=channel_datasets,
         limit=len(channel_datasets),

--- a/statgpt/admin/routers/channel.py
+++ b/statgpt/admin/routers/channel.py
@@ -16,6 +16,7 @@ from statgpt.admin.services import AdminPortalDataSetService as DataSetService
 from statgpt.admin.services import JobsService
 from statgpt.admin.settings.exim import JobsConfig
 from statgpt.common.data.sdmx.v21.dataset import InvalidConfigurationError
+from statgpt.common.models.database import get_session_context_manager
 from statgpt.common.settings.dial import dial_settings
 from statgpt.common.utils.cancel_dependency import cancel_on_disconnect
 
@@ -73,15 +74,15 @@ async def export_channel(
     background_tasks: BackgroundTasks,
     channel_id: int,
     scope: schemas.ExportScope = Query(default=schemas.ExportScope.FULL),
-    session: AsyncSession = Depends(models.get_session),
 ) -> schemas.Job:
     """Create a background job to export channel data to a zip file.
     Use the job id to check the status of the job.
     """
 
-    return await JobsService(session).create_export_job(
-        background_tasks, channel_id, scope=scope, auth_context=SystemUserAuthContext()
-    )
+    async with get_session_context_manager() as session:
+        return await JobsService(session).create_export_job(
+            background_tasks, channel_id, scope=scope, auth_context=SystemUserAuthContext()
+        )
 
 
 IMPORT_CHANNEL_CLEAN_UP_DESCRIPTION = (
@@ -101,20 +102,20 @@ async def import_channel(
     update_data_sources: Annotated[
         bool, Query(description='Whether to update the data sources if it already exists')
     ] = False,
-    session: AsyncSession = Depends(models.get_session),
 ) -> schemas.Job:
     """Create a background job to import a channel from a zip file.
     Use the job id to check the status of the job.
     """
 
-    return await JobsService(session).create_import_job(
-        background_tasks,
-        file,
-        clean_up,
-        update_datasets,
-        update_data_sources,
-        auth_context=SystemUserAuthContext(),
-    )
+    async with get_session_context_manager() as session:
+        return await JobsService(session).create_import_job(
+            background_tasks,
+            file,
+            clean_up,
+            update_datasets,
+            update_data_sources,
+            auth_context=SystemUserAuthContext(),
+        )
 
 
 @router.get('/{channel_id}/jobs')
@@ -279,22 +280,22 @@ async def reload_indicators_for_all_channel_datasets(
             ge=1,
         ),
     ] = None,
-    session: AsyncSession = Depends(models.get_session),
 ) -> schemas.ListResponse[schemas.ChannelDatasetExpanded]:
     """Clears existing indicators for all datasets in the channel and loads them from the data source.
     If any channel dataset is in the status `QUEUED` or `IN_PROGRESS`, it will be skipped.
     This endpoint only starts background jobs.
     """
 
-    try:
-        channel_datasets = await DataSetService(session).reload_all_indicators(
-            background_tasks=background_tasks,
-            channel_id=channel_id,
-            max_n_embeddings=max_n_embeddings,
-            auth_context=SystemUserAuthContext(),
-        )
-    except InvalidConfigurationError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    async with get_session_context_manager() as session:
+        try:
+            channel_datasets = await DataSetService(session).reload_all_indicators(
+                background_tasks=background_tasks,
+                channel_id=channel_id,
+                max_n_embeddings=max_n_embeddings,
+                auth_context=SystemUserAuthContext(),
+            )
+        except InvalidConfigurationError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     return schemas.ListResponse[schemas.ChannelDatasetExpanded](
         data=channel_datasets,
@@ -312,7 +313,6 @@ async def reload_indicators_for_all_channel_datasets(
 async def deduplicate_channel(
     background_tasks: BackgroundTasks,
     channel_id: int,
-    session: AsyncSession = Depends(models.get_session),
 ) -> schemas.Channel:
     """Deduplicates Available_Dimensions and Special_Dimensions vector stores for channel.
 
@@ -320,12 +320,13 @@ async def deduplicate_channel(
 
     The deduplication runs in the background and returns immediately with status 202 Accepted.
     """
-    service = ChannelService(session)
-    return await service.deduplicate_all_dimensions(
-        background_tasks=background_tasks,
-        channel_id=channel_id,
-        auth_context=SystemUserAuthContext(),
-    )
+    async with get_session_context_manager() as session:
+        service = ChannelService(session)
+        return await service.deduplicate_all_dimensions(
+            background_tasks=background_tasks,
+            channel_id=channel_id,
+            auth_context=SystemUserAuthContext(),
+        )
 
 
 @router.get(path="/{channel_id}/index-status")
@@ -383,19 +384,22 @@ async def reload_indicators_for_channel_dataset(
             ge=1,
         ),
     ] = None,
-    session: AsyncSession = Depends(models.get_session),
 ) -> schemas.ChannelDatasetExpanded:
     """Clears existing indicators for the dataset and loads them from the data source.
     This endpoint only starts a background job.
     """
 
-    return await DataSetService(session).reload_indicators(
-        background_tasks=background_tasks,
-        channel_id=channel_id,
-        dataset_id=dataset_id,
-        max_n_embeddings=max_n_embeddings,
-        auth_context=SystemUserAuthContext(),
-    )
+    async with get_session_context_manager() as session:
+        try:
+            return await DataSetService(session).reload_indicators(
+                background_tasks=background_tasks,
+                channel_id=channel_id,
+                dataset_id=dataset_id,
+                max_n_embeddings=max_n_embeddings,
+                auth_context=SystemUserAuthContext(),
+            )
+        except InvalidConfigurationError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.delete("/{channel_id}/datasets/{dataset_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -488,19 +492,19 @@ async def trigger_auto_update(
     background_tasks: BackgroundTasks,
     channel_id: int,
     dataset_id: int,
-    session: AsyncSession = Depends(models.get_session),
 ) -> schemas.AutoUpdateJob:
     """Trigger an auto-update check for a channel dataset.
 
     Creates an auto-update job that checks for changes and reindexes if needed.
     The job runs in the background. Poll the job status to track progress.
     """
-    return await DataSetService(session).trigger_auto_update(
-        background_tasks=background_tasks,
-        channel_id=channel_id,
-        dataset_id=dataset_id,
-        auth_context=SystemUserAuthContext(),
-    )
+    async with get_session_context_manager() as session:
+        return await DataSetService(session).trigger_auto_update(
+            background_tasks=background_tasks,
+            channel_id=channel_id,
+            dataset_id=dataset_id,
+            auth_context=SystemUserAuthContext(),
+        )
 
 
 @router.get(path="/{channel_id}/datasets/{dataset_id}/versions/auto-update-jobs")

--- a/statgpt/admin/services/channel.py
+++ b/statgpt/admin/services/channel.py
@@ -18,6 +18,7 @@ from statgpt.common import utils
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.schemas import AuditActionType, AuditEntityType
 from statgpt.common.services import ChannelSerializer, ChannelService
+from statgpt.common.services.base import DbServiceBase
 from statgpt.common.settings.dial import dial_settings
 from statgpt.common.utils import dial_core_factory
 from statgpt.common.utils.elastic import ElasticSearchFactory
@@ -28,7 +29,9 @@ from .background_tasks import background_task
 _log = logging.getLogger(__name__)
 
 
-class AdminPortalChannelService(ChannelService):
+class AdminPortalChannelService(ChannelService, DbServiceBase):
+    def __init__(self, session=None):
+        DbServiceBase.__init__(self, session)
 
     @staticmethod
     def _parse_integrity_error(
@@ -125,7 +128,7 @@ class AdminPortalChannelService(ChannelService):
         return deleted_item
 
     async def _clear_vector_store(self, channel: models.Channel, auth_context: AuthContext) -> None:
-        vector_store_factory = VectorStoreFactory(session=self._session)
+        vector_store_factory = VectorStoreFactory()
 
         collections = [
             channel.indicator_table_name,
@@ -276,22 +279,28 @@ class AdminPortalChannelService(ChannelService):
         Deduplication is performed based on document content.
         Documents with identical content will be merged.
         """
-        channel = await self.get_model_by_id(channel_id)
-        vector_store_factory = VectorStoreFactory(session=self._session)
+        async with self._scoped_session():
+            channel = await self.get_model_by_id(channel_id)
+            # Extract scalar values while still inside the session scope:
+            available_dims_table = channel.available_dimensions_table_name
+            special_dims_table = channel.special_dimensions_table_name
+            llm_model = channel.llm_model
+
+        vector_store_factory = VectorStoreFactory()
 
         _log.info(f"Deduplicating available_dimensions for channel {channel_id}")
         available_dims_store = await vector_store_factory.get_vector_store(
-            collection_name=channel.available_dimensions_table_name,
+            collection_name=available_dims_table,
             auth_context=auth_context,
-            embedding_model_name=channel.llm_model,
+            embedding_model_name=llm_model,
         )
         await available_dims_store.deduplicate_by_document_content()
 
         _log.info(f"Deduplicating special_dimensions for channel {channel_id}")
         special_dims_store = await vector_store_factory.get_vector_store(
-            collection_name=channel.special_dimensions_table_name,
+            collection_name=special_dims_table,
             auth_context=auth_context,
-            embedding_model_name=channel.llm_model,
+            embedding_model_name=llm_model,
         )
         await special_dims_store.deduplicate_by_document_content()
 
@@ -321,10 +330,10 @@ async def deduplicate_dimensions_in_background_task(
     auth_context: AuthContext,
 ) -> None:
     try:
-        async with models.get_session_context_manager() as session:
-            await AdminPortalChannelService(session).deduplicate_channel_dimensions(
-                channel_id=channel_id,
-                auth_context=auth_context,
-            )
+        service = AdminPortalChannelService()
+        await service.deduplicate_channel_dimensions(
+            channel_id=channel_id,
+            auth_context=auth_context,
+        )
     except Exception:
         _log.exception(f"Failed to deduplicate dimensions for channel {channel_id}")

--- a/statgpt/admin/services/channel.py
+++ b/statgpt/admin/services/channel.py
@@ -8,6 +8,7 @@ import yaml
 from fastapi import BackgroundTasks, HTTPException, status
 from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError, NoResultFound
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.expression import func
 
 import statgpt.common.models as models
@@ -18,7 +19,6 @@ from statgpt.common import utils
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.schemas import AuditActionType, AuditEntityType
 from statgpt.common.services import ChannelSerializer, ChannelService
-from statgpt.common.services.base import DbServiceBase
 from statgpt.common.settings.dial import dial_settings
 from statgpt.common.utils import dial_core_factory
 from statgpt.common.utils.elastic import ElasticSearchFactory
@@ -29,9 +29,9 @@ from .background_tasks import background_task
 _log = logging.getLogger(__name__)
 
 
-class AdminPortalChannelService(ChannelService, DbServiceBase):
-    def __init__(self, session=None):
-        DbServiceBase.__init__(self, session)
+class AdminPortalChannelService(ChannelService):
+    def __init__(self, session: AsyncSession | None = None) -> None:
+        super().__init__(session, None)
 
     @staticmethod
     def _parse_integrity_error(

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -51,7 +51,6 @@ from statgpt.common.vectorstore import VectorStore, VectorStoreFactory
 from .background_tasks import background_task
 from .channel import AdminPortalChannelService as ChannelService
 from .data_source import AdminPortalDataSourceService as DataSourceService
-from .data_source import DataSourceTypeService
 
 _log = logging.getLogger(__name__)
 
@@ -73,8 +72,8 @@ class AutoUpdateChannelResult(NamedTuple):
 
 class AdminPortalDataSetService(DataSetService):
 
-    def __init__(self, session: AsyncSession) -> None:
-        super().__init__(session, None)  # No need for session lock in Admin Portal
+    def __init__(self, session: AsyncSession | None = None) -> None:
+        super().__init__(session, None)
 
     _EXIM_SETTINGS = ExImSettings()
 
@@ -90,7 +89,7 @@ class AdminPortalDataSetService(DataSetService):
         latest_completed_versions: dict[int, LastCompletedVersions],
     ) -> None:
         _log.info("Exporting vector store data...")
-        vector_store_factory = VectorStoreFactory(session=self._session)
+        vector_store_factory = VectorStoreFactory()
 
         # collect last completed version ids
         version_ids: set[int] = set()
@@ -395,7 +394,7 @@ class AdminPortalDataSetService(DataSetService):
         auth_context: AuthContext,
     ) -> None:
         _log.info("Importing vector store data...")
-        vector_store_factory = VectorStoreFactory(session=self._session)
+        vector_store_factory = VectorStoreFactory()
 
         dataset_versions: dict[uuid.UUID, int] = {
             dataset.id_: versions[dataset.id].id for dataset in datasets
@@ -901,7 +900,7 @@ class AdminPortalDataSetService(DataSetService):
         dataset_id: uuid.UUID | None,
         version_ids: list[int] | None,
     ) -> None:
-        vector_store_factory = VectorStoreFactory(session=self._session)
+        vector_store_factory = VectorStoreFactory()
 
         collections = [
             channel.indicator_table_name,
@@ -1711,121 +1710,163 @@ class AdminPortalDataSetService(DataSetService):
         max_n_embeddings: int | None,
         status_on_completion: StatusEnum = StatusEnum.COMPLETED,
     ) -> None:
-        version = await self._get_channel_dataset_version_or_raise(channel_dataset_version_id)
-
-        _log.info(f"Start processing {version}")
         try:
-            if await self._invalid_version_status(version):
-                return
+            # Phase A: DB reads — load entities, convert to schemas/session-independent objects
+            async with self._scoped_session():
+                version = await self._get_channel_dataset_version_or_raise(
+                    channel_dataset_version_id
+                )
+                _log.info(f"Start processing {version}")
 
-            await self._update_channel_dataset_version_status(
-                version, new_status=StatusEnum.IN_PROGRESS
-            )
+                if await self._invalid_version_status(version):
+                    return
 
-            channel_dataset = await self._get_channel_dataset_model_or_raise(
-                version.channel_dataset_id
-            )
-            _log.info(
-                f"Processing version(id={version.id}, version={version.version}) of {channel_dataset}"
-            )
-            channel = await ChannelService(self._session).get_model_by_id(
-                channel_dataset.channel_id
-            )
-            db_dataset: models.DataSet = await self.get_model_by_id(channel_dataset.dataset_id)
-            dataset_config = version.resolved_config or db_dataset.details
+                await self._update_channel_dataset_version_status(
+                    version, new_status=StatusEnum.IN_PROGRESS
+                )
 
-            handler_class = await DataSourceTypeService(
-                self._session
-            ).get_data_source_handler_class_by_id(db_dataset.source.type_id)
-            config = handler_class.parse_config(db_dataset.source.details)
+                channel_dataset = await self._get_channel_dataset_model_or_raise(
+                    version.channel_dataset_id
+                )
+                channel_dataset_id = channel_dataset.id
+                channel_id = channel_dataset.channel_id
+                dataset_id = channel_dataset.dataset_id
+                _log.info(
+                    f"Processing version(id={version.id}, version={version.version})"
+                    f" of {channel_dataset}"
+                )
 
-            handler = handler_class(config=config)
+                db_dataset: models.DataSet = await self.get_model_by_id(dataset_id)
+                version_schema = schemas.ChannelDatasetVersion.model_validate(
+                    version, from_attributes=True
+                )
+                dataset_config = version_schema.resolved_config or db_dataset.details
+                entity_id = db_dataset.id_
+                dataset_title = db_dataset.title
+
+                handler = await self._get_handler(db_dataset.source_id)
+
+            # Phase B: Network I/O — no session needed
             dataset = await handler.get_dataset(
-                entity_id=db_dataset.id_,
-                title=db_dataset.title,
+                entity_id=entity_id,
+                title=dataset_title,
                 config=dataset_config,
                 auth_context=auth_context,
-                allow_offline=False,  # Unable to reindex offline dataset
+                allow_offline=False,
             )
 
-            # Extract and store resolved config from loaded dataset
             resolved_config = dataset.get_resolved_config()
-            await self._set_resolved_config(version, resolved_config)
 
+            hashes_to_store: tuple[str, str, dict, _DataHashes] | None = None
             if reindex_dimensions or (reindex_indicators and not harmonize_indicator):
                 config_hash = dataset.config.indexing_hash
                 structure_hash, meta = await handler.get_structure_hash_and_metadata(
                     dataset_config=dataset_config, auth_context=auth_context
                 )
                 data_hashes = await self._get_data_hashes(dataset, auth_context, allow_cached=True)
-                await self._set_version_hashes_and_metadata(
-                    version, config_hash, structure_hash, meta, data_hashes
-                )
+                hashes_to_store = (config_hash, structure_hash, meta, data_hashes)
 
-            vector_store_factory = VectorStoreFactory(session=self._session)
-
-            if reindex_dimensions:
-                await self._index_available_dimensions(
-                    version=version,
-                    channel=channel,
-                    dataset=dataset,
-                    db_dataset=db_dataset,
-                    vector_store_factory=vector_store_factory,
-                    max_n_embeddings=max_n_embeddings,
-                    auth_context=auth_context,
+            # Phase C: DB writes — store resolved config, hashes, metadata
+            async with self._scoped_session():
+                version = await self._get_channel_dataset_version_or_raise(
+                    channel_dataset_version_id
                 )
+                await self._set_resolved_config(version, resolved_config)
 
-            if reindex_indicators:
-                indexing_stats = await self._index_channel_indicators(
-                    channel=channel,
-                    db_dataset=db_dataset,
-                    version=version,
-                    version_ids=version_ids,
-                    harmonize_indicator=harmonize_indicator,
-                    max_n_embeddings=max_n_embeddings,
-                    vector_store_factory=vector_store_factory,
-                    dataset=dataset,
-                    auth_context=auth_context,
-                )
-                if indexing_stats:
-                    await self._set_indexing_stats(version, indexing_stats)
+                if hashes_to_store is not None:
+                    await self._set_version_hashes_and_metadata(version, *hashes_to_store)
 
-            await self._update_channel_dataset_version_status(
-                version, new_status=status_on_completion
-            )
-            if status_on_completion is StatusEnum.COMPLETED:
-                await self._update_channel_dataset_status(
-                    channel_dataset, new_status=StatusEnum.QUEUED
+            # Phase D: Vector indexing — session actively used for batch inserts
+            async with self._scoped_session():
+                version = await self._get_channel_dataset_version_or_raise(
+                    channel_dataset_version_id
                 )
-            _log.info(f'Finished processing {version} of {channel_dataset}')
+                channel = await ChannelService(self._session).get_model_by_id(channel_id)
+                db_dataset = await self.get_model_by_id(dataset_id)
+
+                vector_store_factory = VectorStoreFactory()
+
+                if reindex_dimensions:
+                    await self._index_available_dimensions(
+                        version=version,
+                        channel=channel,
+                        dataset=dataset,
+                        db_dataset=db_dataset,
+                        vector_store_factory=vector_store_factory,
+                        max_n_embeddings=max_n_embeddings,
+                        auth_context=auth_context,
+                    )
+
+                if reindex_indicators:
+                    indexing_stats = await self._index_channel_indicators(
+                        channel=channel,
+                        db_dataset=db_dataset,
+                        version=version,
+                        version_ids=version_ids,
+                        harmonize_indicator=harmonize_indicator,
+                        max_n_embeddings=max_n_embeddings,
+                        vector_store_factory=vector_store_factory,
+                        dataset=dataset,
+                        auth_context=auth_context,
+                    )
+                    if indexing_stats:
+                        await self._set_indexing_stats(version, indexing_stats)
+
+            # Phase E: Status update
+            async with self._scoped_session():
+                version = await self._get_channel_dataset_version_or_raise(
+                    channel_dataset_version_id
+                )
+                await self._update_channel_dataset_version_status(
+                    version, new_status=status_on_completion
+                )
+                if status_on_completion is StatusEnum.COMPLETED:
+                    channel_dataset = await self._get_channel_dataset_model_or_raise(
+                        channel_dataset_id
+                    )
+                    await self._update_channel_dataset_status(
+                        channel_dataset, new_status=StatusEnum.QUEUED
+                    )
+                _log.info(
+                    f'Finished processing version_id={channel_dataset_version_id}'
+                    f' of channel_dataset_id={channel_dataset_id}'
+                )
         except Exception as e:
-            _log.exception(f"Failed to reindex {version}")
-            await self._update_channel_dataset_version_status(
-                version, new_status=StatusEnum.FAILED, reason_for_failure=str(e)
-            )
+            _log.exception(f"Failed to reindex version_id={channel_dataset_version_id}")
+            async with self._scoped_session():
+                version = await self._get_channel_dataset_version_or_raise(
+                    channel_dataset_version_id
+                )
+                await self._update_channel_dataset_version_status(
+                    version, new_status=StatusEnum.FAILED, reason_for_failure=str(e)
+                )
 
     async def clear_channel_dataset_data_in_background(
         self, channel_dataset_id: int, auth_context: AuthContext
     ) -> None:
-        channel_dataset = await self._get_channel_dataset_model_or_raise(channel_dataset_id)
-
-        _log.info(f"Clear data after reindexing {channel_dataset}")
+        _log.info(f"Clear data after reindexing channel_dataset_id={channel_dataset_id}")
         try:
-            await self._update_channel_dataset_status(
-                channel_dataset, new_status=StatusEnum.IN_PROGRESS
-            )
+            async with self._scoped_session():
+                channel_dataset = await self._get_channel_dataset_model_or_raise(channel_dataset_id)
+                await self._update_channel_dataset_status(
+                    channel_dataset, new_status=StatusEnum.IN_PROGRESS
+                )
 
-            # In case of failure, we clear the data that might have been partially indexed
-            # In case of success, we clear previous version data to save space
-            await self.clear_channel_dataset_versions_data(
-                channel_dataset.channel_id, channel_dataset.dataset_id, auth_context
-            )
-            await self._update_channel_dataset_status(
-                channel_dataset, new_status=StatusEnum.COMPLETED
-            )
+                await self.clear_channel_dataset_versions_data(
+                    channel_dataset.channel_id, channel_dataset.dataset_id, auth_context
+                )
+                await self._update_channel_dataset_status(
+                    channel_dataset, new_status=StatusEnum.COMPLETED
+                )
         except Exception:
-            _log.exception(f"Failed to clear data after reindexing {channel_dataset}")
-            await self._update_channel_dataset_status(channel_dataset, new_status=StatusEnum.FAILED)
+            _log.exception(
+                f"Failed to clear data after reindexing channel_dataset_id={channel_dataset_id}"
+            )
+            async with self._scoped_session():
+                channel_dataset = await self._get_channel_dataset_model_or_raise(channel_dataset_id)
+                await self._update_channel_dataset_status(
+                    channel_dataset, new_status=StatusEnum.FAILED
+                )
 
     async def _get_deduplication_status_by_versions(
         self,
@@ -1949,7 +1990,7 @@ class AdminPortalDataSetService(DataSetService):
     ) -> schemas.ChannelIndexStatus:
         """Checks index status for channel"""
         channel = await ChannelService(self._session).get_model_by_id(channel_id)
-        vector_store_factory = VectorStoreFactory(session=self._session)
+        vector_store_factory = VectorStoreFactory()
 
         available_dims_store = await vector_store_factory.get_vector_store(
             collection_name=channel.available_dimensions_table_name,
@@ -2146,6 +2187,17 @@ class AdminPortalDataSetService(DataSetService):
             parts.append(part)
         return ", ".join(parts)
 
+    async def _get_auto_update_job_or_raise(self, auto_update_job_id: int) -> models.AutoUpdateJob:
+        job: models.AutoUpdateJob | None = await self._session.get(
+            models.AutoUpdateJob, auto_update_job_id
+        )
+        if job is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Auto-update job {auto_update_job_id} not found",
+            )
+        return job
+
     async def _set_auto_update_job_status(
         self,
         job: models.AutoUpdateJob,
@@ -2311,38 +2363,47 @@ class AdminPortalDataSetService(DataSetService):
         auth_context: AuthContext,
     ) -> None:
         """Process an auto-update job in the background."""
-        job: models.AutoUpdateJob | None = await self._session.get(
-            models.AutoUpdateJob, auto_update_job_id
-        )
-        if job is None:
-            _log.error(f"Auto-update job {auto_update_job_id} not found")
-            return
-
         try:
-            await self._set_auto_update_job_status(job=job, status=StatusEnum.IN_PROGRESS)
-
-            channel_dataset = await self._get_channel_dataset_model_or_raise(job.channel_dataset_id)
-            await self._session.refresh(channel_dataset, attribute_names=["channel", "dataset"])
-
-            if await self._is_indexing_in_progress(channel_dataset.id):
-                msg = f"Channel dataset {channel_dataset.id} is currently being indexed."
-                await self._set_auto_update_job_status(
-                    job=job, status=StatusEnum.FAILED, reason_for_failure=msg
+            # Phase A: DB reads — load job, channel_dataset, check state
+            async with self._scoped_session():
+                job: models.AutoUpdateJob | None = await self._session.get(
+                    models.AutoUpdateJob, auto_update_job_id
                 )
-                return
+                if job is None:
+                    _log.error(f"Auto-update job {auto_update_job_id} not found")
+                    return
 
-            last_completed = await self._get_last_completed_version(channel_dataset.id)
-            if last_completed is None:
-                await self._set_auto_update_job_status(
-                    job, StatusEnum.COMPLETED, result=schemas.AutoUpdateResult.NO_COMPLETED_VERSION
-                )
-                return
+                await self._set_auto_update_job_status(job=job, status=StatusEnum.IN_PROGRESS)
 
-            job.base_version_id = last_completed.id
+                channel_dataset_id = job.channel_dataset_id
+                channel_dataset = await self._get_channel_dataset_model_or_raise(channel_dataset_id)
 
-            handler = await self._get_handler(channel_dataset.dataset.source_id)
+                if await self._is_indexing_in_progress(channel_dataset_id):
+                    msg = f"Channel dataset {channel_dataset_id} is currently being indexed."
+                    await self._set_auto_update_job_status(
+                        job=job, status=StatusEnum.FAILED, reason_for_failure=msg
+                    )
+                    return
+
+                last_completed = await self._get_last_completed_version(channel_dataset_id)
+                if last_completed is None:
+                    await self._set_auto_update_job_status(
+                        job,
+                        StatusEnum.COMPLETED,
+                        result=schemas.AutoUpdateResult.NO_COMPLETED_VERSION,
+                    )
+                    return
+
+                job.base_version_id = last_completed.id
+
+                db_dataset: models.DataSet = await self.get_model_by_id(channel_dataset.dataset_id)
+                handler = await self._get_handler(db_dataset.source_id)
+                dataset_details = db_dataset.details
+
+            # Phase B: Network I/O — no session needed
+            # last_completed is a schema, so resolved_config is accessible without a session
             details, new_resolved_config = await handler.resolve_config(
-                config=channel_dataset.dataset.details,
+                config=dataset_details,
                 previous_resolved_config=last_completed.resolved_config,
                 auth_context=auth_context,
             )
@@ -2351,13 +2412,15 @@ class AdminPortalDataSetService(DataSetService):
                 new_resolved_config, auth_context=auth_context, mode="return"
             )
             if not validation_result.is_valid:
-                await self._set_auto_update_job_status(
-                    job=job,
-                    status=StatusEnum.COMPLETED,
-                    result=schemas.AutoUpdateResult.CONFIG_INCOMPATIBLE,
-                    details=details,
-                    reason_for_failure="; ".join(validation_result.errors),
-                )
+                async with self._scoped_session():
+                    job = await self._get_auto_update_job_or_raise(auto_update_job_id)
+                    await self._set_auto_update_job_status(
+                        job=job,
+                        status=StatusEnum.COMPLETED,
+                        result=schemas.AutoUpdateResult.CONFIG_INCOMPATIBLE,
+                        details=details,
+                        reason_for_failure="; ".join(validation_result.errors),
+                    )
                 return
 
             structure_hash, structure_meta = await handler.get_structure_hash_and_metadata(
@@ -2372,42 +2435,57 @@ class AdminPortalDataSetService(DataSetService):
                 details += f" Structure has changed: {structure_changes}."
                 data_changed = None
             else:
-                data_changed, data_details = await self._get_data_changed(
-                    handler, channel_dataset, new_resolved_config, last_completed, auth_context
-                )
+                async with self._scoped_session():
+                    channel_dataset = await self._get_channel_dataset_model_or_raise(
+                        channel_dataset_id
+                    )
+                    await self._session.refresh(
+                        channel_dataset, attribute_names=["channel", "dataset"]
+                    )
+                    data_changed, data_details = await self._get_data_changed(
+                        handler, channel_dataset, new_resolved_config, last_completed, auth_context
+                    )
                 details += f" Structure has not changed. {data_details}"
 
-            if structure_changed or data_changed:
-                await self._trigger_auto_update_reindex(
-                    job, channel_dataset, new_resolved_config, details, auth_context
-                )
-            elif new_resolved_config != last_completed.resolved_config:
-                # Config changed (e.g., URN version updated) but data unchanged
-                # Create a new version with updated config without reindexing
-                new_version = await self._create_config_only_version(
-                    channel_dataset, last_completed, new_resolved_config
-                )
-                job.created_version_id = new_version.id
-                await self._set_auto_update_job_status(
-                    job,
-                    StatusEnum.COMPLETED,
-                    details=details,
-                    result=schemas.AutoUpdateResult.CONFIG_UPDATED,
-                )
-            else:
-                await self._set_auto_update_job_status(
-                    job,
-                    StatusEnum.COMPLETED,
-                    details=details,
-                    result=schemas.AutoUpdateResult.NO_CHANGES,
-                )
+            # Phase C: DB writes — trigger reindex or update status
+            async with self._scoped_session():
+                job = await self._get_auto_update_job_or_raise(auto_update_job_id)
+                channel_dataset = await self._get_channel_dataset_model_or_raise(channel_dataset_id)
+                await self._session.refresh(channel_dataset, attribute_names=["channel", "dataset"])
+                job.base_version_id = last_completed.id
+
+                if structure_changed or data_changed:
+                    await self._trigger_auto_update_reindex(
+                        job, channel_dataset, new_resolved_config, details, auth_context
+                    )
+                elif new_resolved_config != last_completed.resolved_config:
+                    new_version = await self._create_config_only_version(
+                        channel_dataset, last_completed, new_resolved_config
+                    )
+                    job.created_version_id = new_version.id
+                    await self._set_auto_update_job_status(
+                        job,
+                        StatusEnum.COMPLETED,
+                        details=details,
+                        result=schemas.AutoUpdateResult.CONFIG_UPDATED,
+                    )
+                else:
+                    await self._set_auto_update_job_status(
+                        job,
+                        StatusEnum.COMPLETED,
+                        details=details,
+                        result=schemas.AutoUpdateResult.NO_CHANGES,
+                    )
 
         except Exception as e:
             _log.exception(f"Failed to process auto-update job {auto_update_job_id}")
-            await self._session.rollback()
-            job.status = StatusEnum.FAILED
-            job.reason_for_failure = str(e)
-            await self._session.commit()
+            async with self._scoped_session():
+                await self._session.rollback()
+                job = await self._session.get(models.AutoUpdateJob, auto_update_job_id)
+                if job is not None:
+                    job.status = StatusEnum.FAILED
+                    job.reason_for_failure = str(e)
+                    await self._session.commit()
 
 
 @background_task
@@ -2417,12 +2495,11 @@ async def auto_update_in_background_task(
 ) -> None:
     """Background task wrapper for auto-update job processing."""
     try:
-        async with models.get_session_context_manager() as session:
-            service = AdminPortalDataSetService(session)
-            await service.process_auto_update_job(
-                auto_update_job_id=auto_update_job_id,
-                auth_context=auth_context,
-            )
+        service = AdminPortalDataSetService()
+        await service.process_auto_update_job(
+            auto_update_job_id=auto_update_job_id,
+            auth_context=auth_context,
+        )
     except Exception as e:
         _log.exception(e)
 
@@ -2439,18 +2516,17 @@ async def reload_indicators_in_background_task(
     status_on_completion: StatusEnum = StatusEnum.COMPLETED,
 ) -> None:
     try:
-        async with models.get_session_context_manager() as session:
-            service = AdminPortalDataSetService(session)
-            await service.reload_channel_dataset_in_background(
-                channel_dataset_version_id=channel_dataset_version_id,
-                version_ids=version_ids,
-                reindex_indicators=reindex_indicators,
-                harmonize_indicator=harmonize_indicator,
-                reindex_dimensions=reindex_dimensions,
-                auth_context=auth_context,
-                max_n_embeddings=max_n_embeddings,
-                status_on_completion=status_on_completion,
-            )
+        service = AdminPortalDataSetService()
+        await service.reload_channel_dataset_in_background(
+            channel_dataset_version_id=channel_dataset_version_id,
+            version_ids=version_ids,
+            reindex_indicators=reindex_indicators,
+            harmonize_indicator=harmonize_indicator,
+            reindex_dimensions=reindex_dimensions,
+            auth_context=auth_context,
+            max_n_embeddings=max_n_embeddings,
+            status_on_completion=status_on_completion,
+        )
     except Exception as e:
         _log.exception(e)
 
@@ -2460,11 +2536,10 @@ async def clear_channel_dataset_data_in_background_task(
     channel_dataset_id: int, auth_context: AuthContext
 ) -> None:
     try:
-        async with models.get_session_context_manager() as session:
-            service = AdminPortalDataSetService(session)
-            await service.clear_channel_dataset_data_in_background(
-                channel_dataset_id=channel_dataset_id,
-                auth_context=auth_context,
-            )
+        service = AdminPortalDataSetService()
+        await service.clear_channel_dataset_data_in_background(
+            channel_dataset_id=channel_dataset_id,
+            auth_context=auth_context,
+        )
     except Exception as e:
         _log.exception(e)

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -1033,17 +1033,6 @@ class AdminPortalDataSetService(DataSetService):
             and latest_version.preprocessing_status not in StatusEnum.final_statuses()
         )
 
-    async def _set_indexing_stats(
-        self,
-        item: models.ChannelDatasetVersion,
-        indexing_stats: dict,
-    ) -> None:
-        """Merges indexing statistics into the version's indexing_stats JSONB field."""
-        item.indexing_stats = {**(item.indexing_stats or {}), **indexing_stats}
-        item.updated_at = func.now()
-        await self._session.commit()
-        await self._session.refresh(item)
-
     async def rollback_channel_dataset_to_previous_version(
         self, channel_id: int, dataset_id: int
     ) -> schemas.ChannelDatasetVersion:
@@ -1503,33 +1492,30 @@ class AdminPortalDataSetService(DataSetService):
     @staticmethod
     async def _run_semantic_indexer(
         dataset: base.DataSet,
-        db_dataset: models.DataSet,
+        source_id: int,
         vector_store: VectorStore,
-        version: models.ChannelDatasetVersion,
+        version_id: int,
         max_n_embeddings: int | None,
         auth_context: AuthContext,
-    ):
+    ) -> None:
         indicators = await dataset.get_indicators(auth_context=auth_context, allow_cached=True)
         _log.info(f"Loaded {len(indicators)} indicators.")
         if max_n_embeddings:
             indicators = indicators[:max_n_embeddings]  # for debug
 
         documents = (
-            i.to_document({IndicatorDocumentMetadataFields.DATA_SOURCE_ID: db_dataset.source_id})
+            i.to_document({IndicatorDocumentMetadataFields.DATA_SOURCE_ID: source_id})
             for i in indicators
         )
 
-        await vector_store.add_documents(
-            documents, dataset_id=db_dataset.id_, version_id=version.id
-        )
+        await vector_store.add_documents(documents, dataset_id=dataset.id, version_id=version_id)
 
     @staticmethod
     async def _run_hybrid_indexer(
-        channel: models.Channel,
-        channel_config: schemas.ChannelConfig,
+        channel: schemas.Channel,
         vector_store: VectorStore,
         dataset: base.DataSet,
-        version: models.ChannelDatasetVersion,
+        version_id: int,
         version_ids: set[int],
         harmonize_indicator: bool,
         max_n_embeddings: int | None,
@@ -1541,7 +1527,7 @@ class AdminPortalDataSetService(DataSetService):
         indicators_index = await ElasticSearchFactory.get_index(
             channel.indicators_index_name, allow_creation=True
         )
-        if (data_query_config := channel_config.data_query) is None:
+        if (data_query_config := channel.details.data_query) is None:
             raise ValueError(f"No data query configured for the channel {channel}")
         config = data_query_config.details.hybrid_search_config or HybridSearchConfig()
 
@@ -1556,7 +1542,7 @@ class AdminPortalDataSetService(DataSetService):
         )
         return await indexer.index(
             dataset,
-            version_id=version.id,
+            version_id=version_id,
             version_ids=version_ids,
             max_n_indicators=max_n_embeddings,
             auth_context=auth_context,
@@ -1564,14 +1550,14 @@ class AdminPortalDataSetService(DataSetService):
 
     @staticmethod
     async def _index_available_dimensions(
-        version: models.ChannelDatasetVersion,
-        channel: models.Channel,
+        version_id: int,
+        channel: schemas.Channel,
         dataset: base.DataSet,
-        db_dataset: models.DataSet,
+        source_id: int,
         vector_store_factory: VectorStoreFactory,
         max_n_embeddings: int | None,
         auth_context: AuthContext,
-    ):
+    ) -> None:
         vector_store = await vector_store_factory.get_vector_store(
             collection_name=channel.available_dimensions_table_name,
             embedding_model_name=channel.llm_model,
@@ -1590,11 +1576,9 @@ class AdminPortalDataSetService(DataSetService):
             for value in category_values:
                 document = value.to_document()
                 field_name = DimensionValueDocumentMetadataFields.DATA_SOURCE_ID
-                document.metadata[field_name] = db_dataset.source_id
+                document.metadata[field_name] = source_id
                 documents.append(document)
-        await vector_store.add_documents(
-            documents, dataset_id=db_dataset.id_, version_id=version.id
-        )
+        await vector_store.add_documents(documents, dataset_id=dataset.id, version_id=version_id)
 
         # ~~~~~ Special dimensions ~~~~~
 
@@ -1615,19 +1599,18 @@ class AdminPortalDataSetService(DataSetService):
             for value in category_values:
                 document = value.to_document()
                 field_name = SpecialDimensionValueDocumentMetadataFields.DATA_SOURCE_ID
-                document.metadata[field_name] = db_dataset.source_id
+                document.metadata[field_name] = source_id
                 field_name = SpecialDimensionValueDocumentMetadataFields.PROCESSOR_ID
                 document.metadata[field_name] = processor_id
                 documents.append(document)
-        await vector_store.add_documents(
-            documents, dataset_id=db_dataset.id_, version_id=version.id
-        )
+        await vector_store.add_documents(documents, dataset_id=dataset.id, version_id=version_id)
 
     async def _index_channel_indicators(
         self,
-        channel: models.Channel,
-        db_dataset: models.DataSet,
-        version: models.ChannelDatasetVersion,
+        channel: schemas.Channel,
+        source_id: int,
+        version_id: int,
+        channel_dataset_id: int,
         version_ids: set[int] | None,
         harmonize_indicator: bool,
         max_n_embeddings: int | None,
@@ -1641,30 +1624,28 @@ class AdminPortalDataSetService(DataSetService):
             auth_context=auth_context,
         )
 
-        channel_config = schemas.ChannelConfig.model_validate(channel.details)
-
-        if channel_config.data_query is None:
-            _log.info(f"No data query found for {version}, skipping indexing")
+        if channel.details.data_query is None:
+            _log.info(f"No data query found for version_id={version_id}, skipping indexing")
             return None
 
-        indexer_version = channel_config.data_query.details.indexer_version
+        indexer_version = channel.details.data_query.details.indexer_version
         _log.info(f"Indexer version: {indexer_version}")
         if indexer_version == schemas.IndexerVersion.hybrid:
             if version_ids is None:
-                res = await self.get_latest_successful_dataset_versions_for_channel(channel.id)
-                version_ids = {
-                    v.last_completed_version.version_data_id
-                    for v in res.values()
-                    if v.last_completed_version is not None
-                    and v.last_completed_version.channel_dataset_id != version.channel_dataset_id
-                }
+                async with self._scoped_session():
+                    res = await self.get_latest_successful_dataset_versions_for_channel(channel.id)
+                    version_ids = {
+                        v.last_completed_version.version_data_id
+                        for v in res.values()
+                        if v.last_completed_version is not None
+                        and v.last_completed_version.channel_dataset_id != channel_dataset_id
+                    }
 
             return await self._run_hybrid_indexer(
                 channel=channel,
-                channel_config=channel_config,
                 vector_store=vector_store,
                 dataset=dataset,
-                version=version,
+                version_id=version_id,
                 version_ids=version_ids,
                 harmonize_indicator=harmonize_indicator,
                 max_n_embeddings=max_n_embeddings,
@@ -1672,7 +1653,7 @@ class AdminPortalDataSetService(DataSetService):
             )
         elif indexer_version == schemas.IndexerVersion.semantic:
             await self._run_semantic_indexer(
-                dataset, db_dataset, vector_store, version, max_n_embeddings, auth_context
+                dataset, source_id, vector_store, version_id, max_n_embeddings, auth_context
             )
             return None
         else:
@@ -1737,11 +1718,10 @@ class AdminPortalDataSetService(DataSetService):
                 )
 
                 db_dataset: models.DataSet = await self.get_model_by_id(dataset_id)
-                version_schema = schemas.ChannelDatasetVersion.model_validate(
-                    version, from_attributes=True
-                )
-                dataset_config = version_schema.resolved_config or db_dataset.details
+                channel = await ChannelService(self._session).get_schema_by_id(channel_id)
+                dataset_config = version.resolved_config or db_dataset.details
                 entity_id = db_dataset.id_
+                source_id = db_dataset.source_id
                 dataset_title = db_dataset.title
 
                 handler = await self._get_handler(db_dataset.source_id)
@@ -1776,50 +1756,46 @@ class AdminPortalDataSetService(DataSetService):
                 if hashes_to_store is not None:
                     await self._set_version_hashes_and_metadata(version, *hashes_to_store)
 
-            # Phase D: Vector indexing — session actively used for batch inserts
+            # Phase D: Vector indexing — no DB session needed, vector stores manage their own connections
+            vector_store_factory = VectorStoreFactory()
+            indexing_stats: dict | None = None
+
+            if reindex_dimensions:
+                await self._index_available_dimensions(
+                    version_id=channel_dataset_version_id,
+                    channel=channel,
+                    dataset=dataset,
+                    source_id=source_id,
+                    vector_store_factory=vector_store_factory,
+                    max_n_embeddings=max_n_embeddings,
+                    auth_context=auth_context,
+                )
+
+            if reindex_indicators:
+                indexing_stats = await self._index_channel_indicators(
+                    channel=channel,
+                    source_id=source_id,
+                    version_id=channel_dataset_version_id,
+                    channel_dataset_id=channel_dataset_id,
+                    version_ids=version_ids,
+                    harmonize_indicator=harmonize_indicator,
+                    max_n_embeddings=max_n_embeddings,
+                    vector_store_factory=vector_store_factory,
+                    dataset=dataset,
+                    auth_context=auth_context,
+                )
+
+            # Phase E: Persist indexing stats and update status
             async with self._scoped_session():
                 version = await self._get_channel_dataset_version_or_raise(
                     channel_dataset_version_id
                 )
-                channel = await ChannelService(self._session).get_model_by_id(channel_id)
-                db_dataset = await self.get_model_by_id(dataset_id)
-
-                vector_store_factory = VectorStoreFactory()
-
-                if reindex_dimensions:
-                    await self._index_available_dimensions(
-                        version=version,
-                        channel=channel,
-                        dataset=dataset,
-                        db_dataset=db_dataset,
-                        vector_store_factory=vector_store_factory,
-                        max_n_embeddings=max_n_embeddings,
-                        auth_context=auth_context,
-                    )
-
-                if reindex_indicators:
-                    indexing_stats = await self._index_channel_indicators(
-                        channel=channel,
-                        db_dataset=db_dataset,
-                        version=version,
-                        version_ids=version_ids,
-                        harmonize_indicator=harmonize_indicator,
-                        max_n_embeddings=max_n_embeddings,
-                        vector_store_factory=vector_store_factory,
-                        dataset=dataset,
-                        auth_context=auth_context,
-                    )
-                    if indexing_stats:
-                        await self._set_indexing_stats(version, indexing_stats)
-
-            # Phase E: Status update
-            async with self._scoped_session():
-                version = await self._get_channel_dataset_version_or_raise(
-                    channel_dataset_version_id
-                )
+                if indexing_stats:
+                    version.indexing_stats = {**(version.indexing_stats or {}), **indexing_stats}
                 await self._update_channel_dataset_version_status(
                     version, new_status=status_on_completion
                 )
+
                 if status_on_completion is StatusEnum.COMPLETED:
                     channel_dataset = await self._get_channel_dataset_model_or_raise(
                         channel_dataset_id
@@ -2477,7 +2453,6 @@ class AdminPortalDataSetService(DataSetService):
         except Exception as e:
             _log.exception(f"Failed to process auto-update job {auto_update_job_id}")
             async with self._scoped_session():
-                await self._session.rollback()
                 job = await self._session.get(models.AutoUpdateJob, auto_update_job_id)
                 if job is not None:
                     job.status = StatusEnum.FAILED

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -2192,10 +2192,7 @@ class AdminPortalDataSetService(DataSetService):
             models.AutoUpdateJob, auto_update_job_id
         )
         if job is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Auto-update job {auto_update_job_id} not found",
-            )
+            raise RuntimeError(f"Auto-update job {auto_update_job_id} not found")
         return job
 
     async def _set_auto_update_job_status(

--- a/statgpt/app/services/chat_facade.py
+++ b/statgpt/app/services/chat_facade.py
@@ -199,9 +199,7 @@ class ChannelServiceFacade(DbServiceBase):
 
     async def _get_indicators_vector_store(self, auth_context: AuthContext) -> VectorStore:
         with debug_timer("chat_facade._get_indicators_vector_store"):
-            vector_store_factory = VectorStoreFactory(
-                session=self._session, session_lock=self._session_lock
-            )
+            vector_store_factory = VectorStoreFactory()
             vector_store = await vector_store_factory.get_vector_store(
                 collection_name=self._channel.indicator_table_name,
                 embedding_model_name=self._channel.llm_model,
@@ -211,9 +209,7 @@ class ChannelServiceFacade(DbServiceBase):
 
     async def _get_dimensions_vector_store(self, auth_context: AuthContext) -> VectorStore:
         with debug_timer("chat_facade._get_dimensions_vector_store"):
-            vector_store_factory = VectorStoreFactory(
-                session=self._session, session_lock=self._session_lock
-            )
+            vector_store_factory = VectorStoreFactory()
             vector_store = await vector_store_factory.get_vector_store(
                 collection_name=self._channel.available_dimensions_table_name,
                 embedding_model_name=self._channel.llm_model,
@@ -223,9 +219,7 @@ class ChannelServiceFacade(DbServiceBase):
 
     async def _get_special_dimensions_vector_store(self, auth_context: AuthContext) -> VectorStore:
         with debug_timer("chat_facade._get_special_dimensions_vector_store"):
-            vector_store_factory = VectorStoreFactory(
-                session=self._session, session_lock=self._session_lock
-            )
+            vector_store_factory = VectorStoreFactory()
             vector_store = await vector_store_factory.get_vector_store(
                 collection_name=self._channel.special_dimensions_table_name,
                 embedding_model_name=self._channel.llm_model,

--- a/statgpt/common/config/logging.py
+++ b/statgpt/common/config/logging.py
@@ -35,7 +35,7 @@ class LoggingConfig:
         for name in ["statgpt", "statgpt-ml", "__main__"]:
             logging.getLogger(name).setLevel(cls.LOGGING_SETTINGS.level)
 
-        for name in ["common.models.database"]:
+        for name in ["statgpt.common.models.database"]:
             logging.getLogger(name).setLevel(cls.LOGGING_SETTINGS.level_db)
 
         for name in ["uvicorn", "uvicorn.error", "uvicorn.access"]:

--- a/statgpt/common/models/database.py
+++ b/statgpt/common/models/database.py
@@ -244,6 +244,13 @@ class ReadOnlySessionMakerSingleton:
 
 # Dependency
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    """Yield a database session for use as a FastAPI dependency.
+
+    WARNING: When used with FastAPI's Depends(), this session stays open until
+    ALL BackgroundTasks complete — not just until the response is sent.
+    For endpoints that schedule background tasks, use get_session_context_manager()
+    instead to avoid holding connections for the duration of long-running tasks.
+    """
     _log.debug("get_session: Acquiring non-expiring session")
     session_maker = await SessionMakerSingleton.get_or_create()
     async with session_maker() as session:

--- a/statgpt/common/schemas/channel.py
+++ b/statgpt/common/schemas/channel.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, Field
 
+from statgpt.common.settings.elastic import ElasticSearchSettings
+
 from .auditable import Auditable
 from .base import BaseYamlModel, DbDefaultBase
 from .enums import ChannelIndexStatusScope, LocaleEnum
@@ -19,6 +21,8 @@ from .tools import (
     WebSearchAgentTool,
     WebSearchTool,
 )
+
+_elasticsearch_settings = ElasticSearchSettings()
 
 
 class SupremeAgentConfig(BaseYamlModel):
@@ -221,6 +225,26 @@ class Channel(DbDefaultBase, ChannelBase, Auditable):
 
     def get_item_id(self) -> int:
         return self.id
+
+    @property
+    def indicator_table_name(self) -> str:
+        return f"Indicators_{self.id}"
+
+    @property
+    def available_dimensions_table_name(self) -> str:
+        return f"AvailableDimensions_{self.id}"
+
+    @property
+    def special_dimensions_table_name(self) -> str:
+        return f"SpecialDimensions_{self.id}"
+
+    @property
+    def matching_index_name(self) -> str:
+        return f"{_elasticsearch_settings.matching_index}_{self.id}"
+
+    @property
+    def indicators_index_name(self) -> str:
+        return f"{_elasticsearch_settings.indicators_index}_{self.id}"
 
 
 class DeduplicationStatus(BaseModel):

--- a/statgpt/common/services/base.py
+++ b/statgpt/common/services/base.py
@@ -14,6 +14,7 @@ class DbServiceBase:
         session_lock: asyncio.Lock | None = None,
     ) -> None:
         self.__session = session
+        self._scoped_session_active = False
         if session_lock is None:
             self._session_lock = asyncio.Lock()
         else:
@@ -49,12 +50,21 @@ class DbServiceBase:
         (e.g. VectorStoreFactory) works transparently.
         When a session was provided, yields it directly.
         """
+        if self._scoped_session_active:
+            raise RuntimeError(
+                "Concurrent _scoped_session() calls on the same instance "
+                "are not supported. Create a separate service instance per "
+                "concurrent coroutine, or provide a session at construction "
+                "time."
+            )
         if self.__session is not None:
             yield self._session
         else:
+            self._scoped_session_active = True
             async with get_session_context_manager() as session:
                 self.__session = session
                 try:
                     yield session
                 finally:
                     self.__session = None
+                    self._scoped_session_active = False

--- a/statgpt/common/services/base.py
+++ b/statgpt/common/services/base.py
@@ -1,19 +1,60 @@
 import asyncio
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from statgpt.common.models import get_session_context_manager
+
 
 class DbServiceBase:
-    def __init__(self, session: AsyncSession, session_lock: asyncio.Lock | None = None) -> None:
-        self._session = session
+    def __init__(
+        self,
+        session: AsyncSession | None = None,
+        session_lock: asyncio.Lock | None = None,
+    ) -> None:
+        self.__session = session
         if session_lock is None:
             self._session_lock = asyncio.Lock()
         else:
             self._session_lock = session_lock
 
+    @property
+    def _session(self) -> AsyncSession:
+        """Return the current session, raising if none is set.
+
+        Always valid inside a ``_scoped_session()`` block or when the
+        service was constructed with a real session.
+        """
+        if self.__session is None:
+            raise RuntimeError(
+                "Session is not available. "
+                "Use _scoped_session() or provide a session at construction time."
+            )
+        return self.__session
+
     @asynccontextmanager
-    async def _lock_session(self):
+    async def _lock_session(self) -> AsyncIterator[AsyncSession]:
         """Acquire lock and yield session for thread-safe operations."""
         async with self._session_lock:
             yield self._session
+
+    @asynccontextmanager
+    async def _scoped_session(self) -> AsyncIterator[AsyncSession]:
+        """Yield a short-lived session.
+
+        When no session was provided at construction time, creates a new
+        short-lived session via ``get_session_context_manager()`` and
+        temporarily sets self._session so that downstream code
+        (e.g. VectorStoreFactory) works transparently.
+        When a session was provided, yields it directly.
+        """
+        if self.__session is not None:
+            yield self._session
+        else:
+            async with get_session_context_manager() as session:
+                self.__session = session
+                try:
+                    yield session
+                finally:
+                    self.__session = None

--- a/statgpt/common/services/channel.py
+++ b/statgpt/common/services/channel.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -6,6 +8,8 @@ from sqlalchemy.sql.expression import func
 import statgpt.common.models as models
 import statgpt.common.schemas as schemas
 
+from .base import DbServiceBase
+
 
 class ChannelSerializer:
     @staticmethod
@@ -13,9 +17,11 @@ class ChannelSerializer:
         return schemas.Channel.model_validate(channel_db, from_attributes=True)
 
 
-class ChannelService:
-    def __init__(self, session: AsyncSession) -> None:
-        self._session = session
+class ChannelService(DbServiceBase):
+    def __init__(
+        self, session: AsyncSession | None = None, session_lock: asyncio.Lock | None = None
+    ) -> None:
+        super().__init__(session, session_lock)
 
     async def get_channels_count(self) -> int:
         query = select(func.count("*")).select_from(models.Channel)  # type: ignore

--- a/statgpt/common/services/dataset.py
+++ b/statgpt/common/services/dataset.py
@@ -85,7 +85,11 @@ class ChannelDataSetSerializer:
 class DataSetService(DbServiceBase):
     _SETTINGS = DataflowLoaderSettings()
 
-    def __init__(self, session: AsyncSession, session_lock: asyncio.Lock | None = None) -> None:
+    def __init__(
+        self,
+        session: AsyncSession | None = None,
+        session_lock: asyncio.Lock | None = None,
+    ) -> None:
         super().__init__(session, session_lock)
 
     @staticmethod

--- a/statgpt/common/vectorstore/factory.py
+++ b/statgpt/common/vectorstore/factory.py
@@ -16,7 +16,6 @@ class VectorStoreFactory:
     }
 
     def __init__(self, **kwargs):
-        # TODO: 'session' parameter seems to be required to be present in 'kwargs'!
         self._kwargs = kwargs
 
     async def get_vector_store(

--- a/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
+++ b/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
@@ -1,4 +1,3 @@
-import asyncio
 import hashlib
 import io
 import json
@@ -43,14 +42,10 @@ class PgVectorStore(VectorStore, DbServiceBase):
         self,
         collection_name: str,
         embedding_model: EmbeddingModel,
-        *,
-        session: AsyncSession,
-        session_lock: asyncio.Lock | None = None,
         **kwargs,
     ):
         VectorStore.__init__(self, collection_name, embedding_model, **kwargs)
-        DbServiceBase.__init__(self, session, session_lock)
-        self._lock = asyncio.Lock()
+        DbServiceBase.__init__(self)
         self._postgres_settings = PostgresSettings()
 
     @property
@@ -125,32 +120,29 @@ class PgVectorStore(VectorStore, DbServiceBase):
         return d
 
     async def _create_table_if_not_exist(self, model: type[BaseModel]) -> bool:
-        """Returns True if the table was created"""
+        """Returns True if the table was created.
+
+        Must be called within a ``_scoped_session()`` block.
+        """
 
         table_name = model.__tablename__
 
-        async with self._lock_session() as session:
-            if await self._check_if_table_exists(session, table_name):
-                _log.info(f"Table '{table_name}' exist")
-                return False
-            else:
-                await self._create_table(session, model)
-                _log.info(f"Created table '{table_name}'")
-                return True
+        if await self._check_if_table_exists(self._session, table_name):
+            _log.info(f"Table '{table_name}' exist")
+            return False
+        else:
+            await self._create_table(self._session, model)
+            _log.info(f"Created table '{table_name}'")
+            return True
 
     async def clear(self) -> None:
-        # Keep outer transaction scopes (e.g. @audit_action) intact:
-        # only commit when this method is not called inside an active transaction.
-        should_commit = not self._session.in_transaction()
-        async with self._lock_session() as session:
+        async with self._scoped_session() as session:
             for table in [self._table_name, self._metadata_table_name]:
                 if await self._check_if_table_exists(session, table):
-
                     await session.execute(text(f'DROP TABLE IF EXISTS collections."{table}"'))
                     _log.info(f"Dropped '{table}' table")
 
-            if should_commit:
-                await session.commit()
+            await session.commit()
 
     def _dataset_lock_key(self, dataset_id: uuid.UUID) -> int:
         """Generates a consistent lock key from collection_name and dataset_id.
@@ -171,15 +163,15 @@ class PgVectorStore(VectorStore, DbServiceBase):
         Returns the lock key which should be passed to _release_dataset_lock.
         This lock persists across multiple transactions until explicitly released.
         This prevents concurrent modifications to the same dataset within the channel.
+
+        Must be called within a ``_scoped_session()`` block.
         """
         lock_key = self._dataset_lock_key(dataset_id)
-        async with self._lock_session() as session:
-            # Ensure session is in a clean state before acquiring lock
-            if session.in_transaction() and not session.is_active:
-                await session.rollback()
-            await session.execute(
-                text("SELECT pg_advisory_lock(:lock_key)"), {"lock_key": lock_key}
-            )
+        session = self._session
+        # Ensure session is in a clean state before acquiring lock
+        if session.in_transaction() and not session.is_active:
+            await session.rollback()
+        await session.execute(text("SELECT pg_advisory_lock(:lock_key)"), {"lock_key": lock_key})
         _log.debug(
             f"Acquired advisory lock for collection={self._collection_name} dataset={dataset_id} (key={lock_key})"
         )
@@ -189,23 +181,25 @@ class PgVectorStore(VectorStore, DbServiceBase):
         """Releases a session-level advisory lock.
 
         Handles PendingRollback state to ensure lock is always released.
+
+        Must be called within a ``_scoped_session()`` block.
         """
-        async with self._lock_session() as session:
+        session = self._session
+        try:
+            # Rollback if session is in a failed transaction state
+            if session.in_transaction() and not session.is_active:
+                await session.rollback()
+            await session.execute(
+                text("SELECT pg_advisory_unlock(:lock_key)"), {"lock_key": lock_key}
+            )
+        except Exception as e:
+            _log.error(f"Failed to release advisory lock (key={lock_key}): {e}")
+            # Still try to rollback to clean up the session
             try:
-                # Rollback if session is in a failed transaction state
-                if session.in_transaction() and not session.is_active:
-                    await session.rollback()
-                await session.execute(
-                    text("SELECT pg_advisory_unlock(:lock_key)"), {"lock_key": lock_key}
-                )
-            except Exception as e:
-                _log.error(f"Failed to release advisory lock (key={lock_key}): {e}")
-                # Still try to rollback to clean up the session
-                try:
-                    await session.rollback()
-                except Exception:
-                    pass
-                raise
+                await session.rollback()
+            except Exception:
+                pass
+            raise
         _log.debug(f"Released advisory lock (key={lock_key})")
 
     @asynccontextmanager
@@ -234,51 +228,58 @@ class PgVectorStore(VectorStore, DbServiceBase):
     async def add_documents(
         self, documents: Iterable[Document], dataset_id: uuid.UUID, version_id: int
     ) -> None:
-        async with self._dataset_lock(dataset_id):
-            document_model: type[BaseDocument] = await self._get_document_model()
-            metadata_model: type[BaseDocumentMetadata] = await self._get_metadata_model()
+        # Phase 1: Compute ALL embeddings outside any session
+        batches_with_embeddings: list[tuple[list[Document], list[list[float]]]] = []
+        for batch in batched(documents, self._postgres_settings.batch_size):
+            embeddings = await self._embedding_model.model.aembed_documents(
+                [doc.page_content for doc in batch]
+            )
+            batches_with_embeddings.append((batch, embeddings))
 
-            await self._create_table_if_not_exist(document_model)
-            await self._create_table_if_not_exist(metadata_model)
+        # Phase 2: DB writes in a single session (advisory lock + inserts)
+        async with self._scoped_session():
+            async with self._dataset_lock(dataset_id):
+                document_model: type[BaseDocument] = await self._get_document_model()
+                metadata_model: type[BaseDocumentMetadata] = await self._get_metadata_model()
 
-            for batch in batched(documents, self._postgres_settings.batch_size):
-                embeddings = await self._embedding_model.model.aembed_documents(
-                    [doc.page_content for doc in batch]
-                )
+                await self._create_table_if_not_exist(document_model)
+                await self._create_table_if_not_exist(metadata_model)
 
-                items = []
-                for doc, embedding in zip(batch, embeddings):
-                    items.append(
+                for batch, embeddings in batches_with_embeddings:
+                    items = [
                         document_model(
                             document=self._sanitize_text(doc.page_content),
-                            embeddings=embedding,
+                            embeddings=emb,
                         )
-                    )
+                        for doc, emb in zip(batch, embeddings)
+                    ]
 
-                self._session.add_all(items)
-                await self._session.commit()
-                _log.info(f"Added {len(items)} documents")
+                    self._session.add_all(items)
+                    await self._session.commit()
+                    _log.info(f"Added {len(items)} documents")
 
-                mappings = [
-                    metadata_model(
-                        document_id=item.id,
-                        dataset_id=dataset_id,
-                        version_id=version_id,
-                        details=self._sanitize_metadata(doc.metadata),
-                    )
-                    for item, doc in zip(items, batch)
-                ]
-                self._session.add_all(mappings)
-                await self._session.commit()
-                _log.info(f"Added {len(mappings)} document mappings")
+                    mappings = [
+                        metadata_model(
+                            document_id=item.id,
+                            dataset_id=dataset_id,
+                            version_id=version_id,
+                            details=self._sanitize_metadata(doc.metadata),
+                        )
+                        for item, doc in zip(items, batch)
+                    ]
+                    self._session.add_all(mappings)
+                    await self._session.commit()
+                    _log.info(f"Added {len(mappings)} document mappings")
 
     async def _get_dataset_ids_by_version_ids(self, version_ids: list[int]) -> list[uuid.UUID]:
-        """Get all unique dataset_ids associated with given version_ids."""
+        """Get all unique dataset_ids associated with given version_ids.
+
+        Must be called within a ``_scoped_session()`` block.
+        """
         model = await self._get_metadata_model()
-        async with self._lock_session() as session:
-            res = await session.scalars(
-                select(model.dataset_id).distinct().where(model.version_id.in_(version_ids))
-            )
+        res = await self._session.scalars(
+            select(model.dataset_id).distinct().where(model.version_id.in_(version_ids))
+        )
         return [item for item in res.all()]
 
     async def remove_documents_by(
@@ -293,13 +294,13 @@ class PgVectorStore(VectorStore, DbServiceBase):
         if not dataset_id and not version_ids:
             raise ValueError("Either dataset_id or version_ids must be provided")
 
-        if dataset_id:
-            dataset_ids_to_lock = [dataset_id]
-        else:
-            dataset_ids_to_lock = await self._get_dataset_ids_by_version_ids(version_ids)  # type: ignore
+        async with self._scoped_session() as session:
+            if dataset_id:
+                dataset_ids_to_lock = [dataset_id]
+            else:
+                dataset_ids_to_lock = await self._get_dataset_ids_by_version_ids(version_ids)  # type: ignore
 
-        async with self._dataset_locks(dataset_ids_to_lock):
-            async with self._lock_session() as session:
+            async with self._dataset_locks(dataset_ids_to_lock):
                 document_ids = await self._remove_dataset_metadata(
                     session, dataset_id=dataset_id, version_ids=version_ids
                 )
@@ -373,6 +374,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
         with debug_timer("vector_store._get_mapping_model"):
             mapping_model = await self._get_metadata_model()
 
+        # Embedding computation outside any session
         with debug_timer("vector_store.prepare_embeddings"):
             embedding = (await self._embedding_model.model.aembed_documents([query]))[0]
 
@@ -410,8 +412,9 @@ class PgVectorStore(VectorStore, DbServiceBase):
                 .order_by(top_k_docs_cte.c.distance, mapping_model.id)
             )
 
+        # DB query in its own session
         with debug_timer("vector_store.search.sql"):
-            async with self._lock_session() as session:
+            async with self._scoped_session() as session:
                 res = await session.execute(sql_query)
 
         with debug_timer("vector_store.search.process"):
@@ -429,7 +432,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
     async def get_dataset_ids_by_documents_ids(self, ids: Iterable[int]) -> list[int]:
         model = await self._get_metadata_model()
 
-        async with self._lock_session() as session:
+        async with self._scoped_session() as session:
             res = await session.scalars(
                 select(model.dataset_id).distinct().where(model.document_id.in_(ids))
             )
@@ -438,7 +441,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
     async def get_document_ids_by_dataset_id(self, dataset_id: uuid.UUID) -> list[int]:
         model = await self._get_metadata_model()
 
-        async with self._lock_session() as session:
+        async with self._scoped_session() as session:
             res = await session.scalars(
                 select(model.document_id).where(model.dataset_id == dataset_id)
             )
@@ -473,7 +476,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
         document_model = await self._get_document_model()
         metadata_model = await self._get_metadata_model()
 
-        async with self._lock_session() as session:
+        async with self._scoped_session() as session:
             for model in [document_model, metadata_model]:
                 if not await self._check_if_table_exists(session, model.__tablename__):
                     _log.info(f"Table {model.__tablename__!r} does not exist.")
@@ -503,7 +506,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
         document_model = await self._get_document_model()
         metadata_model = await self._get_metadata_model()
 
-        async with self._lock_session() as session:
+        async with self._scoped_session() as session:
             for model in [document_model, metadata_model]:
                 if not await self._check_if_table_exists(session, model.__tablename__):
                     _log.info(f"Table {model.__tablename__!r} does not exist.")
@@ -535,7 +538,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
     async def get_total_size(self) -> int:
         metadata_model = await self._get_metadata_model()
 
-        async with self._lock_session() as session:
+        async with self._scoped_session() as session:
             if not await self._check_if_table_exists(session, metadata_model.__tablename__):
                 _log.info(f"Table {metadata_model.__tablename__!r} does not exist.")
                 return 0
@@ -550,7 +553,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
     async def get_size(self, version_ids: set[int]) -> int:
         metadata_model = await self._get_metadata_model()
 
-        async with self._lock_session() as session:
+        async with self._scoped_session() as session:
             if not await self._check_if_table_exists(session, metadata_model.__tablename__):
                 _log.info(f"Table {metadata_model.__tablename__!r} does not exist.")
                 return 0
@@ -567,7 +570,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
     async def get_size_per_version(self, version_ids: set[int]) -> dict[int, int]:
         metadata_model = await self._get_metadata_model()
 
-        async with self._lock_session() as session:
+        async with self._scoped_session() as session:
             if not await self._check_if_table_exists(session, metadata_model.__tablename__):
                 return {}
 
@@ -598,7 +601,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
         with debug_timer("deduplicate_content._get_metadata_model"):
             metadata_model = await self._get_metadata_model()
 
-        async with self._lock_session() as session:
+        async with self._scoped_session() as session:
             try:
                 with debug_timer("deduplicate_content._check_if_table_exists"):
                     for name in [metadata_model.__tablename__, document_model.__tablename__]:
@@ -681,7 +684,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
         ]
         schema = pa.schema(schema_fields)
 
-        async with self._lock_session() as session:
+        async with self._scoped_session() as session:
             # Only export documents that are referenced by metadata with specified version_ids
             matching_doc_ids = select(metadata_model.document_id.distinct()).where(
                 metadata_model.version_id.in_(version_ids)
@@ -758,7 +761,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
         ]
         schema = pa.schema(schema_fields)
 
-        async with self._lock_session() as session:
+        async with self._scoped_session() as session:
             query = (
                 select(metadata_model)
                 .where(metadata_model.version_id.in_(version_ids))
@@ -845,7 +848,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
         document_model = await self._get_document_model()
         metadata_model = await self._get_metadata_model()
 
-        async with self._lock_session() as session:
+        async with self._scoped_session() as session:
             doc_table_exists = await self._check_if_table_exists(
                 session, document_model.__tablename__
             )
@@ -1105,28 +1108,34 @@ class PgVectorStore(VectorStore, DbServiceBase):
         await self.clear()
         _log.info(f"Cleared existing tables for collection '{self._collection_name}'")
 
-        document_model = await self._get_document_model()
-        metadata_model = await self._get_metadata_model()
-        await self._create_table_if_not_exist(document_model)
-        await self._create_table_if_not_exist(metadata_model)
-        _log.info(f"Created tables for collection '{self._collection_name}'")
+        async with self._scoped_session():
+            document_model = await self._get_document_model()
+            metadata_model = await self._get_metadata_model()
+            await self._create_table_if_not_exist(document_model)
+            await self._create_table_if_not_exist(metadata_model)
+            _log.info(f"Created tables for collection '{self._collection_name}'")
 
-        # Skip import if this was an empty export (no parquet files)
-        if documents_path is None or mappings_path is None:
-            _log.info("Empty export detected, skipping document and mapping import")
-            doc_count = 0
-            mapping_count = 0
-        else:
-            id_mapping = await self._import_documents_from_zipfile(
-                zip_file, document_model, documents_path
-            )
-            doc_count = len(id_mapping)
-            _log.info(f"Imported {doc_count} documents")
+            # Skip import if this was an empty export (no parquet files)
+            if documents_path is None or mappings_path is None:
+                _log.info("Empty export detected, skipping document and mapping import")
+                doc_count = 0
+                mapping_count = 0
+            else:
+                id_mapping = await self._import_documents_from_zipfile(
+                    zip_file, document_model, documents_path
+                )
+                doc_count = len(id_mapping)
+                _log.info(f"Imported {doc_count} documents")
 
-            mapping_count = await self._import_mappings_from_zipfile(
-                zip_file, metadata_model, mappings_path, dataset_versions, data_sources, id_mapping
-            )
-            _log.info(f"Imported {mapping_count} mappings")
+                mapping_count = await self._import_mappings_from_zipfile(
+                    zip_file,
+                    metadata_model,
+                    mappings_path,
+                    dataset_versions,
+                    data_sources,
+                    id_mapping,
+                )
+                _log.info(f"Imported {mapping_count} mappings")
 
         _log.info(
             f"Successfully imported collection '{self._collection_name}': "

--- a/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
+++ b/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
@@ -429,7 +429,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
             ]
         return result
 
-    async def get_dataset_ids_by_documents_ids(self, ids: Iterable[int]) -> list[int]:
+    async def get_dataset_ids_by_documents_ids(self, ids: Iterable[int]) -> list[uuid.UUID]:
         model = await self._get_metadata_model()
 
         async with self._scoped_session() as session:
@@ -584,7 +584,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
                 .group_by(metadata_model.version_id)
             )
             result = await session.execute(query)
-            return dict(result.all())
+            return {row[0]: row[1] for row in result.all()}
 
     async def deduplicate_by_document_content(self) -> None:
         """Removes and remaps duplicate documents based on `document` field content.
@@ -644,7 +644,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
                     """)
 
                     result = await session.execute(remap_query)
-                    remapped_count = result.rowcount
+                    remapped_count = result.rowcount  # type: ignore[attr-defined]
                     _log.info(f"Remapped {remapped_count} metadata rows to keeper documents")
 
                 with debug_timer("deduplicate_content.delete_orphaned"):
@@ -652,7 +652,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
                         document_model.__tablename__, metadata_model.__tablename__
                     )
                     result = await session.execute(delete_query)
-                    deleted_count = result.rowcount
+                    deleted_count = result.rowcount  # type: ignore[attr-defined]
                     _log.info(f"Deleted {deleted_count} orphaned documents")
 
                 with debug_timer("deduplicate_content.commit"):


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- first part of the #174 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Resolves database connection pool exhaustion (`QueuePool limit of size 20 overflow 10 reached`) caused by FastAPI's `Depends(get_session)` keeping sessions open for the entire lifetime of background tasks.

**Root cause:** When a FastAPI endpoint uses `Depends(get_session)` and schedules `BackgroundTasks`, the dependency-injected session is not closed until _all_ background tasks finish.

**Improvement:** `PgVectorStore` and admin services now manage their own short-lived sessions instead of holding a single session for the entire duration of long-running background operations (reindexing, import/export).

**Other changes:**

- **Return 400 for `InvalidConfigurationError` in reload-indicators endpoints** — both single-dataset and all-datasets reload endpoints now catch `InvalidConfigurationError` and return HTTP 400 instead of 500
- **Fix logger name for database log level setting** — corrected `"common.models.database"` → `"statgpt.common.models.database"` so the `level_db` setting actually applies

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
