### PR TITLE
fix: add method to truncate fractional seconds for date parsing compatibility #217 

### DIFF
--- a/statgpt/common/data/quanthub/v21/dataset.py
+++ b/statgpt/common/data/quanthub/v21/dataset.py
@@ -105,9 +105,9 @@ class QuanthubSdmx21DataSet(Sdmx21DataSet):
         """Truncate fractional seconds to 6 digits (microseconds) for strptime compatibility."""
         return re.sub(r'(\.\d{6})\d+', r'\1', value)
 
-    @staticmethod
-    def _parse_date_with_formats(value: str, formats: list[str] | None) -> datetime | None:
-        normalized = QuanthubSdmx21DataSet._truncate_fractional_seconds(value)
+    @classmethod
+    def _parse_date_with_formats(cls, value: str, formats: list[str] | None) -> datetime | None:
+        normalized = cls._truncate_fractional_seconds(value)
         if formats:
             for fmt in formats:
                 try:

--- a/statgpt/common/data/quanthub/v21/dataset.py
+++ b/statgpt/common/data/quanthub/v21/dataset.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import typing
 import uuid
 from collections.abc import Iterable
@@ -100,18 +101,24 @@ class QuanthubSdmx21DataSet(Sdmx21DataSet):
         raise ValueError(f"Unsupported property source: {property_source.source}")
 
     @staticmethod
+    def _truncate_fractional_seconds(value: str) -> str:
+        """Truncate fractional seconds to 6 digits (microseconds) for strptime compatibility."""
+        return re.sub(r'(\.\d{6})\d+', r'\1', value)
+
+    @staticmethod
     def _parse_date_with_formats(value: str, formats: list[str] | None) -> datetime | None:
+        normalized = QuanthubSdmx21DataSet._truncate_fractional_seconds(value)
         if formats:
             for fmt in formats:
                 try:
-                    return datetime.strptime(value, fmt)
+                    return datetime.strptime(normalized, fmt)
                 except ValueError:
                     _log.debug(f"Failed to parse date {value!r} with format {fmt!r}")
             _log.warning(f"Failed to parse date {value!r} with any of the formats: {formats}")
             return None
         else:
             try:
-                return datetime.fromisoformat(value)
+                return datetime.fromisoformat(normalized)
             except ValueError:
                 _log.warning(f"Failed to parse date {value!r} with ISO format")
                 return None


### PR DESCRIPTION


### Applicable issues

#217 

### Description of changes

Add normalizing second fraction in case of nanoseconds fraction(Python can parse up to microsecond only)

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
