### PR TITLE
fix: return 400 with structured errors for InvalidConfigurationError during channel reindex #220

### DIFF
--- a/statgpt/admin/routers/channel.py
+++ b/statgpt/admin/routers/channel.py
@@ -294,8 +294,14 @@ async def reload_indicators_for_all_channel_datasets(
                 max_n_embeddings=max_n_embeddings,
                 auth_context=SystemUserAuthContext(),
             )
-        except InvalidConfigurationError as e:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        except ExceptionGroup as eg:
+            invalid_config_errors = [
+                e for e in eg.exceptions if isinstance(e, InvalidConfigurationError)
+            ]
+            if invalid_config_errors:
+                detail = [e.to_dict() for e in invalid_config_errors]
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+            raise
 
     return schemas.ListResponse[schemas.ChannelDatasetExpanded](
         data=channel_datasets,
@@ -399,7 +405,7 @@ async def reload_indicators_for_channel_dataset(
                 auth_context=SystemUserAuthContext(),
             )
         except InvalidConfigurationError as e:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.to_dict())
 
 
 @router.delete("/{channel_id}/datasets/{dataset_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/statgpt/admin/routers/channel.py
+++ b/statgpt/admin/routers/channel.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta
 from typing import Annotated
 
@@ -19,6 +20,8 @@ from statgpt.common.data.sdmx.v21.dataset import InvalidConfigurationError
 from statgpt.common.models.database import get_session_context_manager
 from statgpt.common.settings.dial import dial_settings
 from statgpt.common.utils.cancel_dependency import cancel_on_disconnect
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/channels",
@@ -299,6 +302,8 @@ async def reload_indicators_for_all_channel_datasets(
                 e for e in eg.exceptions if isinstance(e, InvalidConfigurationError)
             ]
             if invalid_config_errors:
+                for err in eg.exceptions:
+                    logger.error("Error during channel reindex", exc_info=err)
                 detail = [e.to_dict() for e in invalid_config_errors]
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
             raise

--- a/statgpt/common/data/sdmx/v21/dataset.py
+++ b/statgpt/common/data/sdmx/v21/dataset.py
@@ -88,12 +88,17 @@ class SdmxOfflineDataSet(OfflineDataSet[SdmxDataSetConfig, 'Sdmx21DataSourceHand
 
 
 class InvalidConfigurationError(Exception):
-    def __init__(self, message: str, dataset_urn: str | None = None):
+    def __init__(self, message: str, entity_id: uuid.UUID, dataset_urn: str):
         super().__init__(message)
+        self.entity_id = entity_id
         self.dataset_urn = dataset_urn
 
-    def to_dict(self) -> dict[str, str | None]:
-        return {"dataset_urn": self.dataset_urn, "error": str(self)}
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "entity_id": str(self.entity_id),
+            "dataset_urn": self.dataset_urn,
+            "error": str(self),
+        }
 
 
 class Sdmx21DataResponse(DataResponse):
@@ -394,7 +399,7 @@ class Sdmx21DataSet(
                 self._virtual_dimensions[dimension.entity_id] = dimension
                 self._dimensions[dimension.entity_id] = dimension
 
-        self._validate_config_and_dimensions(config, self._dimensions)
+        self._validate_config_and_dimensions(config, self._dimensions, entity_id)
 
         # Set indicator dimensions
         for dim_id, dim_conf in config.dimensions.items():
@@ -405,6 +410,7 @@ class Sdmx21DataSet(
                 ):
                     raise InvalidConfigurationError(
                         f"Indicator dimension must be code list dimension or virtual dimension: {indicator_dimension}",
+                        entity_id=entity_id,
                         dataset_urn=config.urn.short_urn(),
                     )
                 self._indicator_dimensions[dim_id] = indicator_dimension
@@ -414,6 +420,7 @@ class Sdmx21DataSet(
             if not isinstance(country_dimension, SdmxCodeListDimension | VirtualDimension):
                 raise InvalidConfigurationError(
                     f"Country dimension must be code list dimension or virtual dimension: {country_dimension}",
+                    entity_id=entity_id,
                     dataset_urn=config.urn.short_urn(),
                 )
             self._country_dimension = country_dimension
@@ -422,7 +429,9 @@ class Sdmx21DataSet(
 
     @staticmethod
     def _validate_config_and_dimensions(
-        config: SdmxDataSetConfig, dimensions: dict[str, SdmxDimension | VirtualDimension]
+        config: SdmxDataSetConfig,
+        dimensions: dict[str, SdmxDimension | VirtualDimension],
+        entity_id: uuid.UUID,
     ) -> None:
         """Validate that the dataset is properly configured and raises `InvalidConfigurationError` if not."""
 
@@ -443,7 +452,9 @@ class Sdmx21DataSet(
                 f"Dimensions is found in the dataset but not configured: {not_configured_dimensions}."
             )
         if errors:
-            raise InvalidConfigurationError(" ".join(errors), dataset_urn=config.urn.short_urn())
+            raise InvalidConfigurationError(
+                " ".join(errors), entity_id=entity_id, dataset_urn=config.urn.short_urn()
+            )
 
         return None
 

--- a/statgpt/common/data/sdmx/v21/dataset.py
+++ b/statgpt/common/data/sdmx/v21/dataset.py
@@ -88,7 +88,12 @@ class SdmxOfflineDataSet(OfflineDataSet[SdmxDataSetConfig, 'Sdmx21DataSourceHand
 
 
 class InvalidConfigurationError(Exception):
-    pass
+    def __init__(self, message: str, dataset_urn: str | None = None):
+        super().__init__(message)
+        self.dataset_urn = dataset_urn
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {"dataset_urn": self.dataset_urn, "error": str(self)}
 
 
 class Sdmx21DataResponse(DataResponse):
@@ -399,7 +404,8 @@ class Sdmx21DataSet(
                     indicator_dimension, VirtualDimension
                 ):
                     raise InvalidConfigurationError(
-                        f"Indicator dimension must be code list dimension or virtual dimension: {indicator_dimension}"
+                        f"Indicator dimension must be code list dimension or virtual dimension: {indicator_dimension}",
+                        dataset_urn=config.urn.short_urn(),
                     )
                 self._indicator_dimensions[dim_id] = indicator_dimension
 
@@ -407,7 +413,8 @@ class Sdmx21DataSet(
             country_dimension = self._dimensions[country_dimension_id]
             if not isinstance(country_dimension, SdmxCodeListDimension | VirtualDimension):
                 raise InvalidConfigurationError(
-                    f"Country dimension must be code list dimension or virtual dimension: {country_dimension}"
+                    f"Country dimension must be code list dimension or virtual dimension: {country_dimension}",
+                    dataset_urn=config.urn.short_urn(),
                 )
             self._country_dimension = country_dimension
         else:
@@ -436,7 +443,7 @@ class Sdmx21DataSet(
                 f"Dimensions is found in the dataset but not configured: {not_configured_dimensions}."
             )
         if errors:
-            raise InvalidConfigurationError(" ".join(errors))
+            raise InvalidConfigurationError(" ".join(errors), dataset_urn=config.urn.short_urn())
 
         return None
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #220

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Catch ExceptionGroup from asyncio.TaskGroup, filter for InvalidConfigurationError, and return 400 with per-dataset {entity_id, dataset_urn, error} details instead of 500.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
