### PR TITLE
fix: remove DbServiceBase from PgVectorStore to allow concurrent session access #174

### DIFF
--- a/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
+++ b/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
@@ -22,7 +22,7 @@ from sqlalchemy.sql import text
 from sqlalchemy.sql.elements import TextClause
 from sqlalchemy.sql.expression import func
 
-from statgpt.common.services.base import DbServiceBase
+from statgpt.common.models import get_readonly_session_context_manager, get_session_context_manager
 from statgpt.common.settings.database import PostgresSettings
 from statgpt.common.settings.document import DimensionValueDocumentMetadataFields
 from statgpt.common.utils import batched
@@ -37,15 +37,14 @@ from .models import BaseDocument, BaseDocumentMetadata, BaseModel, ModelsStore
 _log = logging.getLogger(__name__)
 
 
-class PgVectorStore(VectorStore, DbServiceBase):
+class PgVectorStore(VectorStore):
     def __init__(
         self,
         collection_name: str,
         embedding_model: EmbeddingModel,
         **kwargs,
     ):
-        VectorStore.__init__(self, collection_name, embedding_model, **kwargs)
-        DbServiceBase.__init__(self)
+        super().__init__(collection_name, embedding_model, **kwargs)
         self._postgres_settings = PostgresSettings()
 
     @property
@@ -119,24 +118,23 @@ class PgVectorStore(VectorStore, DbServiceBase):
         d[field_name] = value
         return d
 
-    async def _create_table_if_not_exist(self, model: type[BaseModel]) -> bool:
-        """Returns True if the table was created.
-
-        Must be called within a ``_scoped_session()`` block.
-        """
+    async def _create_table_if_not_exist(
+        self, session: AsyncSession, model: type[BaseModel]
+    ) -> bool:
+        """Returns True if the table was created."""
 
         table_name = model.__tablename__
 
-        if await self._check_if_table_exists(self._session, table_name):
+        if await self._check_if_table_exists(session, table_name):
             _log.info(f"Table '{table_name}' exist")
             return False
         else:
-            await self._create_table(self._session, model)
+            await self._create_table(session, model)
             _log.info(f"Created table '{table_name}'")
             return True
 
     async def clear(self) -> None:
-        async with self._scoped_session() as session:
+        async with get_session_context_manager() as session:
             for table in [self._table_name, self._metadata_table_name]:
                 if await self._check_if_table_exists(session, table):
                     await session.execute(text(f'DROP TABLE IF EXISTS collections."{table}"'))
@@ -157,17 +155,14 @@ class PgVectorStore(VectorStore, DbServiceBase):
         # Use first 8 bytes to generate a bigint for PostgreSQL advisory lock
         return int.from_bytes(hash_bytes[:8], byteorder='big', signed=True)
 
-    async def _acquire_dataset_lock(self, dataset_id: uuid.UUID) -> int:
+    async def _acquire_dataset_lock(self, session: AsyncSession, dataset_id: uuid.UUID) -> int:
         """Acquires a session-level advisory lock for the given dataset_id within this channel.
 
         Returns the lock key which should be passed to _release_dataset_lock.
         This lock persists across multiple transactions until explicitly released.
         This prevents concurrent modifications to the same dataset within the channel.
-
-        Must be called within a ``_scoped_session()`` block.
         """
         lock_key = self._dataset_lock_key(dataset_id)
-        session = self._session
         # Ensure session is in a clean state before acquiring lock
         if session.in_transaction() and not session.is_active:
             await session.rollback()
@@ -177,14 +172,11 @@ class PgVectorStore(VectorStore, DbServiceBase):
         )
         return lock_key
 
-    async def _release_dataset_lock(self, lock_key: int) -> None:
+    async def _release_dataset_lock(self, session: AsyncSession, lock_key: int) -> None:
         """Releases a session-level advisory lock.
 
         Handles PendingRollback state to ensure lock is always released.
-
-        Must be called within a ``_scoped_session()`` block.
         """
-        session = self._session
         try:
             # Rollback if session is in a failed transaction state
             if session.in_transaction() and not session.is_active:
@@ -203,27 +195,33 @@ class PgVectorStore(VectorStore, DbServiceBase):
         _log.debug(f"Released advisory lock (key={lock_key})")
 
     @asynccontextmanager
-    async def _dataset_lock(self, dataset_id: uuid.UUID) -> AsyncIterator[None]:
+    async def _dataset_lock(
+        self, session: AsyncSession, dataset_id: uuid.UUID
+    ) -> AsyncIterator[None]:
         """Context manager for acquiring and releasing dataset advisory lock."""
-        lock_key = await self._acquire_dataset_lock(dataset_id)
+        lock_key = await self._acquire_dataset_lock(session, dataset_id)
         try:
             yield
         finally:
-            await self._release_dataset_lock(lock_key)
+            await self._release_dataset_lock(session, lock_key)
 
     @asynccontextmanager
-    async def _dataset_locks(self, dataset_ids: list[uuid.UUID]) -> AsyncIterator[None]:
+    async def _dataset_locks(
+        self, session: AsyncSession, dataset_ids: list[uuid.UUID]
+    ) -> AsyncIterator[None]:
         """Context manager for acquiring and releasing multiple dataset advisory locks.
 
         Sorts dataset_ids to ensure deterministic lock ordering and prevent deadlocks.
         """
         sorted_dataset_ids = sorted(dataset_ids)
-        lock_keys = [await self._acquire_dataset_lock(ds_id) for ds_id in sorted_dataset_ids]
+        lock_keys = [
+            await self._acquire_dataset_lock(session, ds_id) for ds_id in sorted_dataset_ids
+        ]
         try:
             yield
         finally:
             for lock_key in lock_keys:
-                await self._release_dataset_lock(lock_key)
+                await self._release_dataset_lock(session, lock_key)
 
     async def add_documents(
         self, documents: Iterable[Document], dataset_id: uuid.UUID, version_id: int
@@ -237,13 +235,13 @@ class PgVectorStore(VectorStore, DbServiceBase):
             batches_with_embeddings.append((batch, embeddings))
 
         # Phase 2: DB writes in a single session (advisory lock + inserts)
-        async with self._scoped_session():
-            async with self._dataset_lock(dataset_id):
+        async with get_session_context_manager() as session:
+            async with self._dataset_lock(session, dataset_id):
                 document_model: type[BaseDocument] = await self._get_document_model()
                 metadata_model: type[BaseDocumentMetadata] = await self._get_metadata_model()
 
-                await self._create_table_if_not_exist(document_model)
-                await self._create_table_if_not_exist(metadata_model)
+                await self._create_table_if_not_exist(session, document_model)
+                await self._create_table_if_not_exist(session, metadata_model)
 
                 for batch, embeddings in batches_with_embeddings:
                     items = [
@@ -254,8 +252,8 @@ class PgVectorStore(VectorStore, DbServiceBase):
                         for doc, emb in zip(batch, embeddings)
                     ]
 
-                    self._session.add_all(items)
-                    await self._session.commit()
+                    session.add_all(items)
+                    await session.commit()
                     _log.info(f"Added {len(items)} documents")
 
                     mappings = [
@@ -267,17 +265,16 @@ class PgVectorStore(VectorStore, DbServiceBase):
                         )
                         for item, doc in zip(items, batch)
                     ]
-                    self._session.add_all(mappings)
-                    await self._session.commit()
+                    session.add_all(mappings)
+                    await session.commit()
                     _log.info(f"Added {len(mappings)} document mappings")
 
-    async def _get_dataset_ids_by_version_ids(self, version_ids: list[int]) -> list[uuid.UUID]:
-        """Get all unique dataset_ids associated with given version_ids.
-
-        Must be called within a ``_scoped_session()`` block.
-        """
+    async def _get_dataset_ids_by_version_ids(
+        self, session: AsyncSession, version_ids: list[int]
+    ) -> list[uuid.UUID]:
+        """Get all unique dataset_ids associated with given version_ids."""
         model = await self._get_metadata_model()
-        res = await self._session.scalars(
+        res = await session.scalars(
             select(model.dataset_id).distinct().where(model.version_id.in_(version_ids))
         )
         return [item for item in res.all()]
@@ -294,13 +291,13 @@ class PgVectorStore(VectorStore, DbServiceBase):
         if not dataset_id and not version_ids:
             raise ValueError("Either dataset_id or version_ids must be provided")
 
-        async with self._scoped_session() as session:
+        async with get_session_context_manager() as session:
             if dataset_id:
                 dataset_ids_to_lock = [dataset_id]
             else:
-                dataset_ids_to_lock = await self._get_dataset_ids_by_version_ids(version_ids)  # type: ignore
+                dataset_ids_to_lock = await self._get_dataset_ids_by_version_ids(session, version_ids)  # type: ignore
 
-            async with self._dataset_locks(dataset_ids_to_lock):
+            async with self._dataset_locks(session, dataset_ids_to_lock):
                 document_ids = await self._remove_dataset_metadata(
                     session, dataset_id=dataset_id, version_ids=version_ids
                 )
@@ -414,7 +411,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
 
         # DB query in its own session
         with debug_timer("vector_store.search.sql"):
-            async with self._scoped_session() as session:
+            async with get_readonly_session_context_manager() as session:
                 res = await session.execute(sql_query)
 
         with debug_timer("vector_store.search.process"):
@@ -432,7 +429,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
     async def get_dataset_ids_by_documents_ids(self, ids: Iterable[int]) -> list[uuid.UUID]:
         model = await self._get_metadata_model()
 
-        async with self._scoped_session() as session:
+        async with get_readonly_session_context_manager() as session:
             res = await session.scalars(
                 select(model.dataset_id).distinct().where(model.document_id.in_(ids))
             )
@@ -441,7 +438,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
     async def get_document_ids_by_dataset_id(self, dataset_id: uuid.UUID) -> list[int]:
         model = await self._get_metadata_model()
 
-        async with self._scoped_session() as session:
+        async with get_readonly_session_context_manager() as session:
             res = await session.scalars(
                 select(model.document_id).where(model.dataset_id == dataset_id)
             )
@@ -476,7 +473,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
         document_model = await self._get_document_model()
         metadata_model = await self._get_metadata_model()
 
-        async with self._scoped_session() as session:
+        async with get_readonly_session_context_manager() as session:
             for model in [document_model, metadata_model]:
                 if not await self._check_if_table_exists(session, model.__tablename__):
                     _log.info(f"Table {model.__tablename__!r} does not exist.")
@@ -506,7 +503,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
         document_model = await self._get_document_model()
         metadata_model = await self._get_metadata_model()
 
-        async with self._scoped_session() as session:
+        async with get_readonly_session_context_manager() as session:
             for model in [document_model, metadata_model]:
                 if not await self._check_if_table_exists(session, model.__tablename__):
                     _log.info(f"Table {model.__tablename__!r} does not exist.")
@@ -538,7 +535,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
     async def get_total_size(self) -> int:
         metadata_model = await self._get_metadata_model()
 
-        async with self._scoped_session() as session:
+        async with get_readonly_session_context_manager() as session:
             if not await self._check_if_table_exists(session, metadata_model.__tablename__):
                 _log.info(f"Table {metadata_model.__tablename__!r} does not exist.")
                 return 0
@@ -553,7 +550,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
     async def get_size(self, version_ids: set[int]) -> int:
         metadata_model = await self._get_metadata_model()
 
-        async with self._scoped_session() as session:
+        async with get_readonly_session_context_manager() as session:
             if not await self._check_if_table_exists(session, metadata_model.__tablename__):
                 _log.info(f"Table {metadata_model.__tablename__!r} does not exist.")
                 return 0
@@ -570,7 +567,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
     async def get_size_per_version(self, version_ids: set[int]) -> dict[int, int]:
         metadata_model = await self._get_metadata_model()
 
-        async with self._scoped_session() as session:
+        async with get_readonly_session_context_manager() as session:
             if not await self._check_if_table_exists(session, metadata_model.__tablename__):
                 return {}
 
@@ -601,7 +598,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
         with debug_timer("deduplicate_content._get_metadata_model"):
             metadata_model = await self._get_metadata_model()
 
-        async with self._scoped_session() as session:
+        async with get_session_context_manager() as session:
             try:
                 with debug_timer("deduplicate_content._check_if_table_exists"):
                     for name in [metadata_model.__tablename__, document_model.__tablename__]:
@@ -684,7 +681,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
         ]
         schema = pa.schema(schema_fields)
 
-        async with self._scoped_session() as session:
+        async with get_readonly_session_context_manager() as session:
             # Only export documents that are referenced by metadata with specified version_ids
             matching_doc_ids = select(metadata_model.document_id.distinct()).where(
                 metadata_model.version_id.in_(version_ids)
@@ -761,7 +758,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
         ]
         schema = pa.schema(schema_fields)
 
-        async with self._scoped_session() as session:
+        async with get_readonly_session_context_manager() as session:
             query = (
                 select(metadata_model)
                 .where(metadata_model.version_id.in_(version_ids))
@@ -848,7 +845,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
         document_model = await self._get_document_model()
         metadata_model = await self._get_metadata_model()
 
-        async with self._scoped_session() as session:
+        async with get_readonly_session_context_manager() as session:
             doc_table_exists = await self._check_if_table_exists(
                 session, document_model.__tablename__
             )
@@ -952,7 +949,11 @@ class PgVectorStore(VectorStore, DbServiceBase):
         return metadata
 
     async def _import_documents_from_zipfile(
-        self, zip_file: zipfile.ZipFile, document_model: type[BaseDocument], file_path: str
+        self,
+        session: AsyncSession,
+        zip_file: zipfile.ZipFile,
+        document_model: type[BaseDocument],
+        file_path: str,
     ) -> dict[int, int]:
         """Imports documents from Parquet file in zip archive in batches.
 
@@ -988,15 +989,15 @@ class PgVectorStore(VectorStore, DbServiceBase):
                         _log.error(f"Error parsing document at index {i}: {e}")
                         raise ValueError(f"Corrupt document data: {e}")
 
-                self._session.add_all(doc_batch)
-                await self._session.flush()
+                session.add_all(doc_batch)
+                await session.flush()
 
                 # Map old IDs to new auto-generated IDs
                 for i, doc in enumerate(doc_batch):
                     old_id = batch_dict['id'][i]
                     id_mapping[old_id] = doc.id
 
-                await self._session.commit()
+                await session.commit()
                 doc_count += len(doc_batch)
                 _log.info(f"Imported {doc_count} documents...")
 
@@ -1004,6 +1005,7 @@ class PgVectorStore(VectorStore, DbServiceBase):
 
     async def _import_mappings_from_zipfile(
         self,
+        session: AsyncSession,
         zip_file: zipfile.ZipFile,
         metadata_model: type[BaseDocumentMetadata],
         file_path: str,
@@ -1066,8 +1068,8 @@ class PgVectorStore(VectorStore, DbServiceBase):
                         _log.error(f"Error parsing mapping at index {i}: {e}")
                         raise ValueError(f"Corrupt mapping data: {e}")
 
-                self._session.add_all(mapping_batch)
-                await self._session.commit()
+                session.add_all(mapping_batch)
+                await session.commit()
                 mapping_count += len(mapping_batch)
                 _log.info(f"Imported {mapping_count} mappings...")
 
@@ -1108,11 +1110,11 @@ class PgVectorStore(VectorStore, DbServiceBase):
         await self.clear()
         _log.info(f"Cleared existing tables for collection '{self._collection_name}'")
 
-        async with self._scoped_session():
+        async with get_session_context_manager() as session:
             document_model = await self._get_document_model()
             metadata_model = await self._get_metadata_model()
-            await self._create_table_if_not_exist(document_model)
-            await self._create_table_if_not_exist(metadata_model)
+            await self._create_table_if_not_exist(session, document_model)
+            await self._create_table_if_not_exist(session, metadata_model)
             _log.info(f"Created tables for collection '{self._collection_name}'")
 
             # Skip import if this was an empty export (no parquet files)
@@ -1122,12 +1124,13 @@ class PgVectorStore(VectorStore, DbServiceBase):
                 mapping_count = 0
             else:
                 id_mapping = await self._import_documents_from_zipfile(
-                    zip_file, document_model, documents_path
+                    session, zip_file, document_model, documents_path
                 )
                 doc_count = len(id_mapping)
                 _log.info(f"Imported {doc_count} documents")
 
                 mapping_count = await self._import_mappings_from_zipfile(
+                    session,
                     zip_file,
                     metadata_model,
                     mappings_path,


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- Second part of the #174

### Description of changes

<!-- Please explain the changes you made right below this line. -->
During channel reindex, the hybrid indexer runs `chain.abatch(max_concurrency=N)` which triggers multiple concurrent calls to `PgVectorStore.search_with_similarity_score()` on the same instance. `DbServiceBase._scoped_session()` stores the session on the instance and uses a boolean flag that raises `RuntimeError` on concurrent access, causing the reindex to fail with an `ExceptionGroup`.

<details>

<summary>Error traceback</summary>

```
ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | RuntimeError: Concurrent _scoped_session() calls on the same instance are not supported.
    |   Create a separate service instance per concurrent coroutine, or provide a session at construction time.
    +------------------------------------
```

</details>

**Root cause:** `PgVectorStore` inherited `DbServiceBase` but used it in a degenerate way — always constructed with `session=None`, never using `_lock_session()` or `_session_lock`. The shared instance-level session storage was incompatible with concurrent coroutines.

**Fix:** Remove `DbServiceBase` from `PgVectorStore` and manage sessions directly:
- Read-only methods use `get_readonly_session_context_manager()` — each call gets an independent session
- Write methods use `get_session_context_manager()`
- Helper methods (`_create_table_if_not_exist`, `_acquire_dataset_lock`, `_import_documents_from_zipfile`, etc.) now accept an explicit `session` parameter instead of relying on `self._session`

This makes `PgVectorStore` inherently concurrency-safe — no shared mutable state between coroutines.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
