### PR TITLE
chore: modernize typing.Optional to union syntax and add unit tests

### DIFF
--- a/statgpt/admin/settings/oidc_auth.py
+++ b/statgpt/admin/settings/oidc_auth.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -18,17 +16,17 @@ class OidcAuthSettings(BaseSettings):
         description="If enabled, all admin endpoints require OIDC authentication",
     )
 
-    oidc_configuration_endpoint: Optional[str] = Field(
+    oidc_configuration_endpoint: str | None = Field(
         default=None, alias="OIDC_CONFIGURATION_ENDPOINT", description="OIDC Configuration Endpoint"
     )
 
-    oidc_client_id: Optional[str] = Field(
+    oidc_client_id: str | None = Field(
         default=None, alias="OIDC_CLIENT_ID", description="OIDC Client ID"
     )
 
-    oidc_issuer: Optional[str] = Field(default=None, alias="OIDC_ISSUER", description="OIDC Issuer")
+    oidc_issuer: str | None = Field(default=None, alias="OIDC_ISSUER", description="OIDC Issuer")
 
-    oidc_username_claim: Optional[str] = Field(
+    oidc_username_claim: str | None = Field(
         default=None, alias="OIDC_USERNAME_CLAIM", description="OIDC Username Claim"
     )
     oidc_audit_user_id_claim: str = Field(
@@ -43,11 +41,11 @@ class OidcAuthSettings(BaseSettings):
     )
 
     # Admin roles settings
-    admin_roles_claim: Optional[str] = Field(
+    admin_roles_claim: str | None = Field(
         default=None, alias="ADMIN_ROLES_CLAIM", description="OIDC Admin Roles Claim"
     )
 
-    admin_roles_values: Optional[str] = Field(
+    admin_roles_values: str | None = Field(
         default=None,
         alias="ADMIN_ROLES_VALUES",
         description="OIDC Admin Roles Values (comma-separated)",
@@ -60,13 +58,13 @@ class OidcAuthSettings(BaseSettings):
         description="If enabled, the admin portal will check for scopes in the OIDC token",
     )
 
-    admin_scope_claim: Optional[str] = Field(
+    admin_scope_claim: str | None = Field(
         default=None,
         alias="ADMIN_SCOPE_CLAIM",
         description="The name of the custom access token field that contains scope information",
     )
 
-    admin_scope_value: Optional[str] = Field(
+    admin_scope_value: str | None = Field(
         default=None,
         alias="ADMIN_SCOPE_VALUE",
         description="Required scope claim value to get access to admin portal",

--- a/statgpt/app/settings/dial_rag.py
+++ b/statgpt/app/settings/dial_rag.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -11,11 +9,11 @@ class DialRagSettings(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="DIAL_RAG_")
 
-    pgvector_url: Optional[str] = Field(
+    pgvector_url: str | None = Field(
         default=None, description="URL for remote DIAL RAG PGVector service"
     )
 
-    pgvector_api_key: Optional[SecretStr] = Field(
+    pgvector_api_key: SecretStr | None = Field(
         default=None, description="API key for remote DIAL RAG PGVector service"
     )
 

--- a/statgpt/common/utils/memory_profiler.py
+++ b/statgpt/common/utils/memory_profiler.py
@@ -7,7 +7,7 @@ import tempfile
 import tracemalloc
 from collections import defaultdict
 from datetime import datetime
-from typing import Optional
+
 
 from statgpt.common.config import multiline_logger as logger
 
@@ -75,7 +75,7 @@ class MemoryProfiler:
 
         return snapshot_id
 
-    def _load_snapshot(self, index: int) -> Optional[tracemalloc.Snapshot]:
+    def _load_snapshot(self, index: int) -> tracemalloc.Snapshot | None:
         """Load a snapshot from disk."""
         if index < 0:
             index = len(self.snapshot_metadata) + index

--- a/statgpt/common/utils/memory_profiler.py
+++ b/statgpt/common/utils/memory_profiler.py
@@ -8,7 +8,6 @@ import tracemalloc
 from collections import defaultdict
 from datetime import datetime
 
-
 from statgpt.common.config import multiline_logger as logger
 
 

--- a/tests/unit/test_markdown_utils.py
+++ b/tests/unit/test_markdown_utils.py
@@ -1,0 +1,73 @@
+import pytest
+
+from statgpt.common.utils.markdown import format_as_markdown_list
+
+
+class TestFormatAsMarkdownList:
+    """Tests for the format_as_markdown_list utility function."""
+
+    # ---- Unordered list ----
+
+    def test_unordered_list(self):
+        result = format_as_markdown_list(["apple", "banana", "cherry"])
+        assert result == "- apple\n- banana\n- cherry"
+
+    def test_unordered_list_single_item(self):
+        result = format_as_markdown_list(["only item"])
+        assert result == "- only item"
+
+    def test_unordered_is_default(self):
+        """Calling without list_type should default to unordered."""
+        result = format_as_markdown_list(["a", "b"])
+        assert result == "- a\n- b"
+
+    # ---- Ordered list ----
+
+    def test_ordered_list(self):
+        result = format_as_markdown_list(["first", "second", "third"], list_type="ordered")
+        assert result == "1. first\n2. second\n3. third"
+
+    def test_ordered_list_single_item(self):
+        result = format_as_markdown_list(["only item"], list_type="ordered")
+        assert result == "1. only item"
+
+    def test_ordered_list_numbering_starts_at_one(self):
+        """Verify that ordered numbering begins at 1, not 0."""
+        result = format_as_markdown_list(["a"], list_type="ordered")
+        assert result.startswith("1.")
+
+    # ---- Empty list ----
+
+    def test_empty_list_unordered(self):
+        result = format_as_markdown_list([])
+        assert result == ""
+
+    def test_empty_list_ordered(self):
+        result = format_as_markdown_list([], list_type="ordered")
+        assert result == ""
+
+    # ---- Invalid list_type ----
+
+    def test_invalid_list_type_raises_value_error(self):
+        with pytest.raises(ValueError, match="list_type must be either"):
+            format_as_markdown_list(["item"], list_type="bullet")
+
+    # ---- Content preservation ----
+
+    def test_preserves_special_characters(self):
+        """Markdown special characters in items should be passed through as-is."""
+        items = ["**bold**", "[link](url)", "`code`"]
+        result = format_as_markdown_list(items)
+        assert "- **bold**" in result
+        assert "- [link](url)" in result
+        assert "- `code`" in result
+
+    def test_preserves_whitespace_in_items(self):
+        """Leading/trailing whitespace within items should be preserved."""
+        result = format_as_markdown_list(["  padded  "])
+        assert result == "-   padded  "
+
+    def test_multiline_items(self):
+        """Items containing newlines should appear on the same bullet line."""
+        result = format_as_markdown_list(["line1\nline2"])
+        assert result == "- line1\nline2"

--- a/tests/unit/test_misc_utils.py
+++ b/tests/unit/test_misc_utils.py
@@ -1,0 +1,193 @@
+import base64
+
+import pytest
+
+from statgpt.common.utils.misc import (
+    argparse_parse_int_or_none,
+    batched,
+    create_base64_uuid,
+    crc32_hash,
+    crc32_hash_incremental,
+    str2bool,
+)
+
+
+# ---------------------------------------------------------------------------
+# batched
+# ---------------------------------------------------------------------------
+
+
+class TestBatched:
+    def test_exact_batches(self):
+        result = list(batched("ABCDEF", 3))
+        assert result == [["A", "B", "C"], ["D", "E", "F"]]
+
+    def test_last_batch_shorter(self):
+        result = list(batched("ABCDEFG", 3))
+        assert result == [["A", "B", "C"], ["D", "E", "F"], ["G"]]
+
+    def test_batch_size_one(self):
+        result = list(batched([1, 2, 3], 1))
+        assert result == [[1], [2], [3]]
+
+    def test_batch_size_larger_than_input(self):
+        result = list(batched([1, 2], 10))
+        assert result == [[1, 2]]
+
+    def test_empty_iterable(self):
+        result = list(batched([], 3))
+        assert result == []
+
+    def test_works_with_generator(self):
+        gen = (x for x in range(5))
+        result = list(batched(gen, 2))
+        assert result == [[0, 1], [2, 3], [4]]
+
+
+# ---------------------------------------------------------------------------
+# crc32_hash
+# ---------------------------------------------------------------------------
+
+
+class TestCrc32Hash:
+    def test_deterministic(self):
+        """Same input should always produce the same hash."""
+        assert crc32_hash("hello") == crc32_hash("hello")
+
+    def test_different_inputs_different_hashes(self):
+        assert crc32_hash("hello") != crc32_hash("world")
+
+    def test_returns_positive_integer(self):
+        result = crc32_hash("test")
+        assert isinstance(result, int)
+        assert result >= 0
+
+    def test_empty_string(self):
+        result = crc32_hash("")
+        assert isinstance(result, int)
+        assert result >= 0
+
+
+# ---------------------------------------------------------------------------
+# crc32_hash_incremental
+# ---------------------------------------------------------------------------
+
+
+class TestCrc32HashIncremental:
+    def test_deterministic(self):
+        values = ["alpha", "beta", "gamma"]
+        assert crc32_hash_incremental(values) == crc32_hash_incremental(values)
+
+    def test_different_values_different_hashes(self):
+        assert crc32_hash_incremental(["a", "b"]) != crc32_hash_incremental(["c", "d"])
+
+    def test_order_matters(self):
+        """Changing the order of values should produce a different hash."""
+        assert crc32_hash_incremental(["a", "b"]) != crc32_hash_incremental(["b", "a"])
+
+    def test_empty_iterable(self):
+        """Empty input should return 0 (initial CRC value masked to unsigned)."""
+        result = crc32_hash_incremental([])
+        assert result == 0
+
+    def test_returns_positive_integer(self):
+        result = crc32_hash_incremental(["value"])
+        assert isinstance(result, int)
+        assert result >= 0
+
+
+# ---------------------------------------------------------------------------
+# str2bool
+# ---------------------------------------------------------------------------
+
+
+class TestStr2Bool:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("true", True),
+            ("True", True),
+            ("TRUE", True),
+            ("  true  ", True),
+            ("false", False),
+            ("False", False),
+            ("FALSE", False),
+            ("  false  ", False),
+            ("", False),
+            ("yes", False),
+            ("1", False),
+            ("0", False),
+        ],
+    )
+    def test_str2bool(self, value, expected):
+        assert str2bool(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# argparse_parse_int_or_none
+# ---------------------------------------------------------------------------
+
+
+class TestArgparseParseIntOrNone:
+    def test_empty_string_returns_none(self):
+        assert argparse_parse_int_or_none("") is None
+
+    def test_valid_positive_int(self):
+        assert argparse_parse_int_or_none("42") == 42
+
+    def test_valid_zero(self):
+        assert argparse_parse_int_or_none("0") == 0
+
+    def test_valid_negative_int(self):
+        assert argparse_parse_int_or_none("-7") == -7
+
+    def test_large_number(self):
+        assert argparse_parse_int_or_none("999999999") == 999999999
+
+    def test_non_numeric_raises(self):
+        with pytest.raises(ValueError):
+            argparse_parse_int_or_none("abc")
+
+    def test_float_string_raises(self):
+        with pytest.raises(ValueError):
+            argparse_parse_int_or_none("3.14")
+
+
+# ---------------------------------------------------------------------------
+# create_base64_uuid
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBase64Uuid:
+    def test_returns_string(self):
+        result = create_base64_uuid()
+        assert isinstance(result, str)
+
+    def test_length_is_22(self):
+        """128-bit UUID in URL-safe base64 without padding is 22 chars."""
+        result = create_base64_uuid()
+        assert len(result) == 22
+
+    def test_no_padding_characters(self):
+        result = create_base64_uuid()
+        assert "=" not in result
+
+    def test_url_safe_characters(self):
+        """Result should only contain URL-safe base64 characters."""
+        result = create_base64_uuid()
+        assert "+" not in result
+        assert "/" not in result
+
+    def test_unique_values(self):
+        """Two calls should produce different UUIDs."""
+        a = create_base64_uuid()
+        b = create_base64_uuid()
+        assert a != b
+
+    def test_decodable(self):
+        """Result should be decodable back to 16 bytes (128-bit UUID)."""
+        result = create_base64_uuid()
+        # Add back padding for decoding
+        padded = result + "=="
+        decoded = base64.urlsafe_b64decode(padded)
+        assert len(decoded) == 16

--- a/tests/unit/test_misc_utils.py
+++ b/tests/unit/test_misc_utils.py
@@ -5,12 +5,11 @@ import pytest
 from statgpt.common.utils.misc import (
     argparse_parse_int_or_none,
     batched,
-    create_base64_uuid,
     crc32_hash,
     crc32_hash_incremental,
+    create_base64_uuid,
     str2bool,
 )
-
 
 # ---------------------------------------------------------------------------
 # batched

--- a/tests/unit/test_oidc_auth_settings.py
+++ b/tests/unit/test_oidc_auth_settings.py
@@ -1,0 +1,194 @@
+import os
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+# The module creates a singleton OidcAuthSettings() at import time, which runs
+# validation and requires OIDC env vars.  We must set them BEFORE importing.
+_MODULE_LEVEL_ENV = {
+    "OIDC_AUTH_ENABLED": "false",
+}
+
+with patch.dict(os.environ, _MODULE_LEVEL_ENV):
+    from statgpt.admin.settings.oidc_auth import OidcAuthSettings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# All required OIDC fields when auth is enabled
+_FULL_OIDC_ENV = {
+    "OIDC_AUTH_ENABLED": "true",
+    "OIDC_CONFIGURATION_ENDPOINT": "https://login.example.com/.well-known/openid-configuration",
+    "OIDC_CLIENT_ID": "my-client-id",
+    "OIDC_ISSUER": "https://login.example.com",
+    "OIDC_USERNAME_CLAIM": "preferred_username",
+    "ADMIN_ROLES_CLAIM": "roles",
+    "ADMIN_ROLES_VALUES": "admin,superadmin",
+    "ADMIN_SCOPE_CLAIM": "scp",
+    "ADMIN_SCOPE_VALUE": "admin_access",
+    "ADMIN_SCOPE_CLAIM_VALIDATION_ENABLED": "true",
+}
+
+
+def _make_settings(**overrides) -> OidcAuthSettings:
+    """Create OidcAuthSettings from a dict of env-like values merged with defaults."""
+    env = {**_FULL_OIDC_ENV, **overrides}
+    return OidcAuthSettings(**env)
+
+
+# ---------------------------------------------------------------------------
+# Validation: OIDC disabled – no required fields enforced
+# ---------------------------------------------------------------------------
+
+
+class TestOidcDisabled:
+    def test_no_required_fields_when_disabled(self):
+        """When OIDC auth is disabled, missing required fields should not raise."""
+        settings = OidcAuthSettings(OIDC_AUTH_ENABLED=False)
+        assert settings.oidc_auth_enabled is False
+        assert settings.oidc_configuration_endpoint is None
+        assert settings.oidc_client_id is None
+
+    def test_disabled_ignores_scope_fields(self):
+        """Scope validation should be skipped entirely when OIDC is disabled."""
+        settings = OidcAuthSettings(
+            OIDC_AUTH_ENABLED=False,
+            ADMIN_SCOPE_CLAIM_VALIDATION_ENABLED=True,
+        )
+        assert settings.admin_scope_claim is None
+        assert settings.admin_scope_value is None
+
+
+# ---------------------------------------------------------------------------
+# Validation: OIDC enabled – missing required fields
+# ---------------------------------------------------------------------------
+
+
+class TestOidcEnabledValidation:
+    def test_missing_all_required_fields_raises(self):
+        """Enabling OIDC without any required fields must raise ValueError."""
+        with pytest.raises(ValidationError, match="OIDC configuration is incomplete"):
+            OidcAuthSettings(OIDC_AUTH_ENABLED=True)
+
+    @pytest.mark.parametrize(
+        "field_to_remove",
+        [
+            "OIDC_CONFIGURATION_ENDPOINT",
+            "OIDC_CLIENT_ID",
+            "OIDC_ISSUER",
+            "OIDC_USERNAME_CLAIM",
+            "ADMIN_ROLES_CLAIM",
+            "ADMIN_ROLES_VALUES",
+        ],
+    )
+    def test_missing_single_required_field_raises(self, field_to_remove):
+        """Removing any single required field while OIDC is enabled must raise."""
+        env = {**_FULL_OIDC_ENV}
+        env.pop(field_to_remove)
+        with pytest.raises(ValidationError, match=field_to_remove.upper()):
+            OidcAuthSettings(**env)
+
+    def test_missing_scope_fields_when_scope_validation_enabled(self):
+        """Scope fields are required when scope claim validation is enabled."""
+        env = {**_FULL_OIDC_ENV}
+        env.pop("ADMIN_SCOPE_CLAIM")
+        env.pop("ADMIN_SCOPE_VALUE")
+        with pytest.raises(ValidationError, match="OIDC scope configuration is incomplete"):
+            OidcAuthSettings(**env)
+
+    def test_scope_fields_not_required_when_scope_validation_disabled(self):
+        """Scope fields should not be required when scope validation is disabled."""
+        settings = _make_settings(
+            ADMIN_SCOPE_CLAIM_VALIDATION_ENABLED="false",
+            ADMIN_SCOPE_CLAIM=None,
+            ADMIN_SCOPE_VALUE=None,
+        )
+        assert settings.admin_scope_claim_validation_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Validation: OIDC enabled – all fields provided
+# ---------------------------------------------------------------------------
+
+
+class TestOidcEnabledFullConfig:
+    def test_full_config_succeeds(self):
+        """All required fields provided should create a valid settings instance."""
+        settings = _make_settings()
+        assert settings.oidc_auth_enabled is True
+        assert settings.oidc_configuration_endpoint == (
+            "https://login.example.com/.well-known/openid-configuration"
+        )
+        assert settings.oidc_client_id == "my-client-id"
+        assert settings.oidc_issuer == "https://login.example.com"
+        assert settings.oidc_username_claim == "preferred_username"
+        assert settings.admin_roles_claim == "roles"
+        assert settings.admin_roles_values == "admin,superadmin"
+        assert settings.admin_scope_claim == "scp"
+        assert settings.admin_scope_value == "admin_access"
+
+    def test_default_audit_user_id_claim(self):
+        """Default audit user id claim should be 'oid,sub'."""
+        settings = _make_settings()
+        assert settings.oidc_audit_user_id_claim == "oid,sub"
+
+    def test_default_audit_performed_by_name_claim(self):
+        """Default audit performed_by_name claim should be 'unique_name,email'."""
+        settings = _make_settings()
+        assert settings.oidc_audit_performed_by_name_claim == "unique_name,email"
+
+
+# ---------------------------------------------------------------------------
+# _parse_audit_claims static method
+# ---------------------------------------------------------------------------
+
+
+class TestParseAuditClaims:
+    @pytest.mark.parametrize(
+        "input_value, expected",
+        [
+            ("oid,sub", ["oid", "sub"]),
+            ("oid", ["oid"]),
+            ("oid, sub, email", ["oid", "sub", "email"]),
+            ("  oid  ,  sub  ", ["oid", "sub"]),
+            ("", []),
+            (",,,", []),
+            ("a,,b", ["a", "b"]),
+        ],
+    )
+    def test_parse_audit_claims(self, input_value, expected):
+        result = OidcAuthSettings._parse_audit_claims(input_value)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# Properties that use _parse_audit_claims
+# ---------------------------------------------------------------------------
+
+
+class TestAuditClaimProperties:
+    def test_oidc_audit_user_id_claims_property(self):
+        """Property should parse the default 'oid,sub' into a list."""
+        settings = _make_settings()
+        assert settings.oidc_audit_user_id_claims == ["oid", "sub"]
+
+    def test_oidc_audit_performed_by_name_claims_property(self):
+        """Property should parse the default 'unique_name,email' into a list."""
+        settings = _make_settings()
+        assert settings.oidc_audit_performed_by_name_claims == ["unique_name", "email"]
+
+    def test_custom_audit_claims(self):
+        """Custom audit claim values should be parsed correctly."""
+        settings = _make_settings(
+            OIDC_AUDIT_USER_ID_CLAIM="custom_id",
+            OIDC_AUDIT_PERFORMED_BY_NAME_CLAIM="display_name, upn, email",
+        )
+        assert settings.oidc_audit_user_id_claims == ["custom_id"]
+        assert settings.oidc_audit_performed_by_name_claims == [
+            "display_name",
+            "upn",
+            "email",
+        ]


### PR DESCRIPTION
### Applicable issues

N/A

### Description of changes

This PR makes two small, non-intrusive contributions:

#### 1. Modernize `typing.Optional` to `X | None` union syntax

The project `CODE_STYLE.md` recommends using the Python 3.10+ pipe (`|`) union syntax (PEP 604), but a few files still used the legacy `typing.Optional` import. This PR updates all of them:

- `statgpt/common/utils/memory_profiler.py` — 1 annotation updated
- `statgpt/admin/settings/oidc_auth.py` — 7 annotations updated
- `statgpt/app/settings/dial_rag.py` — 2 annotations updated

All `from typing import Optional` imports have been removed from these files.

> Note: `statgpt/common/settings/sdmx.py` was originally part of this PR, but the same modernization was already applied upstream (via #290). After rebasing onto `development`, that file is no longer part of the diff, which also resolves the conflict that was flagged on this PR.

#### 2. Add unit tests for previously untested modules

Three new test files covering modules that previously had no dedicated unit tests:

| Test File | Module Under Test | Coverage |
|-----------|-------------------|----------|
| `tests/unit/test_oidc_auth_settings.py` | `OidcAuthSettings` | Validation logic (enabled/disabled), required field enforcement, scope validation, `_parse_audit_claims` static method, audit claim properties |
| `tests/unit/test_markdown_utils.py` | `format_as_markdown_list` | Ordered/unordered formatting, empty lists, invalid `list_type`, content preservation |
| `tests/unit/test_misc_utils.py` | `misc.py` utilities | `batched`, `crc32_hash`, `crc32_hash_incremental`, `str2bool`, `argparse_parse_int_or_none`, `create_base64_uuid` |

No functional behavior changes. No new dependencies.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.