### PR TITLE
feat: IntervalProcessor - add quarters support #256

### DIFF
--- a/statgpt/common/utils/interval_processor.py
+++ b/statgpt/common/utils/interval_processor.py
@@ -91,6 +91,11 @@ class IntervalProcessor:
         # any interval with months only and +/- sign from date
         self._regular_months_pattern = re.compile(self._REGULAR_MONTHS)
 
+    @staticmethod
+    def _get_quarter_start(date: datetime) -> datetime:
+        month = (date.month - 1) // 3 * 3 + 1
+        return datetime(date.year, month, 1)
+
     def _parse_duration(self, interval_str: str) -> Duration:
         """Parse the interval string to get years and months"""
 
@@ -177,7 +182,7 @@ class IntervalProcessor:
             next_month_start = (date + relativedelta(months=1)).replace(day=1)
             start_date = next_month_start - relativedelta(months=months)
         elif quarters > 0:
-            current_q_start = datetime(date.year, (date.month - 1) // 3 * 3 + 1, 1)
+            current_q_start = self._get_quarter_start(date)
             start_date = current_q_start - relativedelta(months=(quarters - 1) * 3)
         else:
             raise ValueError(f"Invalid interval format: {interval_str}")
@@ -195,7 +200,7 @@ class IntervalProcessor:
                 - relativedelta(days=1)
             )
         elif quarters > 0:
-            current_q_start = datetime(date.year, (date.month - 1) // 3 * 3 + 1, 1)
+            current_q_start = self._get_quarter_start(date)
             end_date = current_q_start + relativedelta(months=quarters * 3) - relativedelta(days=1)
         else:
             raise ValueError(f"Invalid interval format: {interval_str}")
@@ -211,7 +216,7 @@ class IntervalProcessor:
             start_date = datetime(date.year, date.month, 1) - relativedelta(months=months)
             end_date = datetime(date.year, date.month, 1) - relativedelta(days=1)
         elif quarters > 0:
-            current_q_start = datetime(date.year, (date.month - 1) // 3 * 3 + 1, 1)
+            current_q_start = self._get_quarter_start(date)
             start_date = current_q_start - relativedelta(months=quarters * 3)
             end_date = current_q_start - relativedelta(days=1)
         else:
@@ -232,7 +237,7 @@ class IntervalProcessor:
             next_month_start = (date + relativedelta(months=1)).replace(day=1)
             end_date = next_month_start + relativedelta(months=months) - relativedelta(days=1)
         elif quarters > 0:
-            current_q_start = datetime(date.year, (date.month - 1) // 3 * 3 + 1, 1)
+            current_q_start = self._get_quarter_start(date)
             start_date = current_q_start + relativedelta(months=3)
             end_date = (
                 current_q_start + relativedelta(months=(quarters + 1) * 3) - relativedelta(days=1)

--- a/statgpt/common/utils/interval_processor.py
+++ b/statgpt/common/utils/interval_processor.py
@@ -293,39 +293,66 @@ class IntervalProcessor:
         else:
             raise ValueError(f"Invalid interval format: {interval_str}")
 
-    def get_absolute_date(self, relative_datetime: str, date: datetime | None = None) -> datetime:
+    def get_absolute_date(self, pattern: str, date: datetime | None = None) -> datetime:
         """
-        Get the relative date to the datetime
-        :param relative_datetime: The relative datetime string
+        Get the relative date to the datetime.
+
+        For last/next interval types, a ``:start`` or ``:end`` suffix is required
+        to select which bound of the interval to return, e.g. ``last_1y:start``,
+        ``next_2q:end``.  The suffix is only valid on last/next patterns.
+
+        :param pattern: The relative datetime string
         :param date: The reference date
         :return: datetime of relative date
         """
         if date is None:
             date = datetime.now()
 
-        duration = self._parse_duration(relative_datetime)
+        bound: str | None = None
+        if pattern.endswith(":start"):
+            bound = "start"
+            pattern = pattern[:-6]
+        elif pattern.endswith(":end"):
+            bound = "end"
+            pattern = pattern[:-4]
+
+        duration = self._parse_duration(pattern)
         years, months, quarters = duration.years, duration.months, duration.quarters
         interval_type = duration.interval_type
+
+        if interval_type in (IntervalType.LAST, IntervalType.NEXT):
+            if bound is None:
+                raise ValueError(f"Invalid relative format: {pattern}")
+            if interval_type == IntervalType.LAST:
+                start, end = self._process_last(years, months, quarters, date, pattern)
+            else:
+                start, end = self._process_next(years, months, quarters, date, pattern)
+            return start if bound == "start" else end
+
+        if bound is not None:
+            raise ValueError(
+                f":start/:end suffix is only valid for last/next patterns, got: {pattern}"
+            )
 
         if interval_type == IntervalType.NOW:
             return date
         elif interval_type == IntervalType.TO_DATE:
-            return self._process_to_date(years, months, quarters, date, relative_datetime)[0]
+            return self._process_to_date(years, months, quarters, date, pattern)[0]
         elif interval_type == IntervalType.FROM_NOW:
-            return self._process_from_now(years, months, quarters, date, relative_datetime)[1]
+            return self._process_from_now(years, months, quarters, date, pattern)[1]
         elif interval_type == IntervalType.REGULAR_NEGATIVE:
             return self._process_regular_negative(years, months, date)[0]
         elif interval_type == IntervalType.REGULAR_POSITIVE:
             return self._process_regular_positive(years, months, date)[1]
         else:
-            raise ValueError(f"Invalid relative format: {relative_datetime}")
+            raise ValueError(f"Invalid relative format: {pattern}")
 
-    def get_absolute_date_str(self, relative_datetime: str, date: datetime | None = None) -> str:
+    def get_absolute_date_str(self, pattern: str, date: datetime | None = None) -> str:
         """
         Get the relative date to the date string
-        :param relative_datetime: The relative datetime string
+        :param pattern: The relative datetime string
         :param date: The reference date
         :return: iso date string
         """
-        res = self.get_absolute_date(relative_datetime, date)
+        res = self.get_absolute_date(pattern, date)
         return res.date().isoformat()

--- a/statgpt/common/utils/interval_processor.py
+++ b/statgpt/common/utils/interval_processor.py
@@ -97,7 +97,7 @@ class IntervalProcessor:
         return datetime(date.year, month, 1)
 
     def _parse_duration(self, interval_str: str) -> Duration:
-        """Parse the interval string to get years and months"""
+        """Parse the interval string to get years, months, and quarters"""
 
         if interval_str == "now":
             return Duration(years=0, months=0, interval_type=IntervalType.NOW)
@@ -172,78 +172,72 @@ class IntervalProcessor:
 
         return Duration(years=years, months=months, quarters=quarters, interval_type=interval_type)
 
-    def _process_to_date(
-        self, years: int, months: int, quarters: int, date: datetime, interval_str: str
-    ) -> tuple[datetime, datetime]:
-        if years > 0:
-            start_date = datetime(date.year + 1, 1, 1) - relativedelta(years=years)
-        elif months > 0:
+    def _process_to_date(self, duration: Duration, date: datetime) -> tuple[datetime, datetime]:
+        if duration.years > 0:
+            start_date = datetime(date.year + 1, 1, 1) - relativedelta(years=duration.years)
+        elif duration.months > 0:
             # use relativedelta in case `date` is December (12th month) to avoid overflow
             next_month_start = (date + relativedelta(months=1)).replace(day=1)
-            start_date = next_month_start - relativedelta(months=months)
-        elif quarters > 0:
+            start_date = next_month_start - relativedelta(months=duration.months)
+        elif duration.quarters > 0:
             current_q_start = self._get_quarter_start(date)
-            start_date = current_q_start - relativedelta(months=(quarters - 1) * 3)
-        else:
-            raise ValueError(f"Invalid interval format: {interval_str}")
+            start_date = current_q_start - relativedelta(months=(duration.quarters - 1) * 3)
         return start_date, date
 
-    def _process_from_now(
-        self, years: int, months: int, quarters: int, date: datetime, interval_str: str
-    ) -> tuple[datetime, datetime]:
-        if years > 0:
-            end_date = datetime(date.year - 1, 12, 31) + relativedelta(years=years)
-        elif months > 0:
+    def _process_from_now(self, duration: Duration, date: datetime) -> tuple[datetime, datetime]:
+        if duration.years > 0:
+            end_date = datetime(date.year - 1, 12, 31) + relativedelta(years=duration.years)
+        elif duration.months > 0:
             end_date = (
                 datetime(date.year, date.month, 1)
-                + relativedelta(months=months)
+                + relativedelta(months=duration.months)
                 - relativedelta(days=1)
             )
-        elif quarters > 0:
+        elif duration.quarters > 0:
             current_q_start = self._get_quarter_start(date)
-            end_date = current_q_start + relativedelta(months=quarters * 3) - relativedelta(days=1)
-        else:
-            raise ValueError(f"Invalid interval format: {interval_str}")
+            end_date = (
+                current_q_start
+                + relativedelta(months=duration.quarters * 3)
+                - relativedelta(days=1)
+            )
         return date, end_date
 
-    def _process_last(
-        self, years: int, months: int, quarters: int, date: datetime, interval_str: str
-    ) -> tuple[datetime, datetime]:
-        if years > 0:
-            start_date = datetime(date.year, 1, 1) - relativedelta(years=years)
+    def _process_last(self, duration: Duration, date: datetime) -> tuple[datetime, datetime]:
+        if duration.years > 0:
+            start_date = datetime(date.year, 1, 1) - relativedelta(years=duration.years)
             end_date = datetime(date.year, 1, 1) - relativedelta(days=1)
-        elif months > 0:
-            start_date = datetime(date.year, date.month, 1) - relativedelta(months=months)
+        elif duration.months > 0:
+            start_date = datetime(date.year, date.month, 1) - relativedelta(months=duration.months)
             end_date = datetime(date.year, date.month, 1) - relativedelta(days=1)
-        elif quarters > 0:
+        elif duration.quarters > 0:
             current_q_start = self._get_quarter_start(date)
-            start_date = current_q_start - relativedelta(months=quarters * 3)
+            start_date = current_q_start - relativedelta(months=duration.quarters * 3)
             end_date = current_q_start - relativedelta(days=1)
-        else:
-            raise ValueError(f"Invalid interval format: {interval_str}")
         return start_date, end_date
 
-    def _process_next(
-        self, years: int, months: int, quarters: int, date: datetime, interval_str: str
-    ) -> tuple[datetime, datetime]:
-        if years > 0:
+    def _process_next(self, duration: Duration, date: datetime) -> tuple[datetime, datetime]:
+        if duration.years > 0:
             start_date = datetime(date.year, 1, 1) + relativedelta(years=1)
             end_date = (
-                datetime(date.year, 1, 1) + relativedelta(years=years + 1) - relativedelta(days=1)
+                datetime(date.year, 1, 1)
+                + relativedelta(years=duration.years + 1)
+                - relativedelta(days=1)
             )
-        elif months > 0:
+        elif duration.months > 0:
             start_date = datetime(date.year, date.month, 1) + relativedelta(months=1)
             # use relativedelta in case `date` is December (12th month) to avoid overflow
             next_month_start = (date + relativedelta(months=1)).replace(day=1)
-            end_date = next_month_start + relativedelta(months=months) - relativedelta(days=1)
-        elif quarters > 0:
+            end_date = (
+                next_month_start + relativedelta(months=duration.months) - relativedelta(days=1)
+            )
+        elif duration.quarters > 0:
             current_q_start = self._get_quarter_start(date)
             start_date = current_q_start + relativedelta(months=3)
             end_date = (
-                current_q_start + relativedelta(months=(quarters + 1) * 3) - relativedelta(days=1)
+                current_q_start
+                + relativedelta(months=(duration.quarters + 1) * 3)
+                - relativedelta(days=1)
             )
-        else:
-            raise ValueError(f"Invalid interval format: {interval_str}")
         return start_date, end_date
 
     def _process_regular_negative(
@@ -275,23 +269,22 @@ class IntervalProcessor:
             date = datetime.now()
 
         duration = self._parse_duration(interval_str)
-        years, months, quarters = duration.years, duration.months, duration.quarters
-        interval_type = duration.interval_type
 
-        if interval_type == IntervalType.TO_DATE:
-            return self._process_to_date(years, months, quarters, date, interval_str)
-        elif interval_type == IntervalType.FROM_NOW:
-            return self._process_from_now(years, months, quarters, date, interval_str)
-        elif interval_type == IntervalType.LAST:
-            return self._process_last(years, months, quarters, date, interval_str)
-        elif interval_type == IntervalType.NEXT:
-            return self._process_next(years, months, quarters, date, interval_str)
-        elif interval_type == IntervalType.REGULAR_NEGATIVE:
-            return self._process_regular_negative(years, months, date)
-        elif interval_type == IntervalType.REGULAR_POSITIVE:
-            return self._process_regular_positive(years, months, date)
-        else:
-            raise ValueError(f"Invalid interval format: {interval_str}")
+        match duration.interval_type:
+            case IntervalType.TO_DATE:
+                return self._process_to_date(duration, date)
+            case IntervalType.FROM_NOW:
+                return self._process_from_now(duration, date)
+            case IntervalType.LAST:
+                return self._process_last(duration, date)
+            case IntervalType.NEXT:
+                return self._process_next(duration, date)
+            case IntervalType.REGULAR_NEGATIVE:
+                return self._process_regular_negative(duration.years, duration.months, date)
+            case IntervalType.REGULAR_POSITIVE:
+                return self._process_regular_positive(duration.years, duration.months, date)
+            case _:
+                raise ValueError(f"Invalid interval format: {interval_str}")
 
     def get_absolute_date(self, pattern: str, date: datetime | None = None) -> datetime:
         """
@@ -317,16 +310,14 @@ class IntervalProcessor:
             pattern = pattern[:-4]
 
         duration = self._parse_duration(pattern)
-        years, months, quarters = duration.years, duration.months, duration.quarters
-        interval_type = duration.interval_type
 
-        if interval_type in (IntervalType.LAST, IntervalType.NEXT):
+        if duration.interval_type in (IntervalType.LAST, IntervalType.NEXT):
             if bound is None:
                 raise ValueError(f"Invalid relative format: {pattern}")
-            if interval_type == IntervalType.LAST:
-                start, end = self._process_last(years, months, quarters, date, pattern)
+            if duration.interval_type == IntervalType.LAST:
+                start, end = self._process_last(duration, date)
             else:
-                start, end = self._process_next(years, months, quarters, date, pattern)
+                start, end = self._process_next(duration, date)
             return start if bound == "start" else end
 
         if bound is not None:
@@ -334,18 +325,19 @@ class IntervalProcessor:
                 f":start/:end suffix is only valid for last/next patterns, got: {pattern}"
             )
 
-        if interval_type == IntervalType.NOW:
-            return date
-        elif interval_type == IntervalType.TO_DATE:
-            return self._process_to_date(years, months, quarters, date, pattern)[0]
-        elif interval_type == IntervalType.FROM_NOW:
-            return self._process_from_now(years, months, quarters, date, pattern)[1]
-        elif interval_type == IntervalType.REGULAR_NEGATIVE:
-            return self._process_regular_negative(years, months, date)[0]
-        elif interval_type == IntervalType.REGULAR_POSITIVE:
-            return self._process_regular_positive(years, months, date)[1]
-        else:
-            raise ValueError(f"Invalid relative format: {pattern}")
+        match duration.interval_type:
+            case IntervalType.NOW:
+                return date
+            case IntervalType.TO_DATE:
+                return self._process_to_date(duration, date)[0]
+            case IntervalType.FROM_NOW:
+                return self._process_from_now(duration, date)[1]
+            case IntervalType.REGULAR_NEGATIVE:
+                return self._process_regular_negative(duration.years, duration.months, date)[0]
+            case IntervalType.REGULAR_POSITIVE:
+                return self._process_regular_positive(duration.years, duration.months, date)[1]
+            case _:
+                raise ValueError(f"Invalid relative format: {pattern}")
 
     def get_absolute_date_str(self, pattern: str, date: datetime | None = None) -> str:
         """

--- a/statgpt/common/utils/interval_processor.py
+++ b/statgpt/common/utils/interval_processor.py
@@ -182,6 +182,8 @@ class IntervalProcessor:
         elif duration.quarters > 0:
             current_q_start = self._get_quarter_start(date)
             start_date = current_q_start - relativedelta(months=(duration.quarters - 1) * 3)
+        else:
+            raise ValueError("Either years, months, or quarters must be greater than 0")
         return start_date, date
 
     def _process_from_now(self, duration: Duration, date: datetime) -> tuple[datetime, datetime]:
@@ -200,6 +202,8 @@ class IntervalProcessor:
                 + relativedelta(months=duration.quarters * 3)
                 - relativedelta(days=1)
             )
+        else:
+            raise ValueError("Either years, months, or quarters must be greater than 0")
         return date, end_date
 
     def _process_last(self, duration: Duration, date: datetime) -> tuple[datetime, datetime]:
@@ -213,6 +217,8 @@ class IntervalProcessor:
             current_q_start = self._get_quarter_start(date)
             start_date = current_q_start - relativedelta(months=duration.quarters * 3)
             end_date = current_q_start - relativedelta(days=1)
+        else:
+            raise ValueError("Either years, months, or quarters must be greater than 0")
         return start_date, end_date
 
     def _process_next(self, duration: Duration, date: datetime) -> tuple[datetime, datetime]:
@@ -238,6 +244,8 @@ class IntervalProcessor:
                 + relativedelta(months=(duration.quarters + 1) * 3)
                 - relativedelta(days=1)
             )
+        else:
+            raise ValueError("Either years, months, or quarters must be greater than 0")
         return start_date, end_date
 
     def _process_regular_negative(

--- a/statgpt/common/utils/interval_processor.py
+++ b/statgpt/common/utils/interval_processor.py
@@ -20,12 +20,18 @@ class IntervalType(StrEnum):
 class Duration(BaseModel):
     years: int = Field()
     months: int = Field()
+    quarters: int = Field(default=0)
     interval_type: IntervalType = Field()
 
     @model_validator(mode="after")
     def validate_duration(self) -> Self:
-        if self.years <= 0 and self.months <= 0 and not self.interval_type == IntervalType.NOW:
-            raise ValueError("Either years or months must be greater than 0")
+        if (
+            self.years <= 0
+            and self.months <= 0
+            and self.quarters <= 0
+            and not self.interval_type == IntervalType.NOW
+        ):
+            raise ValueError("Either years, months, or quarters must be greater than 0")
         return self
 
 
@@ -33,36 +39,39 @@ class IntervalProcessor:
     """
     Process interval strings to generate date ranges.
 
-    Supported interval formats:
+    Units: years (y/year/years), months (m/month/months), quarters (q/quarter/quarters).
+    Separators: space or underscore. Number is optional (defaults to 1).
+    Quarters are calendar-aligned (Q1=Jan-Mar … Q4=Oct-Dec) and only
+    supported in calendar-aligned types (last/next/to_date/from_now).
 
-        Note: All examples assume current date is 2025-10-10
+    Interval types (examples assume current date is 2025-10-10, in Q4):
 
-        - "last <n> years/months"
-            Calendar years/months preceding current date
-            Example: "last 1 year" → 2024-01-01 to 2024-12-31
+    Type      Description                               Example          Result
+    ────────  ────────────────────────────────────────  ───────────────  ──────────────────────────
+    regular   Rolling offset from current date          "-1y"            2024-10-10 … 2025-10-10
+              (quarters are forbidden)                  "-3m"            2025-07-10 … 2025-10-10
+                                                        "1y"             2025-10-10 … 2026-10-10
+    last      Completed calendar periods before current "last 1y"        2024-01-01 … 2024-12-31
+                                                        "last 1m"        2025-09-01 … 2025-09-30
+                                                        "last 1q"        2025-07-01 … 2025-09-30
+    next      Calendar periods after current            "next 1y"        2026-01-01 … 2026-12-31
+                                                        "next 1m"        2025-11-01 … 2025-11-30
+                                                        "next 1q"        2026-01-01 … 2026-03-31
+    to_date   Start of current period to current date   "1y to date"     2025-01-01 … 2025-10-10
+                                                        "1m to date"     2025-10-01 … 2025-10-10
+                                                        "1q to date"     2025-10-01 … 2025-10-10
+    from_now  Current date to end of current period     "1y from now"    2025-10-10 … 2025-12-31
+                                                        "1m from now"    2025-10-10 … 2025-10-31
+                                                        "1q from now"    2025-10-10 … 2025-12-31
 
-        - "next <n> years/months"
-            Calendar years/months following current date
-            Example: "next 1 year" → 2026-01-01 to 2026-12-31
-
-        - "<n> years/months to date"
-            From start of past calendar year/month until current date
-            Example: "1 year to date" → 2025-01-01 to 2025-10-10
-
-        - "<n> years/months from now"
-            From current date until end of future calendar year/month
-            Example: "1 year from now" → 2025-10-10 to 2026-12-31
-
-        - "(+-)?<n> years/months"
-            Relative period from current date
-            Example: "1 year" → 2025-10-10 to 2026-10-10
-            Example: "-1 year" → 2024-10-10 to 2025-10-10
+    See tests/unit/test_interval_processor.py for all accepted input variants.
     """
 
     _NUMBER = r"[1-9]\d*"
     _YEARS = r"y(?:ears?)?"
     _MONTHS = r"m(?:onths?)?"
-    _UNITS = f"{_YEARS}|{_MONTHS}"
+    _QUARTERS = r"q(?:uarters?)?"
+    _UNITS = f"{_YEARS}|{_MONTHS}|{_QUARTERS}"
     _SPACE = r"[_ ]"
     _SIGN = r"[-+]"
     _LAST_NEXT = (
@@ -88,6 +97,8 @@ class IntervalProcessor:
         if interval_str == "now":
             return Duration(years=0, months=0, interval_type=IntervalType.NOW)
 
+        quarters = 0
+
         if match := self._last_next_pattern.match(interval_str):
             prefix = match.group("prefix")
             interval_type = IntervalType(prefix)
@@ -98,6 +109,10 @@ class IntervalProcessor:
             elif units.startswith('m'):
                 years = 0
                 months = int(match.group("number") or 1)
+            elif units.startswith('q'):
+                years = 0
+                months = 0
+                quarters = int(match.group("number") or 1)
             else:
                 raise ValueError(f"Invalid interval format: {interval_str}")
         elif match := self._to_date_from_now_pattern.match(interval_str):
@@ -110,6 +125,10 @@ class IntervalProcessor:
             elif units.startswith('m'):
                 years = 0
                 months = int(match.group("number") or 1)
+            elif units.startswith('q'):
+                years = 0
+                months = 0
+                quarters = int(match.group("number") or 1)
             else:
                 raise ValueError(f"Invalid interval format: {interval_str}")
         elif match := (
@@ -143,11 +162,13 @@ class IntervalProcessor:
             raise ValueError(f"Invalid interval format: {interval_str}")
         if months < 2 and units == 'months':
             raise ValueError(f"Invalid interval format: {interval_str}")
+        if quarters < 2 and units == 'quarters':
+            raise ValueError(f"Invalid interval format: {interval_str}")
 
-        return Duration(years=years, months=months, interval_type=interval_type)
+        return Duration(years=years, months=months, quarters=quarters, interval_type=interval_type)
 
     def _process_to_date(
-        self, years: int, months: int, date: datetime, interval_str: str
+        self, years: int, months: int, quarters: int, date: datetime, interval_str: str
     ) -> tuple[datetime, datetime]:
         if years > 0:
             start_date = datetime(date.year + 1, 1, 1) - relativedelta(years=years)
@@ -155,12 +176,15 @@ class IntervalProcessor:
             # use relativedelta in case `date` is December (12th month) to avoid overflow
             next_month_start = (date + relativedelta(months=1)).replace(day=1)
             start_date = next_month_start - relativedelta(months=months)
+        elif quarters > 0:
+            current_q_start = datetime(date.year, (date.month - 1) // 3 * 3 + 1, 1)
+            start_date = current_q_start - relativedelta(months=(quarters - 1) * 3)
         else:
             raise ValueError(f"Invalid interval format: {interval_str}")
         return start_date, date
 
     def _process_from_now(
-        self, years: int, months: int, date: datetime, interval_str: str
+        self, years: int, months: int, quarters: int, date: datetime, interval_str: str
     ) -> tuple[datetime, datetime]:
         if years > 0:
             end_date = datetime(date.year - 1, 12, 31) + relativedelta(years=years)
@@ -170,12 +194,15 @@ class IntervalProcessor:
                 + relativedelta(months=months)
                 - relativedelta(days=1)
             )
+        elif quarters > 0:
+            current_q_start = datetime(date.year, (date.month - 1) // 3 * 3 + 1, 1)
+            end_date = current_q_start + relativedelta(months=quarters * 3) - relativedelta(days=1)
         else:
             raise ValueError(f"Invalid interval format: {interval_str}")
         return date, end_date
 
     def _process_last(
-        self, years: int, months: int, date: datetime, interval_str: str
+        self, years: int, months: int, quarters: int, date: datetime, interval_str: str
     ) -> tuple[datetime, datetime]:
         if years > 0:
             start_date = datetime(date.year, 1, 1) - relativedelta(years=years)
@@ -183,12 +210,16 @@ class IntervalProcessor:
         elif months > 0:
             start_date = datetime(date.year, date.month, 1) - relativedelta(months=months)
             end_date = datetime(date.year, date.month, 1) - relativedelta(days=1)
+        elif quarters > 0:
+            current_q_start = datetime(date.year, (date.month - 1) // 3 * 3 + 1, 1)
+            start_date = current_q_start - relativedelta(months=quarters * 3)
+            end_date = current_q_start - relativedelta(days=1)
         else:
             raise ValueError(f"Invalid interval format: {interval_str}")
         return start_date, end_date
 
     def _process_next(
-        self, years: int, months: int, date: datetime, interval_str: str
+        self, years: int, months: int, quarters: int, date: datetime, interval_str: str
     ) -> tuple[datetime, datetime]:
         if years > 0:
             start_date = datetime(date.year, 1, 1) + relativedelta(years=1)
@@ -200,6 +231,12 @@ class IntervalProcessor:
             # use relativedelta in case `date` is December (12th month) to avoid overflow
             next_month_start = (date + relativedelta(months=1)).replace(day=1)
             end_date = next_month_start + relativedelta(months=months) - relativedelta(days=1)
+        elif quarters > 0:
+            current_q_start = datetime(date.year, (date.month - 1) // 3 * 3 + 1, 1)
+            start_date = current_q_start + relativedelta(months=3)
+            end_date = (
+                current_q_start + relativedelta(months=(quarters + 1) * 3) - relativedelta(days=1)
+            )
         else:
             raise ValueError(f"Invalid interval format: {interval_str}")
         return start_date, end_date
@@ -233,16 +270,17 @@ class IntervalProcessor:
             date = datetime.now()
 
         duration = self._parse_duration(interval_str)
-        years, months, interval_type = duration.years, duration.months, duration.interval_type
+        years, months, quarters = duration.years, duration.months, duration.quarters
+        interval_type = duration.interval_type
 
         if interval_type == IntervalType.TO_DATE:
-            return self._process_to_date(years, months, date, interval_str)
+            return self._process_to_date(years, months, quarters, date, interval_str)
         elif interval_type == IntervalType.FROM_NOW:
-            return self._process_from_now(years, months, date, interval_str)
+            return self._process_from_now(years, months, quarters, date, interval_str)
         elif interval_type == IntervalType.LAST:
-            return self._process_last(years, months, date, interval_str)
+            return self._process_last(years, months, quarters, date, interval_str)
         elif interval_type == IntervalType.NEXT:
-            return self._process_next(years, months, date, interval_str)
+            return self._process_next(years, months, quarters, date, interval_str)
         elif interval_type == IntervalType.REGULAR_NEGATIVE:
             return self._process_regular_negative(years, months, date)
         elif interval_type == IntervalType.REGULAR_POSITIVE:
@@ -261,14 +299,15 @@ class IntervalProcessor:
             date = datetime.now()
 
         duration = self._parse_duration(relative_datetime)
-        years, months, interval_type = duration.years, duration.months, duration.interval_type
+        years, months, quarters = duration.years, duration.months, duration.quarters
+        interval_type = duration.interval_type
 
         if interval_type == IntervalType.NOW:
             return date
         elif interval_type == IntervalType.TO_DATE:
-            return self._process_to_date(years, months, date, relative_datetime)[0]
+            return self._process_to_date(years, months, quarters, date, relative_datetime)[0]
         elif interval_type == IntervalType.FROM_NOW:
-            return self._process_from_now(years, months, date, relative_datetime)[1]
+            return self._process_from_now(years, months, quarters, date, relative_datetime)[1]
         elif interval_type == IntervalType.REGULAR_NEGATIVE:
             return self._process_regular_negative(years, months, date)[0]
         elif interval_type == IntervalType.REGULAR_POSITIVE:

--- a/tests/unit/test_interval_processor.py
+++ b/tests/unit/test_interval_processor.py
@@ -566,7 +566,7 @@ def test_default_current_date(processor: IntervalProcessor) -> None:
         ("q_from_now", datetime(2025, 8, 15), datetime(2025, 9, 30)),
     ],
 )
-def test_get_absolute_date(
+def test_get_absolute_date_regular_to_date_from_now(
     processor: IntervalProcessor,
     interval_str: str,
     current_date: datetime,
@@ -579,18 +579,89 @@ def test_get_absolute_date(
 @pytest.mark.parametrize(
     "interval_str",
     [
+        "last_y",
         "last_year",
+        "last_q",
         "last_quarter",
+        "last_m",
         "last_month",
+        "next_y",
         "next_year",
+        "next_q",
         "next_quarter",
+        "next_m",
         "next_month",
     ],
 )
-def test_get_absolute_date_invalid_for_last_next(
+def test_get_absolute_date_invalid_for_last_next_no_suffix(
     processor: IntervalProcessor, interval_str: str
 ) -> None:
     with pytest.raises(ValueError, match="Invalid relative format"):
+        processor.get_absolute_date(interval_str, datetime(2025, 10, 10))
+
+
+@pytest.mark.parametrize(
+    "interval_str,current_date,expected_date",
+    [
+        # ── last:start → start of completed period ──
+        ("last_1y:start", datetime(2025, 10, 10), datetime(2024, 1, 1)),
+        ("last_2y:start", datetime(2025, 10, 10), datetime(2023, 1, 1)),
+        ("last_1m:start", datetime(2025, 10, 10), datetime(2025, 9, 1)),
+        ("last_2m:start", datetime(2025, 10, 10), datetime(2025, 8, 1)),
+        ("last_1q:start", datetime(2025, 10, 10), datetime(2025, 7, 1)),
+        ("last_2q:start", datetime(2025, 10, 10), datetime(2025, 4, 1)),
+        ("last_quarter:start", datetime(2025, 2, 15), datetime(2024, 10, 1)),
+        # ── last:end → end of completed period ──
+        ("last_1y:end", datetime(2025, 10, 10), datetime(2024, 12, 31)),
+        ("last_2y:end", datetime(2025, 10, 10), datetime(2024, 12, 31)),
+        ("last_1m:end", datetime(2025, 10, 10), datetime(2025, 9, 30)),
+        ("last_2m:end", datetime(2025, 10, 10), datetime(2025, 9, 30)),
+        ("last_1q:end", datetime(2025, 10, 10), datetime(2025, 9, 30)),
+        ("last_2q:end", datetime(2025, 10, 10), datetime(2025, 9, 30)),
+        ("last_quarter:end", datetime(2025, 2, 15), datetime(2024, 12, 31)),
+        # ── next:start → start of upcoming period ──
+        ("next_1y:start", datetime(2025, 10, 10), datetime(2026, 1, 1)),
+        ("next_2y:start", datetime(2025, 10, 10), datetime(2026, 1, 1)),
+        ("next_1m:start", datetime(2025, 10, 10), datetime(2025, 11, 1)),
+        ("next_2m:start", datetime(2025, 10, 10), datetime(2025, 11, 1)),
+        ("next_1q:start", datetime(2025, 10, 10), datetime(2026, 1, 1)),
+        ("next_2q:start", datetime(2025, 10, 10), datetime(2026, 1, 1)),
+        ("next_2q:start", datetime(2025, 2, 10), datetime(2025, 4, 1)),
+        # ── next:end → end of upcoming period ──
+        ("next_1y:end", datetime(2025, 10, 10), datetime(2026, 12, 31)),
+        ("next_2y:end", datetime(2025, 10, 10), datetime(2027, 12, 31)),
+        ("next_1m:end", datetime(2025, 10, 10), datetime(2025, 11, 30)),
+        ("next_2m:end", datetime(2025, 10, 10), datetime(2025, 12, 31)),
+        ("next_5m:end", datetime(2025, 10, 10), datetime(2026, 3, 31)),
+        ("next_1q:end", datetime(2025, 10, 10), datetime(2026, 3, 31)),
+        ("next_2q:end", datetime(2025, 10, 10), datetime(2026, 6, 30)),
+        ("next_quarter:end", datetime(2025, 8, 15), datetime(2025, 12, 31)),
+    ],
+)
+def test_get_absolute_date_last_next_with_suffix(
+    processor: IntervalProcessor,
+    interval_str: str,
+    current_date: datetime,
+    expected_date: datetime,
+) -> None:
+    result = processor.get_absolute_date(interval_str, current_date)
+    assert result == expected_date
+
+
+@pytest.mark.parametrize(
+    "interval_str",
+    [
+        "now:start",
+        "-1y:end",
+        "1y:start",
+        "1y_to_date:start",
+        "1m_from_now:end",
+    ],
+)
+def test_get_absolute_date_suffix_invalid_on_non_last_next(
+    processor: IntervalProcessor, interval_str: str
+) -> None:
+    with pytest.raises(ValueError, match=":start/:end suffix is only valid for last/next"):
         processor.get_absolute_date(interval_str, datetime(2025, 10, 10))
 
 

--- a/tests/unit/test_interval_processor.py
+++ b/tests/unit/test_interval_processor.py
@@ -104,6 +104,18 @@ def _test_interval(
         # correct end of month detection
         (
             "1m",
+            datetime(2025, 1, 29),
+            datetime(2025, 1, 29),
+            datetime(2025, 2, 28),
+        ),
+        (
+            "1m",
+            datetime(2025, 1, 30),
+            datetime(2025, 1, 30),
+            datetime(2025, 2, 28),
+        ),
+        (
+            "1m",
             datetime(2025, 1, 31),
             datetime(2025, 1, 31),
             datetime(2025, 2, 28),
@@ -113,6 +125,30 @@ def _test_interval(
             datetime(2025, 2, 28),
             datetime(2025, 2, 28),
             datetime(2025, 3, 28),  # NOTE: must be 28th, not 31st
+        ),
+        (
+            "1m",
+            datetime(2025, 2, 27),
+            datetime(2025, 2, 27),
+            datetime(2025, 3, 27),
+        ),
+        (
+            "-1m",
+            datetime(2025, 3, 29),
+            datetime(2025, 2, 28),
+            datetime(2025, 3, 29),
+        ),
+        (
+            "-1m",
+            datetime(2025, 3, 30),
+            datetime(2025, 2, 28),
+            datetime(2025, 3, 30),
+        ),
+        (
+            "-1m",
+            datetime(2025, 3, 31),
+            datetime(2025, 2, 28),
+            datetime(2025, 3, 31),
         ),
     ],
 )
@@ -167,6 +203,26 @@ def test_regular(
             datetime(2025, 12, 1),
             datetime(2025, 12, 10),
         ),
+        # quarter tests — Q4 (Oct-Dec)
+        (
+            "q_to_date",
+            datetime(2025, 10, 10),
+            datetime(2025, 10, 1),
+            datetime(2025, 10, 10),
+        ),
+        (
+            "2q_to_date",
+            datetime(2025, 10, 10),
+            datetime(2025, 7, 1),
+            datetime(2025, 10, 10),
+        ),
+        # Q3 (Jul-Sep)
+        (
+            "q_to_date",
+            datetime(2025, 8, 15),
+            datetime(2025, 7, 1),
+            datetime(2025, 8, 15),
+        ),
     ],
 )
 def test_to_date(
@@ -207,6 +263,26 @@ def test_to_date(
             datetime(2025, 10, 10),
             datetime(2025, 11, 30),
         ),
+        # quarter tests — Q4 (Oct-Dec)
+        (
+            "q_from_now",
+            datetime(2025, 10, 10),
+            datetime(2025, 10, 10),
+            datetime(2025, 12, 31),
+        ),
+        (
+            "2q_from_now",
+            datetime(2025, 10, 10),
+            datetime(2025, 10, 10),
+            datetime(2026, 3, 31),
+        ),
+        # Q3 (Jul-Sep)
+        (
+            "q_from_now",
+            datetime(2025, 8, 15),
+            datetime(2025, 8, 15),
+            datetime(2025, 9, 30),
+        ),
     ],
 )
 def test_from_now(
@@ -245,6 +321,32 @@ def test_from_now(
             "last_2y",
             datetime(2025, 10, 10),
             datetime(2023, 1, 1),
+            datetime(2024, 12, 31),
+        ),
+        # quarter tests
+        (
+            "last_quarter",
+            datetime(2025, 10, 10),
+            datetime(2025, 7, 1),
+            datetime(2025, 9, 30),
+        ),
+        (
+            "last_1q",
+            datetime(2025, 10, 10),
+            datetime(2025, 7, 1),
+            datetime(2025, 9, 30),
+        ),
+        (
+            "last_2q",
+            datetime(2025, 10, 10),
+            datetime(2025, 4, 1),
+            datetime(2025, 9, 30),
+        ),
+        # year boundary: Q1 → previous Q4
+        (
+            "last_quarter",
+            datetime(2025, 2, 15),
+            datetime(2024, 10, 1),
             datetime(2024, 12, 31),
         ),
     ],
@@ -319,6 +421,39 @@ def test_last(
             datetime(2025, 4, 1),
             datetime(2025, 4, 30),
         ),
+        # quarter tests
+        (
+            "next_quarter",
+            datetime(2025, 10, 10),
+            datetime(2026, 1, 1),
+            datetime(2026, 3, 31),
+        ),
+        (
+            "next_1q",
+            datetime(2025, 10, 10),
+            datetime(2026, 1, 1),
+            datetime(2026, 3, 31),
+        ),
+        (
+            "next_2q",
+            datetime(2025, 10, 10),
+            datetime(2026, 1, 1),
+            datetime(2026, 6, 30),
+        ),
+        # Q3 → next is Q4 (same year)
+        (
+            "next_quarter",
+            datetime(2025, 8, 15),
+            datetime(2025, 10, 1),
+            datetime(2025, 12, 31),
+        ),
+        # Q4 → next is Q1 of next year
+        (
+            "next_quarter",
+            datetime(2025, 12, 10),
+            datetime(2026, 1, 1),
+            datetime(2026, 3, 31),
+        ),
     ],
 )
 def test_next(
@@ -351,6 +486,36 @@ def test_next(
         "1y0m",
         "1m0y",
         "1m3m",
+        # quarter regular types are forbidden
+        "q",
+        "0q",
+        "1q",
+        "2q",
+        "quarter",
+        "2quarters",
+        "-q",
+        "-1q",
+        "-2q",
+        "-quarter",
+        "-1quarter",
+        "-2quarters",
+        "+q",
+        "+1q",
+        "+2q",
+        "+quarter",
+        "+2quarters",
+        # mixed with quarters are forbidden
+        "1y1q",
+        "2y1q",
+        "-1y1q",
+        #
+        "1q2m",
+        "1q1y",
+        #
+        "1m1q",
+        "-1m1q",
+        # plural with count < 2
+        "1quarters",
     ],
 )
 def test_invalid_interval_format(processor: IntervalProcessor, interval_str: str) -> None:
@@ -366,28 +531,109 @@ def test_default_current_date(processor: IntervalProcessor) -> None:
 
 
 @pytest.mark.parametrize(
-    "interval_str,expected_years,expected_months",
+    "interval_str,expected_years,expected_months,expected_quarters",
     [
-        ("year", 1, 0),
-        ("1y", 1, 0),
-        ("1year", 1, 0),
-        ("2year", 2, 0),  # should this be valid?
-        ("2years", 2, 0),
-        #
-        ("month", 0, 1),
-        ("1m", 0, 1),
-        ("1month", 0, 1),
-        ("2m", 0, 2),
-        ("2month", 0, 2),  # should this be valid?
-        ("2months", 0, 2),
-        ("3m", 0, 3),
-        #
-        ("1y2m", 1, 2),
-        #
-        ("last_1y", 1, 0),
-        ("last_2y", 2, 0),
-        ("last_y", 1, 0),
-        ("last_m", 0, 1),
+        # ── Regular positive (years) ──
+        ("year", 1, 0, 0),
+        ("1y", 1, 0, 0),
+        ("1year", 1, 0, 0),
+        ("2y", 2, 0, 0),
+        ("2year", 2, 0, 0),  # should this be valid?
+        ("2years", 2, 0, 0),
+        # ── Regular positive (months) ──
+        ("month", 0, 1, 0),
+        ("1m", 0, 1, 0),
+        ("1month", 0, 1, 0),
+        ("2m", 0, 2, 0),
+        ("2month", 0, 2, 0),  # should this be valid?
+        ("2months", 0, 2, 0),
+        ("3m", 0, 3, 0),
+        # ── Regular negative (years) ──
+        ("-year", 1, 0, 0),
+        ("-1y", 1, 0, 0),
+        ("-1year", 1, 0, 0),
+        ("-2y", 2, 0, 0),
+        ("-2years", 2, 0, 0),
+        # ── Regular negative (months) ──
+        ("-month", 0, 1, 0),
+        ("-1m", 0, 1, 0),
+        ("-1month", 0, 1, 0),
+        ("-2m", 0, 2, 0),
+        ("-2months", 0, 2, 0),
+        # ── Regular (combined) ──
+        ("1y2m", 1, 2, 0),
+        ("-1y2m", 1, 2, 0),
+        # ── Last ──
+        ("last_y", 1, 0, 0),
+        ("last_year", 1, 0, 0),
+        ("last_1y", 1, 0, 0),
+        ("last_1year", 1, 0, 0),
+        ("last_2y", 2, 0, 0),
+        ("last_2years", 2, 0, 0),
+        ("last_m", 0, 1, 0),
+        ("last_month", 0, 1, 0),
+        ("last_1m", 0, 1, 0),
+        ("last_2m", 0, 2, 0),
+        ("last_2months", 0, 2, 0),
+        ("last_q", 0, 0, 1),
+        ("last_quarter", 0, 0, 1),
+        ("last_1q", 0, 0, 1),
+        ("last_1quarter", 0, 0, 1),
+        ("last_2q", 0, 0, 2),
+        ("last_2quarters", 0, 0, 2),
+        # ── Next ──
+        ("next_y", 1, 0, 0),
+        ("next_year", 1, 0, 0),
+        ("next_1y", 1, 0, 0),
+        ("next_1year", 1, 0, 0),
+        ("next_2y", 2, 0, 0),
+        ("next_2years", 2, 0, 0),
+        ("next_m", 0, 1, 0),
+        ("next_month", 0, 1, 0),
+        ("next_1m", 0, 1, 0),
+        ("next_2m", 0, 2, 0),
+        ("next_2months", 0, 2, 0),
+        ("next_5m", 0, 5, 0),
+        ("next_q", 0, 0, 1),
+        ("next_quarter", 0, 0, 1),
+        ("next_1q", 0, 0, 1),
+        ("next_1quarter", 0, 0, 1),
+        ("next_2q", 0, 0, 2),
+        ("next_2quarters", 0, 0, 2),
+        # ── To date ──
+        ("y_to_date", 1, 0, 0),
+        ("year_to_date", 1, 0, 0),
+        ("1y_to_date", 1, 0, 0),
+        ("1year_to_date", 1, 0, 0),
+        ("2y_to_date", 2, 0, 0),
+        ("2years_to_date", 2, 0, 0),
+        ("m_to_date", 0, 1, 0),
+        ("month_to_date", 0, 1, 0),
+        ("1m_to_date", 0, 1, 0),
+        ("2m_to_date", 0, 2, 0),
+        ("2months_to_date", 0, 2, 0),
+        ("q_to_date", 0, 0, 1),
+        ("quarter_to_date", 0, 0, 1),
+        ("1q_to_date", 0, 0, 1),
+        ("2q_to_date", 0, 0, 2),
+        ("2quarters_to_date", 0, 0, 2),
+        # ── From now ──
+        ("y_from_now", 1, 0, 0),
+        ("year_from_now", 1, 0, 0),
+        ("1y_from_now", 1, 0, 0),
+        ("1year_from_now", 1, 0, 0),
+        ("2y_from_now", 2, 0, 0),
+        ("2years_from_now", 2, 0, 0),
+        ("m_from_now", 0, 1, 0),
+        ("month_from_now", 0, 1, 0),
+        ("1m_from_now", 0, 1, 0),
+        ("2m_from_now", 0, 2, 0),
+        ("2months_from_now", 0, 2, 0),
+        ("q_from_now", 0, 0, 1),
+        ("quarter_from_now", 0, 0, 1),
+        ("1q_from_now", 0, 0, 1),
+        ("2q_from_now", 0, 0, 2),
+        ("2quarters_from_now", 0, 0, 2),
     ],
 )
 def test_parse_duration(
@@ -395,7 +641,9 @@ def test_parse_duration(
     interval_str: str,
     expected_years: int,
     expected_months: int,
+    expected_quarters: int,
 ) -> None:
     duration = processor._parse_duration(interval_str)
     assert duration.years == expected_years
     assert duration.months == expected_months
+    assert duration.quarters == expected_quarters

--- a/tests/unit/test_interval_processor.py
+++ b/tests/unit/test_interval_processor.py
@@ -515,6 +515,7 @@ def test_next(
         "1m1q",
         "-1m1q",
         # plural with count < 2
+        "quarters",
         "1quarters",
     ],
 )
@@ -528,6 +529,69 @@ def test_default_current_date(processor: IntervalProcessor) -> None:
     start, end = processor.get_interval("-1y")
     assert start == datetime(2024, 10, 10)
     assert end == datetime(2025, 10, 10)
+
+
+@pytest.mark.parametrize(
+    "interval_str,current_date,expected_date",
+    [
+        # ── now ──
+        ("now", datetime(2025, 10, 10), datetime(2025, 10, 10)),
+        # ── regular negative → returns start date ──
+        ("-1y", datetime(2025, 10, 10), datetime(2024, 10, 10)),
+        ("-1y2m", datetime(2025, 10, 10), datetime(2024, 8, 10)),
+        ("-3m", datetime(2025, 10, 10), datetime(2025, 7, 10)),
+        ("-month", datetime(2025, 10, 10), datetime(2025, 9, 10)),
+        ("-1m", datetime(2025, 3, 31), datetime(2025, 2, 28)),
+        # ── regular positive → returns end date ──
+        ("1y", datetime(2025, 10, 10), datetime(2026, 10, 10)),
+        ("3m", datetime(2025, 10, 10), datetime(2026, 1, 10)),
+        ("1y2m", datetime(2025, 10, 10), datetime(2026, 12, 10)),
+        ("1m", datetime(2025, 12, 10), datetime(2026, 1, 10)),
+        ("1m", datetime(2025, 1, 31), datetime(2025, 2, 28)),
+        # ── to_date → returns start of period ──
+        ("y_to_date", datetime(2025, 10, 10), datetime(2025, 1, 1)),
+        ("2y_to_date", datetime(2025, 10, 10), datetime(2024, 1, 1)),
+        ("m_to_date", datetime(2025, 10, 10), datetime(2025, 10, 1)),
+        ("2m_to_date", datetime(2025, 10, 10), datetime(2025, 9, 1)),
+        ("q_to_date", datetime(2025, 10, 10), datetime(2025, 10, 1)),
+        ("2q_to_date", datetime(2025, 10, 10), datetime(2025, 7, 1)),
+        ("q_to_date", datetime(2025, 8, 15), datetime(2025, 7, 1)),
+        # ── from_now → returns end of period ──
+        ("y_from_now", datetime(2025, 10, 10), datetime(2025, 12, 31)),
+        ("2y_from_now", datetime(2025, 10, 10), datetime(2026, 12, 31)),
+        ("m_from_now", datetime(2025, 10, 10), datetime(2025, 10, 31)),
+        ("2m_from_now", datetime(2025, 10, 10), datetime(2025, 11, 30)),
+        ("q_from_now", datetime(2025, 10, 10), datetime(2025, 12, 31)),
+        ("2q_from_now", datetime(2025, 10, 10), datetime(2026, 3, 31)),
+        ("q_from_now", datetime(2025, 8, 15), datetime(2025, 9, 30)),
+    ],
+)
+def test_get_absolute_date(
+    processor: IntervalProcessor,
+    interval_str: str,
+    current_date: datetime,
+    expected_date: datetime,
+) -> None:
+    result = processor.get_absolute_date(interval_str, current_date)
+    assert result == expected_date
+
+
+@pytest.mark.parametrize(
+    "interval_str",
+    [
+        "last_year",
+        "last_quarter",
+        "last_month",
+        "next_year",
+        "next_quarter",
+        "next_month",
+    ],
+)
+def test_get_absolute_date_invalid_for_last_next(
+    processor: IntervalProcessor, interval_str: str
+) -> None:
+    with pytest.raises(ValueError, match="Invalid relative format"):
+        processor.get_absolute_date(interval_str, datetime(2025, 10, 10))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #256

### Description of changes

<!-- Please explain the changes you made right below this line. -->
1. add support for quarters
2. add support for last/next intervals in `get_absolute_date()` function. use `:start`/`:end` postfixes to determine which bound to return for last/next patterns

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
