### PR TITLE
chore: add integration-* branches to PR workflow trigger (#262)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: PR Workflow
 
 on:
   pull_request:
-    branches: [development, release-*]
+    branches: [development, release-*, integration-*]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
No issue. This PR is cherry-pick of PR #262 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
The PR Workflow (`.github/workflows/pr.yml`) only triggered for PRs targeting `development` and `release-*` branches. PRs targeting `integration-*` branches (e.g., `integration-0.5`) were missing the required status checks (`test/style_checks`, `test/code_checks`, `test/ort`, `docker_build`), causing them to be permanently blocked.

This change adds `integration-*` to the branch filter so the PR workflow runs for integration branches as well.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] ~Deployed and tested in a `Review` environment.~ N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
