### PR TITLE
fix: use short-lived DB sessions instead of request-scoped sessions #174

### DIFF
--- a/statgpt/app/application/channel_completion.py
+++ b/statgpt/app/application/channel_completion.py
@@ -18,7 +18,6 @@ from statgpt.app.services.chat_facade import ChannelServiceFacade
 from statgpt.app.settings.dial_app import dial_app_settings
 from statgpt.app.utils.dial_exceptions import RateLimitException
 from statgpt.app.utils.dial_stages import optional_timed_stage
-from statgpt.common.models.database import get_readonly_session_context_manager
 from statgpt.common.schemas.dial import Pricing
 from statgpt.common.schemas.token_usage import TokenUsagePricedItem
 from statgpt.common.settings.application import application_settings
@@ -57,31 +56,28 @@ class ChannelCompletion(ChatCompletion):
                 f"request_start_{self._deployment_id}_{start_time.isoformat()}"
             )
 
-        async with get_readonly_session_context_manager() as db_session:
-            try:
-                service = await ChannelServiceFacade.get_channel(db_session, self._deployment_id)
-            except Exception as e:
-                _log.error(e)
-                raise DIALException(
-                    status_code=404,
-                    code="deployment_not_found",
-                    message="The API deployment for this resource does not exist.",
-                )
-            await self._channel_completion(request, response, service, start_time, configuration)
+        try:
+            service = await ChannelServiceFacade.get_channel(self._deployment_id)
+        except Exception as e:
+            _log.error(e)
+            raise DIALException(
+                status_code=404,
+                code="deployment_not_found",
+                message="The API deployment for this resource does not exist.",
+            )
+        await self._channel_completion(request, response, service, start_time, configuration)
 
     async def configuration(self, request: ConfigurationRequest) -> ConfigurationResponse | dict:
-
-        async with get_readonly_session_context_manager() as db_session:
-            try:
-                service = await ChannelServiceFacade.get_channel(db_session, self._deployment_id)
-            except Exception as e:
-                _log.error(e)
-                raise DIALException(
-                    status_code=404,
-                    code="deployment_not_found",
-                    message="The API deployment for this resource does not exist.",
-                )
-            return service.dial_channel_configuration
+        try:
+            service = await ChannelServiceFacade.get_channel(self._deployment_id)
+        except Exception as e:
+            _log.error(e)
+            raise DIALException(
+                status_code=404,
+                code="deployment_not_found",
+                message="The API deployment for this resource does not exist.",
+            )
+        return service.dial_channel_configuration
 
     @classmethod
     async def _channel_completion(

--- a/statgpt/app/application/channel_onboarding_completion.py
+++ b/statgpt/app/application/channel_onboarding_completion.py
@@ -9,7 +9,6 @@ from statgpt.app.security import create_auth_context
 from statgpt.app.services.chat_facade import ChannelServiceFacade
 from statgpt.app.services.onboarding import OnboardingService, OnboardingState
 from statgpt.common.auth.auth_context import AuthContext
-from statgpt.common.models.database import get_readonly_session_context_manager
 from statgpt.common.schemas.onboarding import OnboardingConfig
 
 _log = logging.getLogger(__name__)
@@ -21,58 +20,56 @@ class ChannelOnboardingCompletion(ChatCompletion):
         self._deployment_id = deployment_id
 
     async def chat_completion(self, request: Request, response: Response) -> None:
-        async with get_readonly_session_context_manager() as db_session:
-            try:
-                service = await ChannelServiceFacade.get_channel(db_session, self._deployment_id)
-            except Exception as e:
-                _log.error(e)
-                raise DIALException(
-                    status_code=404,
-                    code="deployment_not_found",
-                    message="The API deployment for this resource does not exist.",
-                )
-
-            onboarding_config = service.channel_config.onboarding
-            if onboarding_config is None:
-                raise DIALException(
-                    status_code=404,
-                    code="onboarding_not_found",
-                    message="Onboarding configuration not found for this deployment.",
-                )
-
-            auth_context = await create_auth_context(
-                request,
-                bearer_token_required=service.channel_config.bearer_token_required,
+        try:
+            service = await ChannelServiceFacade.get_channel(self._deployment_id)
+        except Exception as e:
+            _log.error(e)
+            raise DIALException(
+                status_code=404,
+                code="deployment_not_found",
+                message="The API deployment for this resource does not exist.",
             )
 
-            with response.create_choice() as choice:
-                await self._run_onboarding(
-                    request=request,
-                    choice=choice,
-                    onboarding_config=onboarding_config,
-                    channel_service=service,
-                    auth_context=auth_context,
-                )
-
-    async def configuration(self, request: ConfigurationRequest) -> ConfigurationResponse | dict:
-        async with get_readonly_session_context_manager() as db_session:
-            try:
-                service = await ChannelServiceFacade.get_channel(db_session, self._deployment_id)
-            except Exception as e:
-                _log.error(e)
-                raise DIALException(
-                    status_code=404,
-                    code="deployment_not_found",
-                    message="The API deployment for this resource does not exist.",
-                )
-            if onboarding_config := service.channel_config.onboarding:
-                onboarding_service = OnboardingService(onboarding_config)
-                return onboarding_service.get_initial_form_schema()
+        onboarding_config = service.channel_config.onboarding
+        if onboarding_config is None:
             raise DIALException(
                 status_code=404,
                 code="onboarding_not_found",
                 message="Onboarding configuration not found for this deployment.",
             )
+
+        auth_context = await create_auth_context(
+            request,
+            bearer_token_required=service.channel_config.bearer_token_required,
+        )
+
+        with response.create_choice() as choice:
+            await self._run_onboarding(
+                request=request,
+                choice=choice,
+                onboarding_config=onboarding_config,
+                channel_service=service,
+                auth_context=auth_context,
+            )
+
+    async def configuration(self, request: ConfigurationRequest) -> ConfigurationResponse | dict:
+        try:
+            service = await ChannelServiceFacade.get_channel(self._deployment_id)
+        except Exception as e:
+            _log.error(e)
+            raise DIALException(
+                status_code=404,
+                code="deployment_not_found",
+                message="The API deployment for this resource does not exist.",
+            )
+        if onboarding_config := service.channel_config.onboarding:
+            onboarding_service = OnboardingService(onboarding_config)
+            return onboarding_service.get_initial_form_schema()
+        raise DIALException(
+            status_code=404,
+            code="onboarding_not_found",
+            message="Onboarding configuration not found for this deployment.",
+        )
 
     @classmethod
     def _extract_state(cls, request: Request) -> OnboardingState:

--- a/statgpt/app/application/service_endpoints.py
+++ b/statgpt/app/application/service_endpoints.py
@@ -2,7 +2,6 @@ from aidial_sdk.exceptions import HTTPException as DIALException
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi import Request as FastAPIRequest
 from fastapi import status
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from statgpt.app.schemas import (
     ChannelDatasetsMetadataResponse,
@@ -14,7 +13,7 @@ from statgpt.app.services.chat_facade import ChannelServiceFacade
 from statgpt.app.settings.dial_app import dial_app_settings
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.config import Versions
-from statgpt.common.models.database import get_readonly_session
+from statgpt.common.models.database import get_readonly_session_context_manager
 from statgpt.common.services.dataset import DataSetService
 
 router = APIRouter()
@@ -87,7 +86,6 @@ async def settings() -> SettingsResponse:
 async def channel_metadata(
     deployment_id: str = Depends(_get_deployment_id),
     auth_context: AuthContext = Depends(_get_auth_context),
-    session: AsyncSession = Depends(get_readonly_session),
 ) -> ChannelMetadataResponse:
     """Returns channel metadata.
 
@@ -97,7 +95,7 @@ async def channel_metadata(
     """
 
     try:
-        service = await ChannelServiceFacade.get_channel(session, deployment_id)
+        service = await ChannelServiceFacade.get_channel(deployment_id)
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -119,7 +117,6 @@ async def channel_metadata(
 async def channel_datasets_metadata(
     deployment_id: str = Depends(_get_deployment_id),
     auth_context: AuthContext = Depends(_get_auth_context),
-    session: AsyncSession = Depends(get_readonly_session),
 ) -> ChannelDatasetsMetadataResponse:
     """Returns datasets metadata for the channel.
 
@@ -129,19 +126,20 @@ async def channel_datasets_metadata(
     """
 
     try:
-        service = await ChannelServiceFacade.get_channel(session, deployment_id)
+        service = await ChannelServiceFacade.get_channel(deployment_id)
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="The API deployment for this resource does not exist.",
         )
 
-    datasets = await DataSetService(session).get_channel_dataset_schemas(
-        limit=None,
-        offset=0,
-        channel_id=service.channel.id,
-        auth_context=auth_context,
-    )
+    async with get_readonly_session_context_manager() as session:
+        datasets = await DataSetService(session).get_channel_dataset_schemas(
+            limit=None,
+            offset=0,
+            channel_id=service.channel.id,
+            auth_context=auth_context,
+        )
 
     for ds in datasets:
         resolved = ds.last_completed_version and ds.last_completed_version.resolved_config

--- a/statgpt/app/chains/glossary_tools.py
+++ b/statgpt/app/chains/glossary_tools.py
@@ -3,7 +3,7 @@ from pydantic import Field
 from statgpt.app.chains.parameters import ChainParameters
 from statgpt.app.chains.tools import StatGptTool, ToolArgs
 from statgpt.app.schemas import ToolArtifact, ToolMessageState
-from statgpt.common import models
+from statgpt.common import schemas
 from statgpt.common.schemas import ToolTypes
 from statgpt.common.schemas.tools import AvailableTermsTool as AvailableTermsToolConfig
 from statgpt.common.schemas.tools import TermDefinitionsTool as TermDefinitionsToolConfig
@@ -32,7 +32,7 @@ class AvailableTermsTool(
 
         return response, ToolArtifact(state=ToolMessageState(type=self.tool_type))
 
-    def _terms_to_markdown(self, terms: list[models.GlossaryTerm]) -> list[str]:
+    def _terms_to_markdown(self, terms: list[schemas.GlossaryTerm]) -> list[str]:
         include_domain = self._tool_config.details.include_domain
         include_source = self._tool_config.details.include_source
 
@@ -103,7 +103,7 @@ class TermDefinitionsTool(
         return response, ToolArtifact(state=ToolMessageState(type=self.tool_type))
 
     @staticmethod
-    def term_definition_to_markdown(terms: list[str], all_terms: list[models.GlossaryTerm]) -> str:
+    def term_definition_to_markdown(terms: list[str], all_terms: list[schemas.GlossaryTerm]) -> str:
         all_terms_dict = {term.term.lower(): term for term in all_terms}
 
         response = "## Glossary term definitions:\n"

--- a/statgpt/app/services/chat_facade.py
+++ b/statgpt/app/services/chat_facade.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
-import asyncio
 import logging
+import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -12,9 +10,9 @@ from aidial_sdk.chat_completion.form import Button, FormMetaclass
 from aidial_sdk.pydantic.v2 import ConfigDict as DialConfigDict
 from aidial_sdk.pydantic.v2 import Field as DialField
 from pydantic import BaseModel, ConfigDict, Field, computed_field
-from sqlalchemy.ext.asyncio import AsyncSession
 
 import statgpt.common.models as models
+import statgpt.common.schemas as schemas
 from statgpt.app import utils
 from statgpt.app.settings.dial_app import dial_app_settings
 from statgpt.common.auth.auth_context import AuthContext
@@ -25,17 +23,17 @@ from statgpt.common.data.base import (
     DataSourceHandler,
     DimensionCategory,
 )
+from statgpt.common.data.manager import DataManager
 from statgpt.common.data.sdmx.common import ComplexIndicator
+from statgpt.common.models.database import get_readonly_session_context_manager
 from statgpt.common.schemas import ChannelConfig, ChannelDatasetVersion
 from statgpt.common.schemas.data_query_tool import SpecialDimensionsProcessor
 from statgpt.common.services import (
     ChannelService,
     DataSetService,
     DataSourceService,
-    DataSourceTypeService,
     GlossaryOfTermsService,
 )
-from statgpt.common.services.base import DbServiceBase
 from statgpt.common.settings.application import application_settings
 from statgpt.common.settings.document import (
     DimensionValueDocumentMetadataFields,
@@ -84,7 +82,7 @@ class ScoredCandidate(BaseModel, ABC):
         pass
 
     @staticmethod
-    def convert_candidates_to_llm_string(candidates: list[ScoredCandidate]):
+    def convert_candidates_to_llm_string(candidates: list["ScoredCandidate"]):
         if not candidates:
             return ''
         # NOTE: we do not pass dataset info to LLM
@@ -161,8 +159,28 @@ class ScoredIndicatorCandidate(ScoredCandidate):
 
 
 @dataclass
+class _DatasetRecord:
+    """Lightweight dataset record extracted from an ORM model within a session."""
+
+    id: int
+    id_: uuid.UUID
+    title: str
+    details: dict[str, Any]
+    source_id: int
+
+    @classmethod
+    def from_model(cls, db: models.DataSet) -> "_DatasetRecord":
+        return cls(
+            id=db.id,
+            id_=db.id_,
+            title=db.title,
+            details=db.details,
+            source_id=db.source_id,
+        )
+
+
+@dataclass
 class VersionedDataSet:
-    model: models.DataSet
     version: ChannelDatasetVersion
     data: DataSet
 
@@ -181,9 +199,8 @@ class BaseChannelConfiguration(BaseModel, metaclass=FormMetaclass):
     )
 
 
-class ChannelServiceFacade(DbServiceBase):
-    def __init__(self, session: AsyncSession, channel: models.Channel) -> None:
-        super().__init__(session, asyncio.Lock())
+class ChannelServiceFacade:
+    def __init__(self, channel: schemas.Channel) -> None:
         self._channel = channel
         self._handler_classes: dict[int, type[DataSourceHandler]] = {}
 
@@ -194,7 +211,7 @@ class ChannelServiceFacade(DbServiceBase):
             gc_debugger.track_object(self, f"ChannelServiceFacade_{id(self)}")
 
     @property
-    def channel(self) -> models.Channel:
+    def channel(self) -> schemas.Channel:
         return self._channel
 
     async def _get_indicators_vector_store(self, auth_context: AuthContext) -> VectorStore:
@@ -228,15 +245,11 @@ class ChannelServiceFacade(DbServiceBase):
         return vector_store
 
     @classmethod
-    async def get_all_channels(cls, session: AsyncSession) -> list["ChannelServiceFacade"]:
-        channels = await ChannelService(session).get_channels_db(limit=None, offset=0)
-
-        return [cls(session=session, channel=item) for item in channels]
-
-    @classmethod
-    async def get_channel(cls, session: AsyncSession, deployment_id: str) -> "ChannelServiceFacade":
-        channel = await ChannelService(session).get_channel_by_deployment_id(deployment_id)
-        return cls(session=session, channel=channel)
+    async def get_channel(cls, deployment_id: str) -> "ChannelServiceFacade":
+        async with get_readonly_session_context_manager() as session:
+            service = ChannelService(session)
+            channel = await service.get_channel_schema_by_deployment_id(deployment_id)
+        return cls(channel=channel)
 
     @property
     def deployment_id(self) -> str:
@@ -244,7 +257,7 @@ class ChannelServiceFacade(DbServiceBase):
 
     @property
     def channel_config(self) -> ChannelConfig:
-        return ChannelConfig.model_validate(self._channel.details)
+        return self._channel.details
 
     @property
     def dial_channel_configuration(self) -> dict[str, Any]:
@@ -284,36 +297,36 @@ class ChannelServiceFacade(DbServiceBase):
     def get_country_named_entity_type(self) -> str:
         return self.channel_config.country_named_entity_type.strip()
 
-    async def get_available_terms(self) -> list[models.GlossaryTerm]:
-        glossary_service = GlossaryOfTermsService(
-            session=self._session, session_lock=self._session_lock
-        )
-        return await glossary_service.get_term_models_by_channel(
-            channel_id=self._channel.id, limit=None, offset=0
-        )
+    async def get_available_terms(self) -> list[schemas.GlossaryTerm]:
+        async with get_readonly_session_context_manager() as session:
+            service = GlossaryOfTermsService(session, session_lock=None)
+            return await service.get_term_schemas_by_channel(
+                channel_id=self._channel.id, limit=None, offset=0
+            )
 
     async def _get_indicators_from_documents(
         self, documents: Iterable[ScoredVectorStoreDocument]
     ) -> list[VectorStoreIndicator]:
-        res = []
+        doc_list = list(documents)
+        if not doc_list:
+            return []
 
-        data_sources = {
-            ds.id: ds
-            for ds in await DataSourceService(
-                self._session, session_lock=self._session_lock
-            ).get_data_sources_models(
-                limit=None,
-                offset=0,
-                ids={
-                    doc.metadata[IndicatorDocumentMetadataFields.DATA_SOURCE_ID]
-                    for doc in documents
-                },
-            )
+        source_ids = {
+            doc.metadata[IndicatorDocumentMetadataFields.DATA_SOURCE_ID] for doc in doc_list
         }
+        async with get_readonly_session_context_manager() as session:
+            source_service = DataSourceService(session, session_lock=None)
+            data_sources = await source_service.get_data_sources_schemas(
+                limit=None, offset=0, ids=source_ids
+            )
 
-        for doc in documents:
-            data_source = data_sources[doc.metadata[IndicatorDocumentMetadataFields.DATA_SOURCE_ID]]
-            handler = await self._get_handler_class(data_source.type, config=data_source.details)
+        handlers = {}
+        for ds in data_sources:
+            handlers[ds.id] = await self._get_handler_class(ds.type.id, ds.type.name, ds.details)
+
+        res = []
+        for doc in doc_list:
+            handler = handlers[doc.metadata[IndicatorDocumentMetadataFields.DATA_SOURCE_ID]]
             res.append(
                 VectorStoreIndicator(
                     document=doc,
@@ -326,79 +339,84 @@ class ChannelServiceFacade(DbServiceBase):
     async def _get_dimension_categories_from_documents(
         self, documents: Iterable[ScoredVectorStoreDocument]
     ) -> list[DimensionCategory]:
-        result = []
-        data_sources = {
-            ds.id: ds
-            for ds in await DataSourceService(
-                self._session, session_lock=self._session_lock
-            ).get_data_sources_models(
-                limit=None,
-                offset=0,
-                ids={
-                    doc.metadata[DimensionValueDocumentMetadataFields.DATA_SOURCE_ID]
-                    for doc in documents
-                },
+        doc_list = list(documents)
+        if not doc_list:
+            return []
+
+        source_ids = {
+            doc.metadata[DimensionValueDocumentMetadataFields.DATA_SOURCE_ID] for doc in doc_list
+        }
+        async with get_readonly_session_context_manager() as session:
+            source_service = DataSourceService(session, session_lock=None)
+            data_sources = await source_service.get_data_sources_schemas(
+                limit=None, offset=0, ids=source_ids
             )
-        }
-        handlers = {
-            ds.id: await self._get_handler_class(ds.type, ds.details)
-            for ds in data_sources.values()
-        }
-        for doc in documents:
+
+        handlers = {}
+        for ds in data_sources:
+            handlers[ds.id] = await self._get_handler_class(ds.type.id, ds.type.name, ds.details)
+
+        result = []
+        for doc in doc_list:
             handler = handlers[doc.metadata[DimensionValueDocumentMetadataFields.DATA_SOURCE_ID]]
             result.append(await handler.document_to_dimension_category(doc))
         return result
 
     @staticmethod
     def _get_config_for_query(
-        db_dataset: models.DataSet,
+        dataset_details: dict,
         version: ChannelDatasetVersion,
     ) -> dict:
         """Get config for querying - prefer resolved_config if available."""
         if version.resolved_config is not None:
             return version.resolved_config
-        return db_dataset.details
+        return dataset_details
 
     async def _load_datasets(self, auth_context: AuthContext) -> list[VersionedDataSet]:
-        dataset_service = DataSetService(self._session, session_lock=self._session_lock)
-        data_source_service = DataSourceService(self._session, session_lock=self._session_lock)
+        async with get_readonly_session_context_manager() as session:
+            dataset_service = DataSetService(session, session_lock=None)
+            data_source_service = DataSourceService(session, session_lock=None)
 
-        last_versions = await dataset_service.get_latest_successful_dataset_versions_for_channel(
-            channel_id=self._channel.id
-        )
-        versions = {
-            k: item.last_completed_version
-            for k, item in last_versions.items()
-            if item.last_completed_version is not None
-        }
-        dataset_models = await dataset_service.get_datasets_models(
-            limit=None, offset=0, ids=versions.keys()
-        )
-        data_sources = {
-            ds.id: ds
-            for ds in await data_source_service.get_data_sources_models(
-                limit=None, offset=0, ids={ds.source_id for ds in dataset_models}
+            last_versions = (
+                await dataset_service.get_latest_successful_dataset_versions_for_channel(
+                    channel_id=self._channel.id
+                )
             )
-        }
+            versions = {
+                k: item.last_completed_version
+                for k, item in last_versions.items()
+                if item.last_completed_version is not None
+            }
+            dataset_models = await dataset_service.get_datasets_models(
+                limit=None, offset=0, ids=versions.keys()
+            )
+            datasets = [_DatasetRecord.from_model(db) for db in dataset_models]
+            data_sources = {
+                ds.id: ds
+                for ds in await data_source_service.get_data_sources_schemas(
+                    limit=None, offset=0, ids={ds.source_id for ds in datasets}
+                )
+            }
 
         res = []
-        for db_dataset in dataset_models:
-            data_source = data_sources[db_dataset.source_id]
-            handler = await self._get_handler_class(data_source.type, config=data_source.details)
-            config_to_use = self._get_config_for_query(db_dataset, versions[db_dataset.id])
+        for dataset in datasets:
+            data_source = data_sources[dataset.source_id]
+            handler = await self._get_handler_class(
+                data_source.type.id, data_source.type.name, data_source.details
+            )
+            version = versions[dataset.id]
+            config_to_use = self._get_config_for_query(dataset.details, version)
             if await handler.is_dataset_available(config_to_use, auth_context):
                 ds = await handler.get_dataset(
-                    entity_id=db_dataset.id_,
-                    title=db_dataset.title,
+                    entity_id=dataset.id_,
+                    title=dataset.title,
                     config=config_to_use,
                     auth_context=auth_context,
                     allow_offline=True,
                     allow_cached=True,
                 )
                 if ds.status.status == 'online':
-                    res.append(
-                        VersionedDataSet(model=db_dataset, version=versions[db_dataset.id], data=ds)
-                    )
+                    res.append(VersionedDataSet(version=version, data=ds))
 
         return res
 
@@ -422,14 +440,14 @@ class ChannelServiceFacade(DbServiceBase):
 
     async def get_dataset_hierarchy(self, auth_context: AuthContext) -> DatasetHierarchy | None:
         """Get first available dataset hierarchy from the channel data sources."""
+        async with get_readonly_session_context_manager() as session:
+            data_source_service = DataSourceService(session, session_lock=None)
+            data_sources = await data_source_service.get_data_sources_schemas_by(
+                channel_id=self._channel.id
+            )
 
-        data_source_service = DataSourceService(self._session, session_lock=self._session_lock)
-        data_sources = await data_source_service.get_data_sources_models_by(
-            channel_id=self._channel.id
-        )
-
-        for source in data_sources:
-            handler = await self._get_handler_class(source.type, config=source.details)
+        for ds in data_sources:
+            handler = await self._get_handler_class(ds.type.id, ds.type.name, ds.details)
             hierarchy = await handler.get_dataset_hierarchy(auth_context=auth_context)
             if hierarchy is not None:
                 return hierarchy
@@ -445,15 +463,10 @@ class ChannelServiceFacade(DbServiceBase):
         return None
 
     async def _get_handler_class(
-        self, data_source_type: models.DataSourceType, config: dict
+        self, type_id: int, type_name: str, config: dict
     ) -> DataSourceHandler:
-        type_id = data_source_type.id
-
         if type_id not in self._handler_classes:
-            handler_class = await DataSourceTypeService.get_data_source_handler_class(
-                data_source_type
-            )
-            self._handler_classes[type_id] = handler_class
+            self._handler_classes[type_id] = DataManager.get_data_source_handler_class(type_name)
 
         cls = self._handler_classes[type_id]
         handler_config = cls.parse_config(config)

--- a/statgpt/common/services/base.py
+++ b/statgpt/common/services/base.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from statgpt.common.models import get_session_context_manager
+from statgpt.common.models.database import get_readonly_session_context_manager
 
 
 class DbServiceBase:
@@ -62,6 +63,32 @@ class DbServiceBase:
         else:
             self._scoped_session_active = True
             async with get_session_context_manager() as session:
+                self.__session = session
+                try:
+                    yield session
+                finally:
+                    self.__session = None
+                    self._scoped_session_active = False
+
+    @asynccontextmanager
+    async def _scoped_readonly_session(self) -> AsyncIterator[AsyncSession]:
+        """Yield a short-lived readonly session.
+
+        Same as ``_scoped_session()`` but creates a readonly session via
+        ``get_readonly_session_context_manager()`` when none is provided.
+        """
+        if self._scoped_session_active:
+            raise RuntimeError(
+                "Concurrent _scoped_readonly_session() calls on the same "
+                "instance are not supported. Create a separate service "
+                "instance per concurrent coroutine, or provide a session "
+                "at construction time."
+            )
+        if self.__session is not None:
+            yield self._session
+        else:
+            self._scoped_session_active = True
+            async with get_readonly_session_context_manager() as session:
                 self.__session = session
                 try:
                     yield session

--- a/statgpt/common/services/channel.py
+++ b/statgpt/common/services/channel.py
@@ -42,6 +42,10 @@ class ChannelService(DbServiceBase):
         q_result = await self._session.execute(query)
         return q_result.scalar_one()
 
+    async def get_channel_schema_by_deployment_id(self, deployment_id: str) -> schemas.Channel:
+        channel = await self.get_channel_by_deployment_id(deployment_id)
+        return ChannelSerializer.db_to_schema(channel)
+
     async def _get_item_or_raise(self, item_id: int) -> models.Channel:
         item: models.Channel | None = await self._session.get(models.Channel, item_id)
         if not item:

--- a/statgpt/common/services/data_source.py
+++ b/statgpt/common/services/data_source.py
@@ -156,6 +156,11 @@ class DataSourceService(DbServiceBase):
         items = await self.get_data_sources_models(limit=limit, offset=offset, ids=ids)
         return [DataSourceSerializer.db_to_schema(item) for item in items]
 
+    async def get_data_sources_schemas_by(self, channel_id: int) -> list[schemas.DataSource]:
+        """Get data source schemas for data sources used by the given channel datasets."""
+        items = await self.get_data_sources_models_by(channel_id)
+        return [DataSourceSerializer.db_to_schema(item) for item in items]
+
     async def _get_item_or_raise(self, item_id: int) -> models.DataSource:
         async with self._lock_session() as session:
             item: models.DataSource | None = await session.get(models.DataSource, item_id)

--- a/statgpt/common/services/glossary_of_terms.py
+++ b/statgpt/common/services/glossary_of_terms.py
@@ -43,7 +43,7 @@ class GlossaryOfTermsService(DbServiceBase):
         return [item for item in q_result.scalars().all()]
 
     async def get_term_schemas_by_channel(
-        self, channel_id: int, limit: int, offset: int
+        self, channel_id: int, limit: int | None, offset: int
     ) -> list[schemas.GlossaryTerm]:
         terms = await self.get_term_models_by_channel(channel_id, limit, offset)
         return [schemas.GlossaryTerm.model_validate(item, from_attributes=True) for item in terms]


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
This PR is cherry-pick of PR #246

### Description of changes

<!-- Please explain the changes you made right below this line. -->
ChannelServiceFacade no longer holds a persistent session for the entire request duration (which could be several minutes). Each method that needs DB access now creates its own short-lived readonly session and returns Pydantic schemas instead of ORM models.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
