### PR TITLE
fix: enhance SDMX query handling by adding flow reference and key string conversion #266 

### DIFF
--- a/statgpt/common/data/sdmx/v21/dataset.py
+++ b/statgpt/common/data/sdmx/v21/dataset.py
@@ -1252,22 +1252,46 @@ class Sdmx21DataSet(
         else:
             provider = self._artefact.maintainer.id  # type: ignore
 
+        flow_ref = (
+            f"{self._artefact.maintainer.id}"  # type: ignore[union-attr]
+            f",{self._artefact.id}"
+            f",{self._artefact.version}"
+        )
+        key_string = self._dict_key_to_sdmx_string(sdmx_query.get_key())
+
         return self._get_python_query_body(
             provider=provider,
-            resource_id=self.source_id,
-            keys=sdmx_query.get_key(),
+            flow_ref=flow_ref,
+            key=key_string,
             params=sdmx_query.get_params(),
             suffix=suffix,
         )
 
+    def _dict_key_to_sdmx_string(self, keys: dict[str, list[str]]) -> str:
+        """Convert a dict key to an SDMX REST key string in DSD dimension order.
+
+        The SDMX 2.1 REST API expects key as ordered dimension values
+        separated by '.', with '+' joining multiple values within a dimension.
+        Time dimensions are excluded (handled via query params).
+        """
+        from sdmx.model.v21 import TimeDimension
+
+        parts = []
+        for dim in self._artefact.structure.dimensions:
+            if isinstance(dim, TimeDimension):
+                continue
+            values = keys.get(dim.id, [])
+            parts.append("+".join(values))
+        return ".".join(parts)
+
     @staticmethod
     def _get_python_query_body(
-        provider: str, resource_id: str, keys: dict, params: dict, suffix: str = ""
+        provider: str, flow_ref: str, key: str, params: dict, suffix: str = ""
     ) -> str:
         return f'''\
 provider{suffix} = sdmx.Client("{provider}")
 data_msg{suffix} = provider{suffix}.data(
-    "{resource_id}",
-    key={keys},
+    "{flow_ref}",
+    key="{key}",
     params={params}
 )'''

--- a/statgpt/common/data/sdmx/v21/dataset.py
+++ b/statgpt/common/data/sdmx/v21/dataset.py
@@ -18,7 +18,8 @@ import sdmx.model.common
 from dateutil.parser import parse
 from sdmx.message import DataMessage, StructureMessage
 from sdmx.model.common import Code
-from sdmx.model.v21 import DataflowDefinition as DataFlow, TimeDimension
+from sdmx.model.v21 import DataflowDefinition as DataFlow
+from sdmx.model.v21 import TimeDimension
 
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.data.base import (

--- a/statgpt/common/data/sdmx/v21/dataset.py
+++ b/statgpt/common/data/sdmx/v21/dataset.py
@@ -18,7 +18,7 @@ import sdmx.model.common
 from dateutil.parser import parse
 from sdmx.message import DataMessage, StructureMessage
 from sdmx.model.common import Code
-from sdmx.model.v21 import DataflowDefinition as DataFlow
+from sdmx.model.v21 import DataflowDefinition as DataFlow, TimeDimension
 
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.data.base import (
@@ -1274,8 +1274,6 @@ class Sdmx21DataSet(
         separated by '.', with '+' joining multiple values within a dimension.
         Time dimensions are excluded (handled via query params).
         """
-        from sdmx.model.v21 import TimeDimension
-
         parts = []
         for dim in self._artefact.structure.dimensions:
             if isinstance(dim, TimeDimension):


### PR DESCRIPTION

### Applicable issues

#266

### Description of changes

- Introduced a new method to convert dictionary keys to SDMX REST key strings in DSD dimension order.
- Updated the query body generation to use flow reference and formatted key string for improved API compatibility.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
