### PR TITLE
fix: add CASCADE delete to auto_update_jobs version foreign keys #253

### DIFF
--- a/statgpt/admin/alembic/versions/2026_04_01_1443-2263b2983f56_add_cascade_delete_to_auto_update_jobs_.py
+++ b/statgpt/admin/alembic/versions/2026_04_01_1443-2263b2983f56_add_cascade_delete_to_auto_update_jobs_.py
@@ -1,0 +1,65 @@
+"""add cascade delete to auto_update_jobs version FKs
+
+Revision ID: 2263b2983f56
+Revises: 75cf43005ed1
+Create Date: 2026-04-01 14:43:53.221299
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '2263b2983f56'
+down_revision: str | None = '75cf43005ed1'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        'auto_update_jobs_base_version_id_fkey', 'auto_update_jobs', type_='foreignkey'
+    )
+    op.drop_constraint(
+        'auto_update_jobs_created_version_id_fkey', 'auto_update_jobs', type_='foreignkey'
+    )
+    op.create_foreign_key(
+        'auto_update_jobs_base_version_id_fkey',
+        'auto_update_jobs',
+        'channel_dataset_versions',
+        ['base_version_id'],
+        ['id'],
+        ondelete='CASCADE',
+    )
+    op.create_foreign_key(
+        'auto_update_jobs_created_version_id_fkey',
+        'auto_update_jobs',
+        'channel_dataset_versions',
+        ['created_version_id'],
+        ['id'],
+        ondelete='CASCADE',
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        'auto_update_jobs_created_version_id_fkey', 'auto_update_jobs', type_='foreignkey'
+    )
+    op.drop_constraint(
+        'auto_update_jobs_base_version_id_fkey', 'auto_update_jobs', type_='foreignkey'
+    )
+    op.create_foreign_key(
+        'auto_update_jobs_base_version_id_fkey',
+        'auto_update_jobs',
+        'channel_dataset_versions',
+        ['base_version_id'],
+        ['id'],
+    )
+    op.create_foreign_key(
+        'auto_update_jobs_created_version_id_fkey',
+        'auto_update_jobs',
+        'channel_dataset_versions',
+        ['created_version_id'],
+        ['id'],
+    )

--- a/statgpt/common/config/versions.py
+++ b/statgpt/common/config/versions.py
@@ -7,4 +7,4 @@ class Versions:
     # Please update this version when you create a new alembic revision.
     # Needed because alembic folder exist only in the statgpt.admin package.
     # (statgpt Dockerfile doesn't copy statgpt.admin package to the container)
-    ALEMBIC_TARGET_VERSION = '75cf43005ed1'
+    ALEMBIC_TARGET_VERSION = '2263b2983f56'

--- a/statgpt/common/models/models.py
+++ b/statgpt/common/models/models.py
@@ -284,12 +284,12 @@ class AutoUpdateJob(DefaultBase):
 
     channel_dataset_id: Mapped[int] = mapped_column(ForeignKey("channel_datasets.id"))
     base_version_id: Mapped[int | None] = mapped_column(
-        ForeignKey("channel_dataset_versions.id"), default=None
+        ForeignKey("channel_dataset_versions.id", ondelete="CASCADE"), default=None
     )
     """The base version used for comparison (last completed version at job creation time)."""
 
     created_version_id: Mapped[int | None] = mapped_column(
-        ForeignKey("channel_dataset_versions.id"), default=None
+        ForeignKey("channel_dataset_versions.id", ondelete="CASCADE"), default=None
     )
     """The newly created version after reindexing (set when reindex is triggered)."""
 


### PR DESCRIPTION
### Applicable issues
This PR is cherry-pick of PR https://github.com/epam/statgpt-backend/pull/260

### Description of changes

`AutoUpdateJob.base_version_id` and `created_version_id` foreign keys to `channel_dataset_versions` had no `ondelete` rule, defaulting to PostgreSQL's RESTRICT behavior. This blocked deletion of `channel_dataset_versions` rows during channel import and dataset removal, causing a `ForeignKeyViolationError`.

Added `ondelete="CASCADE"` to both FK definitions in the model. Auto-update jobs are historical records tied to specific versions and have no value without them, so cascading the delete is the correct behavior.

**Note:** Deploying this change requires a migration or manual SQL to alter the existing DB constraints — the SQLAlchemy `ondelete` parameter only takes effect on table creation. Run the following against the database:

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.