### PR TITLE
hotfix: fix absent cube-regions

### DIFF
--- a/statgpt/common/data/sdmx/v21/dataset.py
+++ b/statgpt/common/data/sdmx/v21/dataset.py
@@ -1038,6 +1038,8 @@ class Sdmx21DataSet(
         elif len(constraints) != 1:
             raise ValueError("Unexpected quantity of constraints in structure message")
         constraint = constraints[0]
+        if len(constraint.data_content_region) == 0:
+            return DataSetAvailabilityQuery()  # empty query
         if len(constraint.data_content_region) != 1:
             raise ValueError("Unexpected quantity of cube-regions in constraint")
         cube_region = constraint.data_content_region[0]


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- N/A

### Description of changes

<!-- Please explain the changes you made right below this line. -->
When SDMX providers return an availability response without the `cube_region` field, the data query throws the following error: `ValueError("Unexpected quantity of cube-regions in constraint")`. This fix results in an empty query being returned in this case.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
