### PR TITLE
fix: split resolve_config to correctly detect user config indexing changes #292

### DIFF
--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -782,9 +782,7 @@ class AdminPortalDataSetService(DataSetService):
                 )
             else:
                 _, resolved_config = await handler.resolve_config(
-                    config=dataset.details,
-                    previous_resolved_config=last_completed.resolved_config,
-                    auth_context=auth_context,
+                    config=dataset.details, auth_context=auth_context
                 )
                 resolved_parsed = handler.parse_data_set_config(resolved_config)
                 new_config_hash = resolved_parsed.indexing_hash
@@ -2465,7 +2463,7 @@ class AdminPortalDataSetService(DataSetService):
 
             # Phase B: Network I/O — no session needed
             # last_completed is a schema, so resolved_config is accessible without a session
-            details, new_resolved_config = await handler.resolve_config(
+            details, new_resolved_config = await handler.reresolve_config(
                 config=dataset_details,
                 previous_resolved_config=last_completed.resolved_config,
                 auth_context=auth_context,

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -2463,11 +2463,16 @@ class AdminPortalDataSetService(DataSetService):
 
             # Phase B: Network I/O — no session needed
             # last_completed is a schema, so resolved_config is accessible without a session
-            details, new_resolved_config = await handler.reresolve_config(
-                config=dataset_details,
-                previous_resolved_config=last_completed.resolved_config,
-                auth_context=auth_context,
-            )
+            if last_completed.resolved_config is None:
+                details, new_resolved_config = await handler.resolve_config(
+                    config=dataset_details, auth_context=auth_context
+                )
+            else:
+                details, new_resolved_config = await handler.reresolve_config(
+                    config=dataset_details,
+                    previous_resolved_config=last_completed.resolved_config,
+                    auth_context=auth_context,
+                )
 
             validation_result = await handler.validate_dataset_config(
                 new_resolved_config, auth_context=auth_context, mode="return"

--- a/statgpt/common/data/base/datasource.py
+++ b/statgpt/common/data/base/datasource.py
@@ -181,20 +181,41 @@ class DataSourceHandler(
     async def resolve_config(
         self,
         config: dict,
-        previous_resolved_config: dict | None,
         auth_context: AuthContext,
     ) -> tuple[str, dict]:
         """Resolve dynamic values in the dataset config to actual values.
 
-        Resolves URN version='latest' (or other dynamic values) to actual version.
-        In the future, may also update other fields such as dimensions if they can be dynamically resolved.
+        Builds the resolved config from the given config, replacing dynamic
+        values (e.g. URN version='latest') with actual values.
 
         Args:
-            config: The current dataset configuration
+            config: The dataset configuration to resolve
+            auth_context: Authentication context for API calls
+
+        Returns:
+            A string describing the resolution details
+            and the new resolved config with dynamic values replaced by actual values.
+        """
+
+    @abstractmethod
+    async def reresolve_config(
+        self,
+        config: dict,
+        previous_resolved_config: dict,
+        auth_context: AuthContext,
+    ) -> tuple[str, dict]:
+        """Re-resolve a previously resolved config to detect upstream changes.
+
+        Checks whether dynamic values (e.g. URN version) have changed since
+        the previous resolution. Uses the previous resolved config as the base,
+        updating only the dynamic values.
+
+        Args:
+            config: The current dataset configuration (used to obtain dynamic references)
             previous_resolved_config: The previously resolved config (from last completed version)
             auth_context: Authentication context for API calls
 
         Returns:
-            A string describing the resolution details (e.g., what was resolved and if there were any changes)
-            and the new resolved config with dynamic values replaced by actual values.
+            A string describing the resolution details
+            and the re-resolved config.
         """

--- a/statgpt/common/data/sdmx/v21/datasource.py
+++ b/statgpt/common/data/sdmx/v21/datasource.py
@@ -597,44 +597,45 @@ class Sdmx21DataSourceHandler(
         merged = resolved.with_non_indexing_fields_from(current)
         return merged.model_dump(mode="json", by_alias=True)
 
-    async def resolve_config(
-        self,
-        config: dict,
-        previous_resolved_config: dict | None,
-        auth_context: AuthContext,
-    ) -> tuple[str, dict]:
-        """Resolve dynamic values in the dataset config to actual values.
-
-        Resolves URN version='latest' (or other dynamic values) to actual version.
-        In the future, may also update other fields such as dimensions if they can be dynamically resolved.
-
-        Returns:
-            A string describing the resolution details (e.g., what was resolved and if there were any changes)
-            and the new resolved config with dynamic values replaced by actual values.
-        """
+    async def _resolve_urn(
+        self, config: dict, auth_context: AuthContext
+    ) -> tuple[SdmxDataSetConfig, UrnReference]:
+        """Parse config and resolve its URN to actual values."""
         dataset_config = self.parse_data_set_config(config)
-
         actual_urn, _ = await self._load_dataset_structure_message(
             urn_ref=dataset_config.urn, auth_context=auth_context
         )
         resolved_urn_ref = UrnReference.model_validate(actual_urn, from_attributes=True)
+        return dataset_config, resolved_urn_ref
 
-        previous_config_obj = None
-        if previous_resolved_config is not None:
-            previous_config_obj = self.parse_data_set_config(previous_resolved_config)
-            if previous_config_obj.urn == resolved_urn_ref:
-                details = f"URN={dataset_config.urn} resolved to the same actual URN={resolved_urn_ref} as before."
-                return details, previous_resolved_config
-            else:
-                details = (
-                    f"URN={dataset_config.urn} resolved to a different actual URN."
-                    f" Previous: {previous_config_obj.urn}, New: {resolved_urn_ref}"
-                )
-        else:
-            details = f"URN={dataset_config.urn} resolved to actual URN={resolved_urn_ref}."
+    async def resolve_config(
+        self,
+        config: dict,
+        auth_context: AuthContext,
+    ) -> tuple[str, dict]:
+        dataset_config, resolved_urn_ref = await self._resolve_urn(config, auth_context)
+        details = f"URN={dataset_config.urn} resolved to actual URN={resolved_urn_ref}."
+        resolved_config_obj = dataset_config.model_copy(update={"urn": resolved_urn_ref})
+        new_resolved_config = resolved_config_obj.model_dump(mode="json", by_alias=True)
+        return details, new_resolved_config
 
-        resolved_config_obj = (previous_config_obj or dataset_config).model_copy(
-            update={"urn": resolved_urn_ref}
+    async def reresolve_config(
+        self,
+        config: dict,
+        previous_resolved_config: dict,
+        auth_context: AuthContext,
+    ) -> tuple[str, dict]:
+        dataset_config, resolved_urn_ref = await self._resolve_urn(config, auth_context)
+        previous_config_obj = self.parse_data_set_config(previous_resolved_config)
+
+        if previous_config_obj.urn == resolved_urn_ref:
+            details = f"URN={dataset_config.urn} resolved to the same actual URN={resolved_urn_ref} as before."
+            return details, previous_resolved_config
+
+        details = (
+            f"URN={dataset_config.urn} resolved to a different actual URN."
+            f" Previous: {previous_config_obj.urn}, New: {resolved_urn_ref}"
         )
+        resolved_config_obj = previous_config_obj.model_copy(update={"urn": resolved_urn_ref})
         new_resolved_config = resolved_config_obj.model_dump(mode="json", by_alias=True)
         return details, new_resolved_config


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #292

### Description of changes

<!-- Please explain the changes you made right below this line. -->

Changing a dimension's `dimensionType` (e.g. `NON_INDICATOR` → `INDICATOR`) via the admin API crashed with:
```
AttributeError: 'IndicatorDimensionConfig' object has no attribute 'subtype'
```

**Root cause**: The old `resolve_config` method served two different purposes with conflicting requirements:
1. **User config update** (`_propagate_config_to_channel_datasets`): needs the user's current config with resolved URN — to detect indexing field changes via hash comparison.
2. **Auto-update** (scheduled upstream check): needs the previous resolved config with a fresh URN lookup — to detect upstream version changes only.

The old single method always used the previous resolved config as the base, so user changes to dimensions were invisible to the hash check. This routed to the merge path where incompatible discriminated union types crashed.

**Fix**: Split `resolve_config` into two methods with clear responsibilities:
- `resolve_config(config, auth_context)` — resolves the user's config with actual URN values. Used by the user update flow for correct hash detection.
- `reresolve_config(config, previous_resolved_config, auth_context)` — re-resolves a previously resolved config to detect upstream URN changes. Used by the auto-update flow.

Both share a `_resolve_urn` helper to avoid duplication. The auto-update call site also handles the case where `resolved_config` is `None` by falling back to `resolve_config`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
