### PR TITLE
fix: add cascade delete to auto_update_jobs channel_dataset FK

### DIFF
--- a/statgpt/admin/alembic/versions/2026_04_16_1045-e7c26f313212_add_cascade_delete_to_auto_update_jobs_.py
+++ b/statgpt/admin/alembic/versions/2026_04_16_1045-e7c26f313212_add_cascade_delete_to_auto_update_jobs_.py
@@ -1,0 +1,44 @@
+"""add cascade delete to auto_update_jobs channel_dataset FK
+
+Revision ID: e7c26f313212
+Revises: 2f0f6f2f0d7b
+Create Date: 2026-04-16 10:45:58.004322
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'e7c26f313212'
+down_revision: str | None = '2f0f6f2f0d7b'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        'auto_update_jobs_channel_dataset_id_fkey', 'auto_update_jobs', type_='foreignkey'
+    )
+    op.create_foreign_key(
+        'auto_update_jobs_channel_dataset_id_fkey',
+        'auto_update_jobs',
+        'channel_datasets',
+        ['channel_dataset_id'],
+        ['id'],
+        ondelete='CASCADE',
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        'auto_update_jobs_channel_dataset_id_fkey', 'auto_update_jobs', type_='foreignkey'
+    )
+    op.create_foreign_key(
+        'auto_update_jobs_channel_dataset_id_fkey',
+        'auto_update_jobs',
+        'channel_datasets',
+        ['channel_dataset_id'],
+        ['id'],
+    )

--- a/statgpt/common/config/versions.py
+++ b/statgpt/common/config/versions.py
@@ -7,4 +7,4 @@ class Versions:
     # Please update this version when you create a new alembic revision.
     # Needed because alembic folder exist only in the statgpt.admin package.
     # (statgpt Dockerfile doesn't copy statgpt.admin package to the container)
-    ALEMBIC_TARGET_VERSION = '2f0f6f2f0d7b'
+    ALEMBIC_TARGET_VERSION = 'e7c26f313212'

--- a/statgpt/common/models/models.py
+++ b/statgpt/common/models/models.py
@@ -282,7 +282,9 @@ class AutoUpdateJob(DefaultBase):
 
     __tablename__ = "auto_update_jobs"
 
-    channel_dataset_id: Mapped[int] = mapped_column(ForeignKey("channel_datasets.id"))
+    channel_dataset_id: Mapped[int] = mapped_column(
+        ForeignKey("channel_datasets.id", ondelete="CASCADE")
+    )
     base_version_id: Mapped[int | None] = mapped_column(
         ForeignKey("channel_dataset_versions.id", ondelete="CASCADE"), default=None
     )


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- Related to #260

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Deleting a channel fails with a 500 error due to a foreign key violation:

```
update or delete on table "channel_datasets" violates foreign key constraint
"auto_update_jobs_channel_dataset_id_fkey" on table "auto_update_jobs"
```

PR #260 added `ondelete="CASCADE"` to the `base_version_id` and `created_version_id` FKs in `auto_update_jobs` (pointing to `channel_dataset_versions`), but missed the `channel_dataset_id` FK (pointing to `channel_datasets`).

This PR adds the missing `ondelete="CASCADE"` to `AutoUpdateJob.channel_dataset_id`, so that when a `ChannelDataset` is deleted (via channel deletion cascade), its associated `AutoUpdateJob` records are properly cleaned up by the database.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
