### PR TITLE
chore: rm stale dataset indexing.description field #319

### DIFF
--- a/configurations/clients/sample/datasets/imf.yaml
+++ b/configurations/clients/sample/datasets/imf.yaml
@@ -52,7 +52,7 @@ dataSets:
       citation:
         provider: "IMF.STA"
         url: "https://data.imf.org/en/datasets/IMF.STA:BOP"
-        description: &bop-description >
+        description: >
           The Balance of Payments (BOP) is a statistical statement that summarizes transactions between residents and
           nonresidents during a period. It consists of the goods and services account, the primary income account, the
           secondary income account, the capital account, and the financial account.
@@ -62,7 +62,6 @@ dataSets:
         - "BOP_ACCOUNTING_ENTRY_Name"
         - "INDICATOR_Name"
       indexer:
-        description: *bop-description
         indicator:
           unpack: true
 
@@ -93,7 +92,7 @@ dataSets:
       citation:
         provider: "IMF.RES"
         url: "https://data.imf.org/en/datasets/IMF.RES:WEO"
-        description: &weo-description >
+        description: >
           The World Economic Outlook (WEO) database contains selected macroeconomic data series from the statistical
           appendix of the World Economic Outlook report, which presents the IMF staff's analysis and projections of
           economic developments at the global level, in major country groups and in many individual countries. The WEO
@@ -108,6 +107,5 @@ dataSets:
         - "COUNTRY_Name"
         - "INDICATOR_Name"
       indexer:
-        description: *weo-description
         indicator:
           unpack: true

--- a/statgpt/admin/mcp/prompts/dataset_config.py
+++ b/statgpt/admin/mcp/prompts/dataset_config.py
@@ -45,7 +45,7 @@ and if they are relevant and could be reused for this dataset.
     - dataset structure tool output
     - dataset config schema
     - all previous reasonings (dimension types, citation description,
-    indexer config, anchors, pinned columns)
+    indexer config, pinned columns, anchors)
     - use uuid tool to generate uuid
 11. Update channel config file with new Named Entity types, if needed.
 12. Validate generated config using validation tool
@@ -115,19 +115,11 @@ Citation `description` field could be filled either with text or `null`:
     - if description is not meaningful / not present,
     write it yourself based on dataset title and structure
 - you MUST EXPLICLTY REASON ABOUT DATASET DESCRIPTION from structure tool output!
-- NOTE: indexer dataset description choice MUST NOT AFFECT on the content of citation description!
 
 ## Indexer config
 
 Dataset indexer has couple of special instructions:
 
-- indexer dataset description must always be non-empty string.
-    - If you determined to write `null` to citation dataset description field -
-    put dataset description from structure tool output to indexer description without edits!
-    - If you filled citation description field with generated description -
-    refer to it here with yaml anchor!
-    - NOTE: choice of indexer dataset description MUST NOT AFFECT content of citation description!
-    - EXPLICITLY REASON about your choice of indexer dataset description!
 - `unpack` field determines how indicator dimensions will be indexed.
 You must use indicator dimensions sample values to determine correct field value:
     - determine a set of IMPORTANT indicator dimensions,

--- a/statgpt/common/data/base/config.py
+++ b/statgpt/common/data/base/config.py
@@ -108,7 +108,6 @@ class IndexerIndicatorConfig(BaseModel):
             "When False, primary is taken from first dimension only."
         ),
     )
-
     annotations: Annotated[IndexerIndicatorAnnotationConfig | None, IndexingField()] = Field(
         default=None
     )

--- a/statgpt/common/data/base/config.py
+++ b/statgpt/common/data/base/config.py
@@ -115,10 +115,6 @@ class IndexerIndicatorConfig(BaseModel):
 
 
 class IndexerConfig(BaseModel, IndexingHashMixin):
-    description: Annotated[str, IndexingField()] = Field(
-        description="dataset_description", default=""
-    )
-
     indicator: Annotated[IndexerIndicatorConfig, IndexingField()] = Field(
         description="indicator_config", default_factory=IndexerIndicatorConfig
     )

--- a/tests/integration/services/test_sdmx_datasets.py
+++ b/tests/integration/services/test_sdmx_datasets.py
@@ -167,7 +167,6 @@ async def test_update_dataset(session, clear_all, sdmx_clint_mock):
     )
 
     indexer_config = IndexerConfig(
-        description='Test description',
         indicator=IndexerIndicatorConfig(unpack=True),
     )
 

--- a/tests/unit/common/data/base/test_indexing.py
+++ b/tests/unit/common/data/base/test_indexing.py
@@ -358,20 +358,17 @@ class TestRealWorldScenarios:
             annotations: Annotated[AnnotationConfig | None, IndexingField()] = None
 
         class IndexerConfig(BaseModel, IndexingHashMixin):
-            description: Annotated[str, IndexingField()] = ""
             indicator: Annotated[IndicatorConfig, IndexingField()] = Field(
                 default_factory=IndicatorConfig
             )
 
         config1 = IndexerConfig(
-            description="Test",
             indicator=IndicatorConfig(
                 unpack=True, annotations=AnnotationConfig(description="annotation")
             ),
         )
 
         config2 = IndexerConfig(
-            description="Test",
             indicator=IndicatorConfig(
                 unpack=True, annotations=AnnotationConfig(description="different")
             ),


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #319

### Description of changes

- rm stale `indexer.description` field not used anymore from pydantic model
- upd admin mcp prompt for onboarding new datasets
- upd tests

**NOTE**: removed field was marked with `IndexingField` annotation - updating it (removing) changes dataset hash

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
