### PR TITLE
fix: join SDMX 3.0 c[TIME_PERIOD] filter values with + per spec

### DIFF
--- a/statgpt/common/data/statgpt_sdmx_proxy/v30/sdmx_client.py
+++ b/statgpt/common/data/statgpt_sdmx_proxy/v30/sdmx_client.py
@@ -275,10 +275,10 @@ class AsyncStatGptSdmxProxyClient(AsyncSdmxClient):
                 parts.append("+".join(values))
         return ".".join(parts).rstrip(".") or "*"
 
-    def _build_url(self, *, path: str, params: dict[str, str | list[str]] | None) -> str:
+    def _build_url(self, *, path: str, params: dict[str, str] | None) -> str:
         url = f"{self._sync_client.source.url}{path}"
         if params:
-            return f"{url}?{urlencode(params, doseq=True)}"
+            return f"{url}?{urlencode(params)}"
         return url
 
     @staticmethod
@@ -290,11 +290,11 @@ class AsyncStatGptSdmxProxyClient(AsyncSdmxClient):
     @staticmethod
     def _convert_time_params(
         params: dict[str, str] | None,
-    ) -> dict[str, str | list[str]] | None:
+    ) -> dict[str, str] | None:
         """Convert startPeriod/endPeriod to SDMX 3.0 c[TIME_PERIOD] filter syntax."""
         if not params:
             return None
-        result: dict[str, str | list[str]] = {}
+        result: dict[str, str] = {}
         time_filters: list[str] = []
         for k, v in params.items():
             if k == "startPeriod":
@@ -304,7 +304,7 @@ class AsyncStatGptSdmxProxyClient(AsyncSdmxClient):
             else:
                 result[k] = v
         if time_filters:
-            result["c[TIME_PERIOD]"] = time_filters
+            result["c[TIME_PERIOD]"] = "+".join(time_filters)
         return result or None
 
     async def _perform_get(


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
N/A

### Description of changes

<!-- Please explain the changes you made right below this line. -->
The SDMX 3.0 proxy built data URLs with the `c[TIME_PERIOD]` component filter repeated when both `startPeriod` and `endPeriod` were set. Per the SDMX 3.0 REST spec, `c[<COMPONENT>]` may appear at most once per component — multiple filter values must be joined with `+` inside a single parameter. Some compliant servers reject the duplicated form.

**Before:**
```
?c%5BTIME_PERIOD%5D=ge%3A2025-01-01&c%5BTIME_PERIOD%5D=le%3A2025-01-31
```

**After:**
```
?c%5BTIME_PERIOD%5D=ge%3A2025-01-01%2Ble%3A2025-01-31
```
(decoded: `c[TIME_PERIOD]=ge:2025-01-01+le:2025-01-31`)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
