### PR TITLE
chore: silence spurious pydantic `parsed` field serializer warning during reindexing

### DIFF
--- a/statgpt/common/utils/models.py
+++ b/statgpt/common/utils/models.py
@@ -14,6 +14,18 @@ warnings.filterwarnings(
     module=r"langchain_openai\.chat_models\.base",
 )
 
+# langchain_openai serializes openai SDK's generic ParsedChatCompletion[ContentType] after a
+# structured-output call. Under pydantic 2.11+ this emits a spurious
+# PydanticSerializationUnexpectedValue for the `parsed` field (generic TypeVar vs. a concrete
+# BaseModel value), even though `parsed` is already in the `exclude` set and is not serialized.
+# Tracked upstream: openai-python PR #2885 (still open as of 2026-04-23).
+warnings.filterwarnings(
+    "ignore",
+    message=r"Pydantic serializer warnings:[\s\S]*field_name='parsed'",
+    category=UserWarning,
+    module=r"pydantic\.main",
+)
+
 from statgpt.common.config.logging import multiline_logger as logger
 from statgpt.common.schemas import EmbeddingsModelConfig, LLMModelConfig
 from statgpt.common.settings.dial import dial_settings


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
N/A

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Hybrid reindexing logs were flooded with `PydanticSerializationUnexpectedValue ... field_name='parsed'` warnings — one per LLM call in `Indexer._normalize` / `_harmonize`.

Root cause is upstream: `langchain_openai` serializes OpenAI SDK's generic `ParsedChatCompletion[ContentType]`, and under pydantic ≥ 2.11 the serializer validates field types before applying `exclude`, so the existing `exclude={... "parsed" ...}` workaround in `langchain_openai` can't silence it. Package upgrades don't help — the upstream fix in openai-python is still open.

Adds a narrow `warnings.filterwarnings` in `statgpt/common/utils/models.py`, next to the existing filter, scoped to `pydantic.main` + `field_name='parsed'` so unrelated pydantic warnings stay visible. Remove once the upstream fix ships.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
