### PR TITLE
feat: add "additional_instructions" section to agent's prompt #328

### DIFF
--- a/statgpt/app/chains/supreme_agent.py
+++ b/statgpt/app/chains/supreme_agent.py
@@ -236,6 +236,7 @@ class SupremeAgent:
                 channel_config.supreme_agent.language_instructions, list_type="ordered"
             ),
             additional_context=channel_config.supreme_agent.additional_context,
+            default_guardrails=channel_config.supreme_agent.default_guardrails,
         )
         model = get_chat_model(
             api_key=auth_context.api_key,

--- a/statgpt/app/chains/supreme_agent.py
+++ b/statgpt/app/chains/supreme_agent.py
@@ -235,8 +235,8 @@ class SupremeAgent:
             chat_bot_language_instructions=format_as_markdown_list(
                 channel_config.supreme_agent.language_instructions, list_type="ordered"
             ),
+            additional_instructions=channel_config.supreme_agent.additional_instructions,
             additional_context=channel_config.supreme_agent.additional_context,
-            default_guardrails=channel_config.supreme_agent.default_guardrails,
         )
         model = get_chat_model(
             api_key=auth_context.api_key,

--- a/statgpt/app/default_prompts/assets/supreme_agent.yaml
+++ b/statgpt/app/default_prompts/assets/supreme_agent.yaml
@@ -11,6 +11,10 @@ systemPrompt: |-
 
   {chat_bot_language_instructions}
 
+  # Default Guardrails
+
+  {default_guardrails}
+
   # Instructions
 
   The following instructions are **mandatory** for all responses. **Adhere to them strictly**.

--- a/statgpt/app/default_prompts/assets/supreme_agent.yaml
+++ b/statgpt/app/default_prompts/assets/supreme_agent.yaml
@@ -11,10 +11,6 @@ systemPrompt: |-
 
   {chat_bot_language_instructions}
 
-  # Default Guardrails
-
-  {default_guardrails}
-
   # Instructions
 
   The following instructions are **mandatory** for all responses. **Adhere to them strictly**.
@@ -29,6 +25,7 @@ systemPrompt: |-
   6. All data points, facts and analysis that are timestamped **after today's date** are forecasted and should be
      treated as such. All data points, facts and analysis that are timestamped **before today's date** are historical
      and should be treated as such. It's important to **adjust responses language** accordingly.
+  {additional_instructions}
 
   ## No Assumptions Policy
 

--- a/statgpt/common/schemas/channel.py
+++ b/statgpt/common/schemas/channel.py
@@ -45,16 +45,13 @@ class SupremeAgentConfig(BaseYamlModel):
         default_factory=LLMModelConfig,
         description="LLM model configuration for the supreme agent",
     )
+    additional_instructions: str = Field(
+        default="",
+        description=("Additional instructions to put to the agent's system prompt"),
+    )
     additional_context: str = Field(
         default="",
         description="Additional context for the supreme agent",
-    )
-    default_guardrails: str = Field(
-        default="",
-        description=(
-            "Default guardrails text injected into the supreme agent's system prompt."
-            " Rendered as an empty string when None."
-        ),
     )
 
 

--- a/statgpt/common/schemas/channel.py
+++ b/statgpt/common/schemas/channel.py
@@ -49,6 +49,13 @@ class SupremeAgentConfig(BaseYamlModel):
         default="",
         description="Additional context for the supreme agent",
     )
+    default_guardrails: str = Field(
+        default="",
+        description=(
+            "Default guardrails text injected into the supreme agent's system prompt."
+            " Rendered as an empty string when None."
+        ),
+    )
 
 
 class OutOfScopeConfig(BaseYamlModel):

--- a/statgpt/common/schemas/channel.py
+++ b/statgpt/common/schemas/channel.py
@@ -47,7 +47,7 @@ class SupremeAgentConfig(BaseYamlModel):
     )
     additional_instructions: str = Field(
         default="",
-        description=("Additional instructions to put to the agent's system prompt"),
+        description="Additional instructions to put to the agent's system prompt",
     )
     additional_context: str = Field(
         default="",


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #328

### Description of changes

Added template var to supreme agent prompt which can be configured throught channel config

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
