### PR TITLE
feat: add per-phase timings to hybrid search #348

### DIFF
--- a/statgpt/app/chains/data_query/query_builder/dimensions/indicators.py
+++ b/statgpt/app/chains/data_query/query_builder/dimensions/indicators.py
@@ -102,6 +102,9 @@ class IndicatorsSearchChainFactory(DimensionSearchChainFactoryBase):
             | RunnablePassthrough.assign(
                 strong_queries=lambda d: d["indicators_selection_result"].queries,
                 retrieval_results=lambda d: d["indicators_selection_result"].retrieval_results,
+                hybrid_search_timings=(
+                    lambda d: d["indicators_selection_result"].hybrid_search_timings
+                ),
             ).with_config(
                 config=RunnableConfig(
                     callbacks=[

--- a/statgpt/app/chains/data_query/query_builder/indicator_selection/indicators_hybrid.py
+++ b/statgpt/app/chains/data_query/query_builder/indicator_selection/indicators_hybrid.py
@@ -163,7 +163,6 @@ class IndicatorsSelectionHybrid(IndicatorSelectionBase):
         retrieval_results = self._get_retrieval_results(inputs)
         search_result: HybridSearchResult = inputs['search_result']
         # Don't overload the result with timings if show_debug_stages is disabled
-        # NOTE: disabling time.perf_counter() calls inside the search would save negligible amount of time (under a ms)
         timings = search_result.timings if chain_state.show_debug_stages else None
         return IndicatorsSearchResult(
             queries=final_queries,

--- a/statgpt/app/chains/data_query/query_builder/indicator_selection/indicators_hybrid.py
+++ b/statgpt/app/chains/data_query/query_builder/indicator_selection/indicators_hybrid.py
@@ -6,7 +6,6 @@ from statgpt.app.chains.parameters import ChainParameters
 from statgpt.app.schemas.query_builder import (
     ChainState,
     DatasetAvailabilityQueriesType,
-    HybridSearchTimings,
     IndicatorsSearchResult,
     RetrievalStageDescription,
     RetrievalStagesResults,
@@ -164,8 +163,8 @@ class IndicatorsSelectionHybrid(IndicatorSelectionBase):
         retrieval_results = self._get_retrieval_results(inputs)
         search_result: HybridSearchResult = inputs['search_result']
         # Don't overload the result with timings if show_debug_stages is disabled
-        # NOTE: disabling time.perf_counter() calls inside the search will save negligible amount of time (under a ms)
-        timings = search_result.timings if chain_state.show_debug_stages else HybridSearchTimings()
+        # NOTE: disabling time.perf_counter() calls inside the search would save negligible amount of time (under a ms)
+        timings = search_result.timings if chain_state.show_debug_stages else None
         return IndicatorsSearchResult(
             queries=final_queries,
             retrieval_results=retrieval_results,

--- a/statgpt/app/chains/data_query/query_builder/indicator_selection/indicators_hybrid.py
+++ b/statgpt/app/chains/data_query/query_builder/indicator_selection/indicators_hybrid.py
@@ -6,6 +6,7 @@ from statgpt.app.chains.parameters import ChainParameters
 from statgpt.app.schemas.query_builder import (
     ChainState,
     DatasetAvailabilityQueriesType,
+    HybridSearchTimings,
     IndicatorsSearchResult,
     RetrievalStageDescription,
     RetrievalStagesResults,
@@ -158,9 +159,18 @@ class IndicatorsSelectionHybrid(IndicatorSelectionBase):
         )
 
     def _get_primary_queries_with_retrieval_results(self, inputs: dict) -> IndicatorsSearchResult:
+        chain_state = ChainState.model_validate(inputs)
         final_queries = self._get_final_queries(inputs)
         retrieval_results = self._get_retrieval_results(inputs)
-        return IndicatorsSearchResult(queries=final_queries, retrieval_results=retrieval_results)
+        search_result: HybridSearchResult = inputs['search_result']
+        # Don't overload the result with timings if show_debug_stages is disabled
+        # NOTE: disabling time.perf_counter() calls inside the search will save negligible amount of time (under a ms)
+        timings = search_result.timings if chain_state.show_debug_stages else HybridSearchTimings()
+        return IndicatorsSearchResult(
+            queries=final_queries,
+            retrieval_results=retrieval_results,
+            hybrid_search_timings=timings,
+        )
 
     def create_chain(self) -> Runnable:
         return (

--- a/statgpt/app/chains/data_query/query_builder/utils.py
+++ b/statgpt/app/chains/data_query/query_builder/utils.py
@@ -98,6 +98,7 @@ def set_tool_state(inputs: dict) -> dict:
         dataset_queries=chain_state.dataset_queries,
         dimension_id_to_name=chain_state.dimension_id_to_name,
         special_dims_outputs=chain_state.special_dims_outputs,
+        hybrid_search_timings=chain_state.hybrid_search_timings,
     )
     agent_state_dict = agent_state.model_dump(mode='json')
 

--- a/statgpt/app/schemas/query_builder.py
+++ b/statgpt/app/schemas/query_builder.py
@@ -149,9 +149,35 @@ class RetrievalStagesResults(BaseModel):
     )
 
 
+class HybridMatchTimings(BaseModel):
+    """Per-subquery timing breakdown for HybridMatch.search. All values in seconds."""
+
+    query: str = ''
+    query_planner: float = 0.0
+    lexical: float = 0.0
+    semantic_raw: float = 0.0
+    hybrid_combination: float = 0.0
+    hybrid_candidates_total: float = 0.0
+    relevance_per_batch: list[float] = Field(default_factory=list)
+    relevance_total: float = 0.0
+    total: float = 0.0
+
+
+class HybridSearchTimings(BaseModel):
+    """Top-level timing breakdown for HybridSearcher.search. All values in seconds."""
+
+    lexical_pre_match: float = 0.0
+    normalize_input: float = 0.0
+    separate_subjects: float = 0.0
+    parallel_subqueries_wall: float = 0.0
+    total: float = 0.0
+    per_subquery: list[HybridMatchTimings] = Field(default_factory=list)
+
+
 class IndicatorsSearchResult(BaseModel):
     queries: DatasetAvailabilityQueriesType
     retrieval_results: RetrievalStagesResults
+    hybrid_search_timings: HybridSearchTimings = Field(default_factory=HybridSearchTimings)
 
 
 class SpecialDimensionChainOutput(BaseModel):
@@ -219,6 +245,10 @@ class QueryBuilderAgentState(ToolMessageState):
     special_dims_outputs: dict[str, SpecialDimensionChainOutput] = Field(
         description="mapping from SpecialDimensionsProcessor.id to its chain output",
         default_factory=dict,
+    )
+    hybrid_search_timings: HybridSearchTimings = Field(
+        description="Per-phase timing breakdown of the hybrid indicator search.",
+        default_factory=HybridSearchTimings,
     )
 
 
@@ -369,6 +399,7 @@ class ChainState(BaseModel):
     strong_availability: DatasetAvailabilityQueriesType = {}
 
     retrieval_results: RetrievalStagesResults = RetrievalStagesResults()
+    hybrid_search_timings: HybridSearchTimings = Field(default_factory=HybridSearchTimings)
     special_dims_outputs: dict[str, SpecialDimensionChainOutput] = {}
     dataset_queries: dict[str, DataSetQuery] = {}  # final data queries
 

--- a/statgpt/app/schemas/query_builder.py
+++ b/statgpt/app/schemas/query_builder.py
@@ -177,7 +177,7 @@ class HybridSearchTimings(BaseModel):
 class IndicatorsSearchResult(BaseModel):
     queries: DatasetAvailabilityQueriesType
     retrieval_results: RetrievalStagesResults
-    hybrid_search_timings: HybridSearchTimings = Field(default_factory=HybridSearchTimings)
+    hybrid_search_timings: HybridSearchTimings | None = None
 
 
 class SpecialDimensionChainOutput(BaseModel):
@@ -246,9 +246,12 @@ class QueryBuilderAgentState(ToolMessageState):
         description="mapping from SpecialDimensionsProcessor.id to its chain output",
         default_factory=dict,
     )
-    hybrid_search_timings: HybridSearchTimings = Field(
-        description="Per-phase timing breakdown of the hybrid indicator search.",
-        default_factory=HybridSearchTimings,
+    hybrid_search_timings: HybridSearchTimings | None = Field(
+        default=None,
+        description=(
+            "Per-phase timing breakdown of the hybrid indicator search. "
+            "None when debug stages are disabled."
+        ),
     )
 
 
@@ -399,7 +402,7 @@ class ChainState(BaseModel):
     strong_availability: DatasetAvailabilityQueriesType = {}
 
     retrieval_results: RetrievalStagesResults = RetrievalStagesResults()
-    hybrid_search_timings: HybridSearchTimings = Field(default_factory=HybridSearchTimings)
+    hybrid_search_timings: HybridSearchTimings | None = None
     special_dims_outputs: dict[str, SpecialDimensionChainOutput] = {}
     dataset_queries: dict[str, DataSetQuery] = {}  # final data queries
 

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -1,4 +1,3 @@
-import asyncio
 import collections
 import json
 import re
@@ -868,21 +867,6 @@ class HybridSearcher:
         tokens = await self._matching_index.analyze(text=value)
         return " ".join(t.token for t in tokens)
 
-    async def _tokenize_cached(self, value: str, cache: dict[str, str]) -> str:
-        cached = cache.get(value)
-        if cached is not None:
-            return cached
-        tokenized = await self._tokenize(value)
-        cache[value] = tokenized
-        return tokenized
-
-    async def _prewarm_tokenize_cache(self, values: t.Iterable[str], cache: dict[str, str]) -> None:
-        missing = list({v for v in values if v not in cache})
-        if not missing:
-            return
-        results = await asyncio.gather(*(self._tokenize(v) for v in missing))
-        cache.update(zip(missing, results))
-
     async def _search_by_query(
         self, stage: Stage, query: str, version_ids: set[int], availability: DatasetDimTermsSetType
     ) -> HybridSearchResultInner:
@@ -1088,33 +1072,19 @@ class HybridSearcher:
             query, highlight_field, version_ids, max_candidates
         )
 
-        cache: dict[str, str] = {}
-        valid_hits: list[tuple[t.Any, str]] = [
-            (h, h.highlight[highlight_field][0])
-            for h in search_result.hits.hits
-            if h.highlight is not None
-        ]
-        primary_strings = [h.source[highlight_field] for h, _ in valid_hits]
-        highlight_tokens = (
-            token
-            for _, hl in valid_hits
-            for token in hl.split()
-            if not self.RE_HIGHLIGHT_MATCH_1.match(token)
-        )
-        await self._prewarm_tokenize_cache([*primary_strings, *highlight_tokens], cache)
-
         candidates: set[str] = set()
         good_candidates: set[str] = set()
-        skipped = len(search_result.hits.hits) - len(valid_hits)
-        if skipped > 0:
-            # TODO: review this and fix if possible
-            logger.warning(
-                f"Skipped {skipped} of {len(search_result.hits.hits)} "
-                "hits due to missing highlights"
-            )
-        for hit, highlight in valid_hits:
+        skipped = 0
+        for hit in search_result.hits.hits:
+            if hit.highlight is None:
+                # TODO: review this and fix if possible
+                logger.warning("No highlight found for hit, skipping.")
+                skipped += 1
+                continue
+
+            highlight = hit.highlight[highlight_field][0]
             primary = hit.source[highlight_field]
-            primary_tokenized = await self._tokenize_cached(primary, cache)
+            primary_tokenized = await self._tokenize(primary)
 
             running = []
             for token in highlight.split():
@@ -1125,22 +1095,26 @@ class HybridSearcher:
                     matched = matched.replace("</em>", "")
                     running.append(matched)
                 else:
-                    tokenized = await self._tokenize_cached(token, cache)
+                    tokenized = await self._tokenize(token)
                     if len(running) > 0 and (not tokenized or len(tokenized.strip()) == 0):
                         running.append(token)
                         continue
                     if len(running) == 0:
                         continue
                     await self._assess_candidate(
-                        candidates, good_candidates, primary_tokenized, running, cache
+                        candidates, good_candidates, primary_tokenized, running
                     )
                     running = []
-            await self._assess_candidate(
-                candidates, good_candidates, primary_tokenized, running, cache
+            await self._assess_candidate(candidates, good_candidates, primary_tokenized, running)
+
+        if skipped > 0:
+            logger.warning(
+                f"Skipped {skipped} of {len(search_result.hits.hits)} "
+                "hits due to missing highlights"
             )
 
-        good_candidates = await self._remove_duplicates(good_candidates, cache)
-        candidates = await self._cleanup_candidates(good_candidates, candidates, cache)
+        good_candidates = await self._remove_duplicates(good_candidates)
+        candidates = await self._cleanup_candidates(good_candidates, candidates)
 
         total = search_result.hits.total.value
         primaries = (
@@ -1150,12 +1124,10 @@ class HybridSearcher:
         )
         return primaries, total, candidates, good_candidates
 
-    async def _assess_candidate(
-        self, candidates, good_candidates, primary_tokenized, running, cache: dict[str, str]
-    ):
+    async def _assess_candidate(self, candidates, good_candidates, primary_tokenized, running):
         if len(running) > 0:
             candidate = " ".join(running)
-            exact_tokenized = await self._tokenize_cached(candidate, cache)
+            exact_tokenized = await self._tokenize(candidate)
             if primary_tokenized == exact_tokenized or len(exact_tokenized.split()) > 1:
                 if candidate in good_candidates:
                     return
@@ -1163,13 +1135,12 @@ class HybridSearcher:
             else:
                 candidates |= {candidate}
 
-    async def _remove_duplicates(self, good_candidates, cache: dict[str, str]):
-        await self._prewarm_tokenize_cache(good_candidates, cache)
+    async def _remove_duplicates(self, good_candidates):
         good_candidates = sorted(good_candidates, key=lambda x: len(x), reverse=True)
-        good_list: set[str] = set()
-        result: set[str] = set()
+        good_list = set()
+        result = set()
         for good_candidate in good_candidates:
-            tokenized = await self._tokenize_cached(good_candidate, cache)
+            tokenized = await self._tokenize(good_candidate)
             if tokenized in good_list:
                 continue
             found = False
@@ -1183,17 +1154,16 @@ class HybridSearcher:
             result |= {good_candidate}
         return result
 
-    async def _cleanup_candidates(self, good_candidates, candidates, cache: dict[str, str]):
-        await self._prewarm_tokenize_cache([*good_candidates, *candidates], cache)
-        good_list: set[str] = set()
+    async def _cleanup_candidates(self, good_candidates, candidates):
+        good_list = set()
         for good_candidate in good_candidates:
-            tokenized = await self._tokenize_cached(good_candidate, cache)
+            tokenized = await self._tokenize(good_candidate)
             good_list |= {tokenized}
 
-        result: set[str] = set()
+        result = set()
         candidates = sorted(candidates, key=lambda x: len(x), reverse=True)
         for candidate in candidates:
-            tokenized = await self._tokenize_cached(candidate, cache)
+            tokenized = await self._tokenize(candidate)
             if tokenized in good_list:
                 continue
             found = False
@@ -1244,5 +1214,6 @@ class HybridSearcher:
             query=query,
             aggs=aggs,
             highlight=highlight,
+            explain=True,
             size=max_candidates,
         )

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -129,9 +129,9 @@ class HybridSearcher:
             timings = HybridMatchTimings(query=query)
             t_total = time.perf_counter()
 
-            t = time.perf_counter()
+            t_query_planner = time.perf_counter()
             search_params = await self._query_planner(stage, query, version_ids)
-            timings.query_planner = time.perf_counter() - t
+            timings.query_planner = time.perf_counter() - t_query_planner
 
             reasoning = "\n        relevance score: 1 - 3 (1 - lowest, 3 - highest)\n"
             lexical, semantic, candidates = await self._hybrid_candidates(
@@ -151,9 +151,9 @@ class HybridSearcher:
             for items in batches:
                 items = self._pre_append_confirmed(items, selected)
 
-                t = time.perf_counter()
+                t_relevance_batch = time.perf_counter()
                 relevance = await self._relevance_candidates(query, items)
-                timings.relevance_per_batch.append(time.perf_counter() - t)
+                timings.relevance_per_batch.append(time.perf_counter() - t_relevance_batch)
 
                 llm_scored += self._add_llm_scores_to_indexed(indexed=indexed, scores=relevance)
 
@@ -374,33 +374,33 @@ class HybridSearcher:
 
             t_total = time.perf_counter()
 
-            t = time.perf_counter()
+            t_lexical = time.perf_counter()
             lex = await self._lexical(
                 query, version_ids, max_query=search_params.max_lexical_candidates
             )
-            timings.lexical = time.perf_counter() - t
+            timings.lexical = time.perf_counter() - t_lexical
             lex_filtered: HarmonizedItemsScoredDict = self._filer_candidates_by_availability(
                 lex, availability
             )
 
-            t = time.perf_counter()
+            t_semantic_raw = time.perf_counter()
             sem_raw: list[ScoredVectorStoreDocument] = await self._semantic_raw(
                 query, version_ids, max_query=search_params.max_semantic_candidates
             )
-            timings.semantic_raw = time.perf_counter() - t
+            timings.semantic_raw = time.perf_counter() - t_semantic_raw
             sem_indexed = self._semantic_result(sem_raw)
             sem_filtered: PlainItemsScoredDict = self._filer_candidates_by_availability(
                 sem_indexed, availability
             )
 
-            t = time.perf_counter()
+            t_hybrid_combination = time.perf_counter()
             hybrid = await self._hybrid_combination(
                 sem_raw=sem_raw,
                 lexical=lex_filtered,
                 semantic=sem_filtered,
                 alpha=search_params.alpha,
             )
-            timings.hybrid_combination = time.perf_counter() - t
+            timings.hybrid_combination = time.perf_counter() - t_hybrid_combination
 
             hybrid_sorted: list[tuple[str, HarmonizedItemScored]] = sorted(
                 hybrid.items(), key=lambda x: x[1].score, reverse=True
@@ -903,23 +903,23 @@ class HybridSearcher:
         timings = HybridSearchTimings()
         t_total = time.perf_counter()
 
-        t = time.perf_counter()
+        t_lexical_pre_match = time.perf_counter()
         primaries, total, candidates, good_candidates = await self.lexical_pre_match(
             query, "name_normalized", version_ids, self.config.max_lexical_pre_match_candidates
         )
-        timings.lexical_pre_match = time.perf_counter() - t
+        timings.lexical_pre_match = time.perf_counter() - t_lexical_pre_match
         forbidden = good_candidates | candidates
         logger.info(
             f"[search], {len(good_candidates)} good candidates, {len(candidates)} candidates "
-            f"(elapsed: {timings.lexical_pre_match:0.3f} sec)"
+            f"(elapsed: {time.perf_counter() - t_total:0.3f} sec)"
         )
         logger.info(f"[search], {good_candidates=}")
         logger.info(f"[search], {candidates=}")
 
-        t = time.perf_counter()
+        t_normalize_input = time.perf_counter()
         normalized = await self._normalize_input(query, named_entities, period, forbidden)
         normalized = normalized.lower()
-        timings.normalize_input = time.perf_counter() - t
+        timings.normalize_input = time.perf_counter() - t_normalize_input
 
         if stage:
             stage.append_content("> [raw input query]:\n")
@@ -932,12 +932,12 @@ class HybridSearcher:
             forbidden_str = "[" + "]  [".join(forbidden) + "]"
             stage.append_content(f"```\n{forbidden_str}\n```\n")
 
-        logger.info(f"[search], {normalized=}, (elapsed {timings.normalize_input:0.3f} sec)")
+        logger.info(f"[search], {normalized=}, (elapsed {time.perf_counter() - t_total:0.3f} sec)")
 
-        t = time.perf_counter()
+        t_separate_subjects = time.perf_counter()
         queries = await self._separate_subjects(normalized, good_candidates)
-        timings.separate_subjects = time.perf_counter() - t
-        logger.info(f"[search], {queries=}, (elapsed {timings.separate_subjects:0.3f} sec)")
+        timings.separate_subjects = time.perf_counter() - t_separate_subjects
+        logger.info(f"[search], {queries=}, (elapsed {time.perf_counter() - t_total:0.3f} sec)")
 
         tasks = [
             self._search_by_query(
@@ -948,11 +948,11 @@ class HybridSearcher:
             )
             for query in queries
         ]
-        t = time.perf_counter()
+        t_parallel_subqueries = time.perf_counter()
         partial: list[HybridSearchResultInner] = await async_utils.gather_with_concurrency(
             20, *tasks
         )
-        timings.parallel_subqueries_wall = time.perf_counter() - t
+        timings.parallel_subqueries_wall = time.perf_counter() - t_parallel_subqueries
         timings.per_subquery = [item.timings for item in partial]
 
         lexical_merged = self._merge_scored_dicts([item.lexical for item in partial])

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -1,3 +1,4 @@
+import asyncio
 import collections
 import json
 import re
@@ -867,6 +868,21 @@ class HybridSearcher:
         tokens = await self._matching_index.analyze(text=value)
         return " ".join(t.token for t in tokens)
 
+    async def _tokenize_cached(self, value: str, cache: dict[str, str]) -> str:
+        cached = cache.get(value)
+        if cached is not None:
+            return cached
+        tokenized = await self._tokenize(value)
+        cache[value] = tokenized
+        return tokenized
+
+    async def _prewarm_tokenize_cache(self, values: t.Iterable[str], cache: dict[str, str]) -> None:
+        missing = list({v for v in values if v not in cache})
+        if not missing:
+            return
+        results = await asyncio.gather(*(self._tokenize(v) for v in missing))
+        cache.update(zip(missing, results))
+
     async def _search_by_query(
         self, stage: Stage, query: str, version_ids: set[int], availability: DatasetDimTermsSetType
     ) -> HybridSearchResultInner:
@@ -1072,19 +1088,33 @@ class HybridSearcher:
             query, highlight_field, version_ids, max_candidates
         )
 
+        cache: dict[str, str] = {}
+        valid_hits: list[tuple[t.Any, str]] = [
+            (h, h.highlight[highlight_field][0])
+            for h in search_result.hits.hits
+            if h.highlight is not None
+        ]
+        primary_strings = [h.source[highlight_field] for h, _ in valid_hits]
+        highlight_tokens = (
+            token
+            for _, hl in valid_hits
+            for token in hl.split()
+            if not self.RE_HIGHLIGHT_MATCH_1.match(token)
+        )
+        await self._prewarm_tokenize_cache([*primary_strings, *highlight_tokens], cache)
+
         candidates: set[str] = set()
         good_candidates: set[str] = set()
-        skipped = 0
-        for hit in search_result.hits.hits:
-            if hit.highlight is None:
-                # TODO: review this and fix if possible
-                logger.warning("No highlight found for hit, skipping.")
-                skipped += 1
-                continue
-
-            highlight = hit.highlight[highlight_field][0]
+        skipped = len(search_result.hits.hits) - len(valid_hits)
+        if skipped > 0:
+            # TODO: review this and fix if possible
+            logger.warning(
+                f"Skipped {skipped} of {len(search_result.hits.hits)} "
+                "hits due to missing highlights"
+            )
+        for hit, highlight in valid_hits:
             primary = hit.source[highlight_field]
-            primary_tokenized = await self._tokenize(primary)
+            primary_tokenized = await self._tokenize_cached(primary, cache)
 
             running = []
             for token in highlight.split():
@@ -1095,26 +1125,22 @@ class HybridSearcher:
                     matched = matched.replace("</em>", "")
                     running.append(matched)
                 else:
-                    tokenized = await self._tokenize(token)
+                    tokenized = await self._tokenize_cached(token, cache)
                     if len(running) > 0 and (not tokenized or len(tokenized.strip()) == 0):
                         running.append(token)
                         continue
                     if len(running) == 0:
                         continue
                     await self._assess_candidate(
-                        candidates, good_candidates, primary_tokenized, running
+                        candidates, good_candidates, primary_tokenized, running, cache
                     )
                     running = []
-            await self._assess_candidate(candidates, good_candidates, primary_tokenized, running)
-
-        if skipped > 0:
-            logger.warning(
-                f"Skipped {skipped} of {len(search_result.hits.hits)} "
-                "hits due to missing highlights"
+            await self._assess_candidate(
+                candidates, good_candidates, primary_tokenized, running, cache
             )
 
-        good_candidates = await self._remove_duplicates(good_candidates)
-        candidates = await self._cleanup_candidates(good_candidates, candidates)
+        good_candidates = await self._remove_duplicates(good_candidates, cache)
+        candidates = await self._cleanup_candidates(good_candidates, candidates, cache)
 
         total = search_result.hits.total.value
         primaries = (
@@ -1124,10 +1150,12 @@ class HybridSearcher:
         )
         return primaries, total, candidates, good_candidates
 
-    async def _assess_candidate(self, candidates, good_candidates, primary_tokenized, running):
+    async def _assess_candidate(
+        self, candidates, good_candidates, primary_tokenized, running, cache: dict[str, str]
+    ):
         if len(running) > 0:
             candidate = " ".join(running)
-            exact_tokenized = await self._tokenize(candidate)
+            exact_tokenized = await self._tokenize_cached(candidate, cache)
             if primary_tokenized == exact_tokenized or len(exact_tokenized.split()) > 1:
                 if candidate in good_candidates:
                     return
@@ -1135,12 +1163,13 @@ class HybridSearcher:
             else:
                 candidates |= {candidate}
 
-    async def _remove_duplicates(self, good_candidates):
+    async def _remove_duplicates(self, good_candidates, cache: dict[str, str]):
+        await self._prewarm_tokenize_cache(good_candidates, cache)
         good_candidates = sorted(good_candidates, key=lambda x: len(x), reverse=True)
-        good_list = set()
-        result = set()
+        good_list: set[str] = set()
+        result: set[str] = set()
         for good_candidate in good_candidates:
-            tokenized = await self._tokenize(good_candidate)
+            tokenized = await self._tokenize_cached(good_candidate, cache)
             if tokenized in good_list:
                 continue
             found = False
@@ -1154,16 +1183,17 @@ class HybridSearcher:
             result |= {good_candidate}
         return result
 
-    async def _cleanup_candidates(self, good_candidates, candidates):
-        good_list = set()
+    async def _cleanup_candidates(self, good_candidates, candidates, cache: dict[str, str]):
+        await self._prewarm_tokenize_cache([*good_candidates, *candidates], cache)
+        good_list: set[str] = set()
         for good_candidate in good_candidates:
-            tokenized = await self._tokenize(good_candidate)
+            tokenized = await self._tokenize_cached(good_candidate, cache)
             good_list |= {tokenized}
 
-        result = set()
+        result: set[str] = set()
         candidates = sorted(candidates, key=lambda x: len(x), reverse=True)
         for candidate in candidates:
-            tokenized = await self._tokenize(candidate)
+            tokenized = await self._tokenize_cached(candidate, cache)
             if tokenized in good_list:
                 continue
             found = False
@@ -1214,6 +1244,5 @@ class HybridSearcher:
             query=query,
             aggs=aggs,
             highlight=highlight,
-            explain=True,
             size=max_candidates,
         )

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -7,12 +7,14 @@ from collections.abc import Generator
 from typing import Any, NamedTuple
 
 from aidial_sdk.chat_completion import Stage
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from statgpt.app.default_prompts import hybrid_search_default_prompts
 from statgpt.app.schemas.query_builder import (
     DatasetAvailabilityQueriesType,
     DateTimeQueryResponse,
+    HybridMatchTimings,
+    HybridSearchTimings,
     NamedEntity,
 )
 from statgpt.app.services.chat_facade import VersionedDataSet
@@ -78,6 +80,7 @@ class HybridSearchResultInner(BaseModel):
     semantic: PlainItemsScoredDict
     llm_scored: list[HybridCandidateScored]
     final: DatasetDimTermsSetType
+    timings: HybridMatchTimings = Field(default_factory=HybridMatchTimings)
 
 
 class HybridSearchResult(BaseModel):
@@ -85,6 +88,7 @@ class HybridSearchResult(BaseModel):
     semantic: list[dict]
     llm_scored: list[HybridCandidateScored]
     final_queries: dict[str, list[DimensionQuery]]
+    timings: HybridSearchTimings = Field(default_factory=HybridSearchTimings)
 
 
 class HybridSearcher:
@@ -120,14 +124,22 @@ class HybridSearcher:
             list[HybridCandidateScored],
             list[dict],
             str,
+            HybridMatchTimings,
         ]:
+            timings = HybridMatchTimings(query=query)
+            t_total = time.perf_counter()
+
+            t = time.perf_counter()
             search_params = await self._query_planner(stage, query, version_ids)
+            timings.query_planner = time.perf_counter() - t
 
             reasoning = "\n        relevance score: 1 - 3 (1 - lowest, 3 - highest)\n"
             lexical, semantic, candidates = await self._hybrid_candidates(
-                query, version_ids, availability, search_params
+                query, version_ids, availability, search_params, timings
             )
+
             batches, indexed = self._prepare_for_relevance(candidates)
+
             dataset_max_score: dict[str, float] = {}
             if stage:
                 stage.append_content(reasoning)
@@ -135,10 +147,14 @@ class HybridSearcher:
             is_only_one_dataset_available = len(availability) == 1
             llm_scored = []
             selected: list[dict] = []
+            t_relevance_total = time.perf_counter()
             for items in batches:
                 items = self._pre_append_confirmed(items, selected)
 
+                t = time.perf_counter()
                 relevance = await self._relevance_candidates(query, items)
+                timings.relevance_per_batch.append(time.perf_counter() - t)
+
                 llm_scored += self._add_llm_scores_to_indexed(indexed=indexed, scores=relevance)
 
                 batch_selected, batch_reasoning = self._filter_candidates(
@@ -146,7 +162,9 @@ class HybridSearcher:
                 )
                 selected += batch_selected
                 reasoning += batch_reasoning
-            return lexical, semantic, llm_scored, selected, reasoning
+            timings.relevance_total = time.perf_counter() - t_relevance_total
+            timings.total = time.perf_counter() - t_total
+            return lexical, semantic, llm_scored, selected, reasoning, timings
 
         async def _query_planner(
             self, stage: Stage, query: str, version_ids: set[int]
@@ -351,29 +369,39 @@ class HybridSearcher:
             version_ids: set[int],
             availability: DatasetDimTermsSetType,
             search_params: SearchParams,
+            timings: HybridMatchTimings,
         ) -> tuple[HarmonizedItemsScoredDict, PlainItemsScoredDict, list[dict]]:
 
+            t_total = time.perf_counter()
+
+            t = time.perf_counter()
             lex = await self._lexical(
                 query, version_ids, max_query=search_params.max_lexical_candidates
             )
+            timings.lexical = time.perf_counter() - t
             lex_filtered: HarmonizedItemsScoredDict = self._filer_candidates_by_availability(
                 lex, availability
             )
 
+            t = time.perf_counter()
             sem_raw: list[ScoredVectorStoreDocument] = await self._semantic_raw(
                 query, version_ids, max_query=search_params.max_semantic_candidates
             )
+            timings.semantic_raw = time.perf_counter() - t
             sem_indexed = self._semantic_result(sem_raw)
             sem_filtered: PlainItemsScoredDict = self._filer_candidates_by_availability(
                 sem_indexed, availability
             )
 
+            t = time.perf_counter()
             hybrid = await self._hybrid_combination(
                 sem_raw=sem_raw,
                 lexical=lex_filtered,
                 semantic=sem_filtered,
                 alpha=search_params.alpha,
             )
+            timings.hybrid_combination = time.perf_counter() - t
+
             hybrid_sorted: list[tuple[str, HarmonizedItemScored]] = sorted(
                 hybrid.items(), key=lambda x: x[1].score, reverse=True
             )
@@ -387,6 +415,7 @@ class HybridSearcher:
                 candidates, hybrid_sorted, max_output=search_params.max_candidates
             )
 
+            timings.hybrid_candidates_total = time.perf_counter() - t_total
             return lex_filtered, sem_filtered, candidates
 
         def make_sure_top_n_is_included(
@@ -845,7 +874,7 @@ class HybridSearcher:
             stage.append_content(f"\n1. {query}\n")
 
         hybrid_match = self.HybridMatch(self)
-        lexical, semantic, llm_scored, selected, reasoning = await hybrid_match.search(
+        lexical, semantic, llm_scored, selected, reasoning, timings = await hybrid_match.search(
             stage, query, version_ids, availability
         )
         final = self._best_of(selected)
@@ -854,6 +883,7 @@ class HybridSearcher:
             semantic=semantic,
             llm_scored=llm_scored,
             final=final,
+            timings=timings,
         )
         return res
 
@@ -870,22 +900,26 @@ class HybridSearcher:
         availability_dict = self._dimension_queries_to_dict(availability_queries)
         version_ids: set[int] = {ds.version.version_data_id for ds in datasets.values()}
 
-        pc0 = time.perf_counter()
+        timings = HybridSearchTimings()
+        t_total = time.perf_counter()
 
+        t = time.perf_counter()
         primaries, total, candidates, good_candidates = await self.lexical_pre_match(
             query, "name_normalized", version_ids, self.config.max_lexical_pre_match_candidates
         )
+        timings.lexical_pre_match = time.perf_counter() - t
         forbidden = good_candidates | candidates
-        elapsed = time.perf_counter() - pc0
         logger.info(
             f"[search], {len(good_candidates)} good candidates, {len(candidates)} candidates "
-            f"(elapsed: {elapsed:0.3f} sec)"
+            f"(elapsed: {timings.lexical_pre_match:0.3f} sec)"
         )
         logger.info(f"[search], {good_candidates=}")
         logger.info(f"[search], {candidates=}")
+
+        t = time.perf_counter()
         normalized = await self._normalize_input(query, named_entities, period, forbidden)
         normalized = normalized.lower()
-        elapsed = time.perf_counter() - pc0
+        timings.normalize_input = time.perf_counter() - t
 
         if stage:
             stage.append_content("> [raw input query]:\n")
@@ -898,11 +932,12 @@ class HybridSearcher:
             forbidden_str = "[" + "]  [".join(forbidden) + "]"
             stage.append_content(f"```\n{forbidden_str}\n```\n")
 
-        logger.info(f"[search], {normalized=}, (elapsed {elapsed:0.3f} sec)")
+        logger.info(f"[search], {normalized=}, (elapsed {timings.normalize_input:0.3f} sec)")
 
+        t = time.perf_counter()
         queries = await self._separate_subjects(normalized, good_candidates)
-        elapsed = time.perf_counter() - pc0
-        logger.info(f"[search], {queries=}, (elapsed {elapsed:0.3f} sec)")
+        timings.separate_subjects = time.perf_counter() - t
+        logger.info(f"[search], {queries=}, (elapsed {timings.separate_subjects:0.3f} sec)")
 
         tasks = [
             self._search_by_query(
@@ -913,9 +948,12 @@ class HybridSearcher:
             )
             for query in queries
         ]
+        t = time.perf_counter()
         partial: list[HybridSearchResultInner] = await async_utils.gather_with_concurrency(
             20, *tasks
         )
+        timings.parallel_subqueries_wall = time.perf_counter() - t
+        timings.per_subquery = [item.timings for item in partial]
 
         lexical_merged = self._merge_scored_dicts([item.lexical for item in partial])
         semantic_merged = self._merge_scored_dicts([item.semantic for item in partial])
@@ -928,11 +966,14 @@ class HybridSearcher:
         final_queries = self._merge_dimensions_into_queries(final_merged)
         logger.info(f"Final hybrid queries: {final_queries}")
 
+        timings.total = time.perf_counter() - t_total
+
         return HybridSearchResult(
             lexical=lexical_merged,
             semantic=semantic_merged,
             llm_scored=llm_scored_merged,
             final_queries=final_queries,
+            timings=timings,
         )
 
     @staticmethod

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -7,7 +7,7 @@ from collections.abc import Generator
 from typing import Any, NamedTuple
 
 from aidial_sdk.chat_completion import Stage
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from statgpt.app.default_prompts import hybrid_search_default_prompts
 from statgpt.app.schemas.query_builder import (
@@ -80,7 +80,7 @@ class HybridSearchResultInner(BaseModel):
     semantic: PlainItemsScoredDict
     llm_scored: list[HybridCandidateScored]
     final: DatasetDimTermsSetType
-    timings: HybridMatchTimings = Field(default_factory=HybridMatchTimings)
+    timings: HybridMatchTimings
 
 
 class HybridSearchResult(BaseModel):
@@ -88,7 +88,7 @@ class HybridSearchResult(BaseModel):
     semantic: list[dict]
     llm_scored: list[HybridCandidateScored]
     final_queries: dict[str, list[DimensionQuery]]
-    timings: HybridSearchTimings = Field(default_factory=HybridSearchTimings)
+    timings: HybridSearchTimings
 
 
 class HybridSearcher:


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #348 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Adds per-phase wall-clock timings to the hybrid indicator search. Each call to HybridSearcher.search now produces a structured HybridSearchTimings object covering the top-level phases (lexical pre-match, normalization, query separation, parallel sub-search) and a per-subquery breakdown (query planner, lexical, semantic, hybrid combination, per-batch LLM relevance). The object is attached to QueryBuilderAgentState, so it flows out via DIAL response state without further plumbing.

A few deliberate scope choices worth calling out:

- Timings only land in the response state when show_debug_stages is on. When the flag is off, the result carries  None in hybrid_search_timings field — we don't want to bloat the regular response payload with profiling data. 
- time.perf_counter() calls are NOT gated, even when the flag is off. Each call is sub-microsecond and there are roughly a dozen per request — gating them would save under a millisecond total, well below noise vs. the LLM calls that dominate the search. Adding conditionals would cost more in code complexity than it saves in latency.
- Existing logger.info lines in HybridSearcher.search are left untouched. Skipping them when the flag is off would save more than gating the perf-counter calls (string formatting + I/O), but in absolute terms it's still small next to the LLM round-trips. Not worth bundling into this MR; can be revisited later during refactoring of the logging itself.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
