### PR TITLE
feat: declare MCP ToolAnnotations for every StatGptTool #349

### DIFF
--- a/statgpt/app/chains/available_publications.py
+++ b/statgpt/app/chains/available_publications.py
@@ -1,3 +1,5 @@
+from mcp.types import ToolAnnotations
+
 from statgpt.app.chains.parameters import ChainParameters
 from statgpt.app.chains.tools import StatGptTool
 from statgpt.app.schemas import ToolArtifact, ToolMessageState
@@ -8,6 +10,10 @@ from statgpt.common.schemas import ToolTypes
 class AvailablePublicationsTool(
     StatGptTool[AvailablePublicationsToolConfig], tool_type=ToolTypes.AVAILABLE_PUBLICATIONS
 ):
+    @classmethod
+    def get_mcp_annotations(cls) -> ToolAnnotations:
+        return ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
+
     async def _arun(self, inputs: dict) -> tuple[str, ToolArtifact]:
         response = (
             f"The following publication types are available:\n\n"

--- a/statgpt/app/chains/data_query/data_query_tool.py
+++ b/statgpt/app/chains/data_query/data_query_tool.py
@@ -1,4 +1,5 @@
 from langchain_core.runnables import Runnable
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from statgpt.app.chains.tools import StatGptTool, ToolArgs
@@ -25,6 +26,10 @@ class DataQueryArgs(ToolArgs):
 
 
 class DataQueryTool(StatGptTool[DataQueryToolConfig], tool_type=ToolTypes.DATA_QUERY):
+
+    @classmethod
+    def get_mcp_annotations(cls) -> ToolAnnotations:
+        return ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
 
     @classmethod
     def get_args_schema(cls, tool_config: DataQueryToolConfig) -> type[DataQueryArgs]:

--- a/statgpt/app/chains/datasets_meta/available_datasets_tool.py
+++ b/statgpt/app/chains/datasets_meta/available_datasets_tool.py
@@ -1,3 +1,5 @@
+from mcp.types import ToolAnnotations
+
 from statgpt.app.chains.parameters import ChainParameters
 from statgpt.app.chains.tools import StatGptTool
 from statgpt.app.schemas import ToolArtifact, ToolMessageState
@@ -11,6 +13,10 @@ from ._utils import _create_formatter_config
 class AvailableDatasetsTool(
     StatGptTool[AvailableDatasetsToolConfig], tool_type=ToolTypes.AVAILABLE_DATASETS
 ):
+
+    @classmethod
+    def get_mcp_annotations(cls) -> ToolAnnotations:
+        return ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
 
     def __init__(
         self, tool_config: AvailableDatasetsToolConfig, channel_config: ChannelConfig, **kwargs

--- a/statgpt/app/chains/datasets_meta/metadata_tool.py
+++ b/statgpt/app/chains/datasets_meta/metadata_tool.py
@@ -1,4 +1,5 @@
 from langchain_core.prompts import ChatPromptTemplate, SystemMessagePromptTemplate
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from statgpt.app.chains.parameters import ChainParameters
@@ -24,6 +25,10 @@ class DatasetsMetadataArgs(ToolArgs):
 class DatasetsMetadataTool(
     StatGptTool[DatasetsMetadataToolConfig], tool_type=ToolTypes.DATASETS_METADATA
 ):
+    @classmethod
+    def get_mcp_annotations(cls) -> ToolAnnotations:
+        return ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
+
     def __init__(
         self, tool_config: DatasetsMetadataToolConfig, channel_config: ChannelConfig, **kwargs
     ):

--- a/statgpt/app/chains/datasets_meta/structure_tool.py
+++ b/statgpt/app/chains/datasets_meta/structure_tool.py
@@ -1,3 +1,4 @@
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from statgpt.app.chains.parameters import ChainParameters
@@ -23,6 +24,10 @@ class DatasetStructureArgs(ToolArgs):
 class DatasetStructureTool(
     StatGptTool[DatasetStructureToolConfig], tool_type=ToolTypes.DATASET_STRUCTURE
 ):
+    @classmethod
+    def get_mcp_annotations(cls) -> ToolAnnotations:
+        return ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
+
     def __init__(
         self, tool_config: DatasetStructureToolConfig, channel_config: ChannelConfig, **kwargs
     ):

--- a/statgpt/app/chains/file_rags/file_rag_tool.py
+++ b/statgpt/app/chains/file_rags/file_rag_tool.py
@@ -2,6 +2,7 @@ import typing as t
 
 from langchain_core.runnables import Runnable
 from langchain_core.tools import InjectedToolArg
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from statgpt.app.chains.parameters import ChainParameters
@@ -41,6 +42,10 @@ The query to search an answer for.
 
 
 class FileRagTool(StatGptTool[FileRagToolConfig], tool_type=ToolTypes.FILE_RAG):
+    @classmethod
+    def get_mcp_annotations(cls) -> ToolAnnotations:
+        return ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
+
     @classmethod
     def get_args_schema(cls, tool_config: FileRagToolConfig) -> type[FileRagArgs]:
         """Return the schema for the arguments that this tool accepts."""

--- a/statgpt/app/chains/glossary_tools.py
+++ b/statgpt/app/chains/glossary_tools.py
@@ -1,3 +1,4 @@
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from statgpt.app.chains.parameters import ChainParameters
@@ -12,6 +13,10 @@ from statgpt.common.schemas.tools import TermDefinitionsTool as TermDefinitionsT
 class AvailableTermsTool(
     StatGptTool[AvailableTermsToolConfig], tool_type=ToolTypes.AVAILABLE_TERMS
 ):
+    @classmethod
+    def get_mcp_annotations(cls) -> ToolAnnotations:
+        return ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
+
     async def _arun(self, inputs: dict) -> tuple[str, ToolArtifact]:
         data_service = ChainParameters.get_data_service(inputs)
 
@@ -63,6 +68,10 @@ class BaseTermDefinitionsArgs(ToolArgs):
 class TermDefinitionsTool(
     StatGptTool[TermDefinitionsToolConfig], tool_type=ToolTypes.TERM_DEFINITIONS
 ):
+    @classmethod
+    def get_mcp_annotations(cls) -> ToolAnnotations:
+        return ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
+
     @classmethod
     def get_args_schema(cls, tool_config: TermDefinitionsToolConfig) -> type[ToolArgs]:
         """Return the schema for the arguments that this tool accepts."""

--- a/statgpt/app/chains/plain_content_tool.py
+++ b/statgpt/app/chains/plain_content_tool.py
@@ -1,3 +1,5 @@
+from mcp.types import ToolAnnotations
+
 from statgpt.app.chains.tools import StatGptTool
 from statgpt.app.schemas import ToolArtifact, ToolMessageState
 from statgpt.common.auth.auth_context import AuthContext
@@ -28,6 +30,10 @@ class PlainContentTool(StatGptTool[PlainContentToolConfig], tool_type=ToolTypes.
     """
     Tool for displaying plain content (text, json, yaml) in Markdown format.
     """
+
+    @classmethod
+    def get_mcp_annotations(cls) -> ToolAnnotations:
+        return ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=False)
 
     async def _arun(self, inputs: dict) -> tuple[str, ToolArtifact]:
         # it's assumed that file is stored under app's API key

--- a/statgpt/app/chains/tools.py
+++ b/statgpt/app/chains/tools.py
@@ -3,6 +3,7 @@ from collections.abc import MutableMapping
 from typing import Annotated, Any, Generic, Literal, TypeVar
 
 from langchain_core.tools import BaseTool, InjectedToolArg
+from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
 from statgpt.app.schemas import ToolArtifact
@@ -134,6 +135,13 @@ class StatGptTool(BaseTool, ABC, Generic[ToolConfigType]):
     def get_args_schema(cls, tool_config: ToolConfigType) -> type[ToolArgs]:
         """Return the schema for the arguments that this tool accepts."""
         return ToolArgs
+
+    @classmethod
+    @abstractmethod
+    def get_mcp_annotations(cls) -> ToolAnnotations:
+        """MCP tool hints may be used by clients for UX decisions (e.g. skipping
+        confirmation prompts for read-only tools, flagging open-world tools).
+        Advisory only — clients must not rely on them for security."""
 
     @staticmethod
     def from_config(tool_config: ToolConfigType, channel_config: ChannelConfig) -> 'StatGptTool':

--- a/statgpt/app/chains/web_search/web_agent.py
+++ b/statgpt/app/chains/web_search/web_agent.py
@@ -1,3 +1,4 @@
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from statgpt.app.chains.parameters import ChainParameters
@@ -14,6 +15,10 @@ class WebSearchArgs(ToolArgs):
 
 
 class WebSearchAgentTool(StatGptTool[WebSearchToolConfig], tool_type=ToolTypes.WEB_SEARCH_AGENT):
+    @classmethod
+    def get_mcp_annotations(cls) -> ToolAnnotations:
+        return ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=True)
+
     def __init__(self, tool_config: WebSearchToolConfig, channel_config: ChannelConfig, **kwargs):
         super().__init__(tool_config, channel_config, **kwargs)
 

--- a/statgpt/app/chains/web_search/web_rag.py
+++ b/statgpt/app/chains/web_search/web_rag.py
@@ -2,6 +2,7 @@ import re
 from enum import StrEnum
 from typing import Any
 
+from mcp.types import ToolAnnotations
 from pydantic import Field, create_model
 
 from statgpt.app.chains.parameters import ChainParameters
@@ -26,6 +27,10 @@ class BaseWebSearchArgs(ToolArgs):
 
 
 class WebSearchTool(StatGptTool[WebSearchToolConfig], tool_type=ToolTypes.WEB_SEARCH):
+    @classmethod
+    def get_mcp_annotations(cls) -> ToolAnnotations:
+        return ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=True)
+
     def __init__(self, tool_config: WebSearchToolConfig, channel_config: ChannelConfig, **kwargs):
         super().__init__(tool_config, channel_config, **kwargs)
 

--- a/statgpt/app/mcp/provider.py
+++ b/statgpt/app/mcp/provider.py
@@ -109,6 +109,7 @@ class ChannelToolProvider(Provider):
             name=tool_config.name,
             description=tool_config.description,
             parameters=langchain_tool.get_public_args_schema(),
+            annotations=langchain_tool.get_mcp_annotations(),
         )
 
     async def _list_tools(self) -> Sequence[Tool]:


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- close #349

### Description of changes

<!-- Please explain the changes you made right below this line. -->

Every channel tool now declares MCP `ToolAnnotations` so connected clients can tell read-only tools apart from open-world ones and adjust their UX accordingly (e.g. skip confirmation prompts).

Per the MCP spec, these are advisory hints — clients may ignore them.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
