### PR TITLE
chore: rename available_dimensions to non_indicator_dimensions

### DIFF
--- a/statgpt/admin/routers/channel.py
+++ b/statgpt/admin/routers/channel.py
@@ -325,7 +325,7 @@ async def deduplicate_channel(
     background_tasks: BackgroundTasks,
     channel_id: int,
 ) -> schemas.Channel:
-    """Deduplicates Available_Dimensions and Special_Dimensions vector stores for channel.
+    """Deduplicates the non-indicator and special dimensions vector stores for the channel.
 
     This operation removes duplicate dimension values based on document content.
 

--- a/statgpt/admin/services/channel.py
+++ b/statgpt/admin/services/channel.py
@@ -132,7 +132,7 @@ class AdminPortalChannelService(ChannelService):
 
         collections = [
             channel.indicator_table_name,
-            channel.available_dimensions_table_name,
+            channel.non_indicator_dimensions_table_name,
             channel.special_dimensions_table_name,
         ]
         for collection in collections:
@@ -274,7 +274,7 @@ class AdminPortalChannelService(ChannelService):
     async def deduplicate_channel_dimensions(
         self, channel_id: int, auth_context: AuthContext
     ) -> None:
-        """Deduplicates Available_Dimensions and Special_Dimensions vector stores for channel.
+        """Deduplicates the non-indicator and special dimensions vector stores for the channel.
 
         Deduplication is performed based on document content.
         Documents with identical content will be merged.
@@ -282,19 +282,19 @@ class AdminPortalChannelService(ChannelService):
         async with self._scoped_session():
             channel = await self.get_model_by_id(channel_id)
             # Extract scalar values while still inside the session scope:
-            available_dims_table = channel.available_dimensions_table_name
+            non_indicator_dims_table = channel.non_indicator_dimensions_table_name
             special_dims_table = channel.special_dimensions_table_name
             llm_model = channel.llm_model
 
         vector_store_factory = VectorStoreFactory()
 
-        _log.info(f"Deduplicating available_dimensions for channel {channel_id}")
-        available_dims_store = await vector_store_factory.get_vector_store(
-            collection_name=available_dims_table,
+        _log.info(f"Deduplicating non_indicator_dimensions for channel {channel_id}")
+        non_indicator_dims_store = await vector_store_factory.get_vector_store(
+            collection_name=non_indicator_dims_table,
             auth_context=auth_context,
             embedding_model_name=llm_model,
         )
-        await available_dims_store.deduplicate_by_document_content()
+        await non_indicator_dims_store.deduplicate_by_document_content()
 
         _log.info(f"Deduplicating special_dimensions for channel {channel_id}")
         special_dims_store = await vector_store_factory.get_vector_store(

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -107,7 +107,7 @@ class AdminPortalDataSetService(DataSetService):
         _log.info(f"Exporting {len(version_ids)} version(s): {sorted(version_ids)}")
 
         collections = [
-            channel.available_dimensions_table_name,
+            channel.non_indicator_dimensions_table_name,
             channel.indicator_table_name,
             channel.special_dimensions_table_name,
         ]
@@ -411,7 +411,7 @@ class AdminPortalDataSetService(DataSetService):
         }
 
         collections = [
-            channel.available_dimensions_table_name,
+            channel.non_indicator_dimensions_table_name,
             channel.indicator_table_name,
             channel.special_dimensions_table_name,
         ]
@@ -938,7 +938,7 @@ class AdminPortalDataSetService(DataSetService):
         collections = [
             channel.indicator_table_name,
             channel.special_dimensions_table_name,
-            channel.available_dimensions_table_name,
+            channel.non_indicator_dimensions_table_name,
         ]
         for collection_name in collections:
             vector_store = await vector_store_factory.get_vector_store(
@@ -1594,7 +1594,7 @@ class AdminPortalDataSetService(DataSetService):
         )
 
     @staticmethod
-    async def _index_available_dimensions(
+    async def _index_non_indicator_dimensions(
         version_id: int,
         channel: schemas.Channel,
         dataset: base.DataSet,
@@ -1604,7 +1604,7 @@ class AdminPortalDataSetService(DataSetService):
         auth_context: AuthContext,
     ) -> None:
         vector_store = await vector_store_factory.get_vector_store(
-            collection_name=channel.available_dimensions_table_name,
+            collection_name=channel.non_indicator_dimensions_table_name,
             embedding_model_name=channel.llm_model,
             auth_context=auth_context,
         )
@@ -1806,7 +1806,7 @@ class AdminPortalDataSetService(DataSetService):
             indexing_stats: dict | None = None
 
             if reindex_dimensions:
-                await self._index_available_dimensions(
+                await self._index_non_indicator_dimensions(
                     version_id=channel_dataset_version_id,
                     channel=channel,
                     dataset=dataset,
@@ -1912,13 +1912,13 @@ class AdminPortalDataSetService(DataSetService):
 
     async def _get_deduplication_status_by_versions(
         self,
-        available_dims_store: VectorStore,
+        non_indicator_dims_store: VectorStore,
         special_dims_store: VectorStore,
         indicator_dims_store: VectorStore,
         versions: set[int],
     ) -> schemas.DeduplicationStatus:
-        available_has_duplicates, available_count = (
-            await available_dims_store.has_duplicates_in_versions(version_ids=versions)
+        non_indicator_has_duplicates, non_indicator_count = (
+            await non_indicator_dims_store.has_duplicates_in_versions(version_ids=versions)
         )
         special_has_duplicates, special_count = await special_dims_store.has_duplicates_in_versions(
             version_ids=versions
@@ -1927,36 +1927,38 @@ class AdminPortalDataSetService(DataSetService):
             version_ids=versions
         )
 
-        # we only consider available and special dimensions for deduplication requirement
-        deduplication_required = available_has_duplicates or special_has_duplicates
-        total_duplicates = available_count + special_count + indicator_count
+        # we only consider non-indicator and special dimensions for deduplication requirement
+        deduplication_required = non_indicator_has_duplicates or special_has_duplicates
+        total_duplicates = non_indicator_count + special_count + indicator_count
 
         return schemas.DeduplicationStatus(
             deduplication_required=deduplication_required,
             total_duplicate_count=total_duplicates,
-            available_dimensions_duplicate_count=available_count,
+            non_indicator_dimensions_duplicate_count=non_indicator_count,
             special_dimensions_duplicate_count=special_count,
             indicator_dimensions_duplicate_count=indicator_count,
         )
 
     async def _get_full_deduplication_status(
         self,
-        available_dims_store: VectorStore,
+        non_indicator_dims_store: VectorStore,
         special_dims_store: VectorStore,
         indicator_dims_store: VectorStore,
     ) -> schemas.DeduplicationStatus:
-        available_has_duplicates, available_count = await available_dims_store.has_duplicates()
+        non_indicator_has_duplicates, non_indicator_count = (
+            await non_indicator_dims_store.has_duplicates()
+        )
         special_has_duplicates, special_count = await special_dims_store.has_duplicates()
         _, indicator_count = await indicator_dims_store.has_duplicates()
 
-        # we only consider available and special dimensions for deduplication requirement
-        deduplication_required = available_has_duplicates or special_has_duplicates
-        total_duplicates = available_count + special_count + indicator_count
+        # we only consider non-indicator and special dimensions for deduplication requirement
+        deduplication_required = non_indicator_has_duplicates or special_has_duplicates
+        total_duplicates = non_indicator_count + special_count + indicator_count
 
         return schemas.DeduplicationStatus(
             deduplication_required=deduplication_required,
             total_duplicate_count=total_duplicates,
-            available_dimensions_duplicate_count=available_count,
+            non_indicator_dimensions_duplicate_count=non_indicator_count,
             special_dimensions_duplicate_count=special_count,
             indicator_dimensions_duplicate_count=indicator_count,
         )
@@ -1964,7 +1966,7 @@ class AdminPortalDataSetService(DataSetService):
     async def _check_latest_versions_status(
         self,
         channel: models.Channel,
-        available_dims_store: VectorStore,
+        non_indicator_dims_store: VectorStore,
         special_dims_store: VectorStore,
         indicator_dims_store: VectorStore,
     ) -> schemas.ChannelIndexStatus:
@@ -1978,13 +1980,15 @@ class AdminPortalDataSetService(DataSetService):
         }
 
         deduplication_status = await self._get_deduplication_status_by_versions(
-            available_dims_store,
+            non_indicator_dims_store,
             special_dims_store,
             indicator_dims_store,
             versions,
         )
         sizes = schemas.VectorStoreSizes(
-            available_dimensions_size=await available_dims_store.get_size(version_ids=versions),
+            non_indicator_dimensions_size=await non_indicator_dims_store.get_size(
+                version_ids=versions
+            ),
             special_dimensions_size=await special_dims_store.get_size(version_ids=versions),
             indicator_dimensions_size=await indicator_dims_store.get_size(version_ids=versions),
         )
@@ -2001,17 +2005,17 @@ class AdminPortalDataSetService(DataSetService):
     async def _check_full_index_status(
         self,
         channel: models.Channel,
-        available_dims_store: VectorStore,
+        non_indicator_dims_store: VectorStore,
         special_dims_store: VectorStore,
         indicator_dims_store: VectorStore,
     ) -> schemas.ChannelIndexStatus:
         deduplication_status = await self._get_full_deduplication_status(
-            available_dims_store,
+            non_indicator_dims_store,
             special_dims_store,
             indicator_dims_store,
         )
         sizes = schemas.VectorStoreSizes(
-            available_dimensions_size=await available_dims_store.get_total_size(),
+            non_indicator_dimensions_size=await non_indicator_dims_store.get_total_size(),
             special_dimensions_size=await special_dims_store.get_total_size(),
             indicator_dimensions_size=await indicator_dims_store.get_total_size(),
         )
@@ -2034,8 +2038,8 @@ class AdminPortalDataSetService(DataSetService):
         channel = await ChannelService(self._session).get_model_by_id(channel_id)
         vector_store_factory = VectorStoreFactory()
 
-        available_dims_store = await vector_store_factory.get_vector_store(
-            collection_name=channel.available_dimensions_table_name,
+        non_indicator_dims_store = await vector_store_factory.get_vector_store(
+            collection_name=channel.non_indicator_dimensions_table_name,
             auth_context=auth_context,
             embedding_model_name=channel.llm_model,
         )
@@ -2053,14 +2057,14 @@ class AdminPortalDataSetService(DataSetService):
         if scope == schemas.ChannelIndexStatusScope.FULL:
             return await self._check_full_index_status(
                 channel=channel,
-                available_dims_store=available_dims_store,
+                non_indicator_dims_store=non_indicator_dims_store,
                 special_dims_store=special_dims_store,
                 indicator_dims_store=indicator_dims_store,
             )
         elif scope == schemas.ChannelIndexStatusScope.LATEST_COMPLETED_VERSIONS:
             return await self._check_latest_versions_status(
                 channel=channel,
-                available_dims_store=available_dims_store,
+                non_indicator_dims_store=non_indicator_dims_store,
                 special_dims_store=special_dims_store,
                 indicator_dims_store=indicator_dims_store,
             )

--- a/statgpt/app/chains/data_query/query_builder/dimensions/non_indicators.py
+++ b/statgpt/app/chains/data_query/query_builder/dimensions/non_indicators.py
@@ -57,7 +57,7 @@ class NonIndicatorsSearchChainFactory(DimensionSearchChainFactoryBase):
             tasks = []
             for entity in filtered_named_entities:
                 tasks.append(
-                    search_input.data_service.search_dimensions_scored(
+                    search_input.data_service.search_non_indicator_dimensions_scored(
                         entity.to_query(),
                         auth_context=search_input.auth_context,
                         k=self._config.candidates_per_entity,

--- a/statgpt/app/services/chat_facade.py
+++ b/statgpt/app/services/chat_facade.py
@@ -224,11 +224,13 @@ class ChannelServiceFacade:
             )
         return vector_store
 
-    async def _get_dimensions_vector_store(self, auth_context: AuthContext) -> VectorStore:
-        with debug_timer("chat_facade._get_dimensions_vector_store"):
+    async def _get_non_indicator_dimensions_vector_store(
+        self, auth_context: AuthContext
+    ) -> VectorStore:
+        with debug_timer("chat_facade._get_non_indicator_dimensions_vector_store"):
             vector_store_factory = VectorStoreFactory()
             vector_store = await vector_store_factory.get_vector_store(
-                collection_name=self._channel.available_dimensions_table_name,
+                collection_name=self._channel.non_indicator_dimensions_table_name,
                 embedding_model_name=self._channel.llm_model,
                 auth_context=auth_context,
             )
@@ -472,7 +474,7 @@ class ChannelServiceFacade:
         handler_config = cls.parse_config(config)
         return cls(handler_config)
 
-    async def search_dimensions_scored(
+    async def search_non_indicator_dimensions_scored(
         self,
         query: str,
         *,
@@ -480,14 +482,14 @@ class ChannelServiceFacade:
         k: int = 10,
         dataset_versions: Iterable[int],
     ) -> list[ScoredDimensionCandidate]:
-        vector_store = await self._get_dimensions_vector_store(auth_context)
+        vector_store = await self._get_non_indicator_dimensions_vector_store(auth_context)
         version_ids = set(dataset_versions)
-        with debug_timer("chat_facade.search_dimensions_scored.similarity_search"):
+        with debug_timer("chat_facade.search_non_indicator_dimensions_scored.similarity_search"):
             documents = await vector_store.search_with_similarity_score(
                 query, k=k, version_ids=version_ids
             )
 
-        with debug_timer("search_dimensions_scored.post_process_documents"):
+        with debug_timer("search_non_indicator_dimensions_scored.post_process_documents"):
             dimension_categories = await self._get_dimension_categories_from_documents(documents)
             result = []
             for doc, category in zip(documents, dimension_categories):

--- a/statgpt/cli/commands/channel.py
+++ b/statgpt/cli/commands/channel.py
@@ -315,7 +315,8 @@ async def status_handler(
             console.print(f"  [dim]Scope:[/dim] {index_status.scope}")
             console.print("  [dim]Vector Store index:[/dim]")
             console.print(
-                f"    [dim]Available dimensions index:[/dim] {sizes.available_dimensions_size}"
+                f"    [dim]Non-indicator dimensions index:[/dim] "
+                f"{sizes.non_indicator_dimensions_size}"
             )
             console.print(
                 f"    [dim]Special dimensions index:[/dim] {sizes.special_dimensions_size}"

--- a/statgpt/common/models/models.py
+++ b/statgpt/common/models/models.py
@@ -57,7 +57,7 @@ class Channel(DefaultBase):
         return f"Indicators_{self.id}"
 
     @property
-    def available_dimensions_table_name(self) -> str:
+    def non_indicator_dimensions_table_name(self) -> str:
         return f"AvailableDimensions_{self.id}"
 
     @property

--- a/statgpt/common/schemas/channel.py
+++ b/statgpt/common/schemas/channel.py
@@ -235,7 +235,7 @@ class Channel(DbDefaultBase, ChannelBase, Auditable):
         return f"Indicators_{self.id}"
 
     @property
-    def available_dimensions_table_name(self) -> str:
+    def non_indicator_dimensions_table_name(self) -> str:
         return f"AvailableDimensions_{self.id}"
 
     @property
@@ -260,28 +260,52 @@ class DeduplicationStatus(BaseModel):
     total_duplicate_count: int = Field(
         description="Total number of duplicate documents across all dimension stores"
     )
-    available_dimensions_duplicate_count: int = Field(
-        description="Number of duplicate documents in available dimensions store"
+    non_indicator_dimensions_duplicate_count: int = Field(
+        description=(
+            "Number of duplicate documents in the non-indicator dimensions store "
+            "(regular dimensions such as country, frequency, region — excludes "
+            "indicator and special dimensions)."
+        )
     )
     special_dimensions_duplicate_count: int = Field(
-        description="Number of duplicate documents in special dimensions store"
+        description=(
+            "Number of duplicate documents in the special dimensions store. Special "
+            "dimensions require dedicated processor-based handling (configured per "
+            "channel) and are counted separately — they are NOT part of indicator or "
+            "non-indicator dimensions."
+        )
     )
     indicator_dimensions_duplicate_count: int = Field(
-        description="Number of duplicate documents in indicator dimensions store"
+        description=(
+            "Number of duplicate documents in the indicator dimensions store "
+            "(dimensions used as measures, e.g. GDP, Inflation)."
+        )
     )
 
 
 class VectorStoreSizes(BaseModel):
     """Size information about channel vector store index"""
 
-    available_dimensions_size: int = Field(
-        description="Number of documents in available dimensions store"
+    non_indicator_dimensions_size: int = Field(
+        description=(
+            "Number of documents in the non-indicator dimensions store "
+            "(regular dimensions such as country, frequency, region — excludes "
+            "indicator and special dimensions)."
+        )
     )
     special_dimensions_size: int = Field(
-        description="Number of documents in special dimensions store"
+        description=(
+            "Number of documents in the special dimensions store. Special dimensions "
+            "require dedicated processor-based handling (configured per channel) and "
+            "are counted separately — they are NOT part of indicator or non-indicator "
+            "dimensions."
+        )
     )
     indicator_dimensions_size: int = Field(
-        description="Number of documents in indicator dimensions store"
+        description=(
+            "Number of documents in the indicator dimensions store "
+            "(dimensions used as measures, e.g. GDP, Inflation)."
+        )
     )
 
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
N/A

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Renames `available_dimensions` to `non_indicator_dimensions` across the REST API surface, internal Python symbols, and CLI display so the naming matches the existing internal terminology used by the dataset interface (`Dataset.non_indicator_dimensions()`) and the channel config (`NonIndicatorDimensionConfig`). Also tightens the field descriptions on `DeduplicationStatus` and `VectorStoreSizes` so the OpenAPI schema makes the three-bucket model (indicator / non-indicator / special) explicit, and notes that special dimensions need processor-based handling and are counted **separately** from indicator and non-indicator dimensions.

**Breaking change** for `GET /admin/api/v1/channels/{channel_id}/index-status`:

| Old field | New field |
|---|---|
| `vector_store.sizes.available_dimensions_size` | `vector_store.sizes.non_indicator_dimensions_size` |
| `vector_store.deduplication.available_dimensions_duplicate_count` | `vector_store.deduplication.non_indicator_dimensions_duplicate_count` |

**What is preserved:** the literal DB / vector-store collection name `AvailableDimensions_{channel_id}` is intentionally unchanged — only the Python *property* that returns it (`Channel.available_dimensions_table_name` → `Channel.non_indicator_dimensions_table_name`) is renamed. Existing channels do not need any data migration.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
