### PR TITLE
feat: add 'excluded' filter operator #359

### DIFF
--- a/statgpt/app/services/python_code_generator.py
+++ b/statgpt/app/services/python_code_generator.py
@@ -145,6 +145,11 @@ def generate_python_code_from_query(
 
 
 def generate_merged_python_code(queries: list[JsonQueryWithMetadata]) -> str:
+    queries = [
+        q for q in queries if not any(f.operator == JsonQueryOperator.EXCLUDED for f in q.filters)
+    ]
+    if not queries:
+        return PYTHON_SDMX1_HEADER
     if len(queries) == 1:
         body = generate_python_code_from_query(queries[0])
     else:

--- a/statgpt/common/schemas/query.py
+++ b/statgpt/common/schemas/query.py
@@ -19,6 +19,9 @@ class JsonQueryOperator(StrEnum):
     """Greater than"""
     LT = "lt"
     """Less than"""
+    EXCLUDED = "excluded"
+    """User selected a value valid in another dataset, but, given the other
+    selected filters, no such value exists for this dimension here."""
 
 
 class JsonComponentQuery(BaseYamlModel):

--- a/tests/unit/test_python_code_generator.py
+++ b/tests/unit/test_python_code_generator.py
@@ -200,3 +200,53 @@ def test_generate_merged_python_code_multi_query_separates_sections() -> None:
     assert f"# Dataset: {urn_a}" in code
     assert f"# Dataset: {urn_b}" in code
     assert "provider_1" in code and "provider_2" in code
+
+
+def test_generate_merged_python_code_drops_dataset_with_any_excluded_filter() -> None:
+    excluded_query = JsonQueryWithMetadata(
+        urn="IMF:DF_X(1.0)",
+        filters=[
+            JsonComponentQuery(component_code="A", operator=JsonQueryOperator.IN, values=["a1"]),
+            JsonComponentQuery(
+                component_code="B",
+                operator=JsonQueryOperator.EXCLUDED,
+                values=["b_unavailable"],
+            ),
+        ],
+        metadata=JsonQueryMetadata(
+            country_dimension="A",
+            indicator_dimensions=["B"],
+            time_period_dimension="TIME_PERIOD",
+        ),
+    )
+    code = generate_merged_python_code([_make_query(_VALID_URN), excluded_query])
+    assert "DF_X" not in code
+    assert "b_unavailable" not in code
+    # Only one query survives, so the single-query branch is taken (no `# Dataset:` headers).
+    assert "# Dataset:" not in code
+    assert "provider_1" not in code
+    # The surviving query renders as a complete sdmx1 snippet.
+    assert 'provider = sdmx.Client("IMF")' in code
+    assert '"IMF,WEO,1.0"' in code
+    assert 'key="a1"' in code
+    assert "'detail': 'full'" in code
+
+
+def test_generate_merged_python_code_returns_header_only_when_all_excluded() -> None:
+    excluded_query = JsonQueryWithMetadata(
+        urn="IMF:DF_X(1.0)",
+        filters=[
+            JsonComponentQuery(
+                component_code="B",
+                operator=JsonQueryOperator.EXCLUDED,
+                values=["b1"],
+            ),
+        ],
+        metadata=JsonQueryMetadata(
+            country_dimension="A",
+            indicator_dimensions=["B"],
+            time_period_dimension="TIME_PERIOD",
+        ),
+    )
+    code = generate_merged_python_code([excluded_query])
+    assert code == PYTHON_SDMX1_HEADER


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- resolve #359

### Description of changes

<!-- Please explain the changes you made right below this line. -->
A new `excluded` operator on `JsonQuery` filters lets the frontend persist user selections that don't apply to the current dataset — e.g. a value the user picked that is valid in another dataset but, given the other selected filters, doesn't exist here — without using them as query constraints.

`/python-attachment` recognizes the marker and drops any query that contains at least one `excluded` filter, so the generated sdmx1 snippet never asks for data the dataset cannot return. If every query is excluded, the response is just the import header.

`excluded` is a **UI-only marker** — produced by the frontend, never by backend code. Existing query-construction and query-consumption paths therefore never encounter it and stay unchanged; the internal `QueryOperator` enum is untouched for the same reason.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
