### PR TITLE
fix: ORT

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
       code-checks-bypassed: false
       ort-enabled: true
       ort-bypassed: false
-      ort-version: "latest"
+      ort-version: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
       python-version: "3.11"
       poetry-version: "2.1.1"
       runs-on: '["ubuntu-24.04"]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       code-checks-bypassed: false
       ort-enabled: true
       ort-bypassed: false
-      ort-version: "latest"
+      ort-version: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
       python-version: "3.11"
       poetry-version: "2.1.1"
       runs-on: '["ubuntu-24.04"]'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ on:
       ort-version:
         type: string
         description: ORT version to use
-        default: "latest"
+        default: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
       python-version:
         type: string
         description: Python version to use


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
N/A

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Fix the following error:
```
Exception in thread "main" java.util.NoSuchElementException: Key (Identifier(type=Poetry, namespace=, name=poetry.lock, version=6b56cfb064768d5b4e16b8525fc4f32a1bb4cc13), Identifier(type=PyPI, namespace=, name=jsonpointer, version=3.0.0)) is missing in the map.
	at kotlin.collections.MapsKt__MapWithDefaultKt.getOrImplicitDefaultNullable(MapWithDefault.kt:24)
	at kotlin.collections.MapsKt__MapsKt.getValue(Maps.kt:398)
	at org.ossreviewtoolkit.plugins.reporters.spdx.SpdxDocumentModelMapper.map$addDependencyRelationships(SpdxDocumentModelMapper.kt:74)
	at org.ossreviewtoolkit.plugins.reporters.spdx.SpdxDocumentModelMapper.map(SpdxDocumentModelMapper.kt:105)
	at org.ossreviewtoolkit.plugins.reporters.spdx.SpdxDocumentReporter.generateReport(SpdxDocumentReporter.kt:124)
	at org.ossreviewtoolkit.plugins.commands.reporter.ReportCommand$run$reportDurationMap$1$1$1$1.invokeSuspend(ReportCommand.kt:316)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:829)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
