### PR TITLE
fix: allow text/markdown attachments in system messages #356

### DIFF
--- a/statgpt/app/utils/message_interceptors/system_msg_interceptor.py
+++ b/statgpt/app/utils/message_interceptors/system_msg_interceptor.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 
 from statgpt.app.services.chat_facade import ChannelServiceFacade
 from statgpt.common.schemas.query import JsonQuery
+from statgpt.common.utils.media_types import MediaTypes
 
 from .base import BaseMessageInterceptor
 
@@ -38,18 +39,22 @@ class SystemMessageInterceptor(BaseMessageInterceptor):
                 )
             attachments = msg.custom_content.attachments
             for attachment in attachments:
-                if attachment.type != "application/json":
+                if attachment.type == MediaTypes.JSON:
+                    if not attachment.data:
+                        raise InvalidRequestError("System message attachment must have data field")
+                    try:
+                        JsonQuery.model_validate_json(attachment.data)
+                    except ValidationError as e:
+                        raise InvalidRequestError(
+                            "Failed to parse system message attachment data as JsonQuery"
+                        ) from e
+                elif attachment.type == MediaTypes.MARKDOWN:
+                    continue
+                else:
                     raise InvalidRequestError(
-                        f"Unsupported system message attachment type: {attachment.type}. Only application/json is supported."
+                        f"Unsupported system message attachment type: {attachment.type}."
+                        f" Supported types: {MediaTypes.JSON}, {MediaTypes.MARKDOWN}."
                     )
-                if not attachment.data:
-                    raise InvalidRequestError("System message attachment must have data field")
-                try:
-                    JsonQuery.model_validate_json(attachment.data)
-                except ValidationError as e:
-                    raise InvalidRequestError(
-                        "Failed to parse system message attachment data as JsonQuery"
-                    ) from e
 
             # result.append(msg)  # ToDo: finish implementation
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #356

### Description of changes

<!-- Please explain the changes you made right below this line. -->
The portal's **Advanced View** now sends a `text/markdown` attachment alongside the existing `application/json` `JsonQuery`, which `SystemMessageInterceptor` rejected. This PR widens the allowlist to accept `text/markdown` without body validation; `application/json` is still validated as `JsonQuery`, and any other type is still rejected.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
