### PR TITLE
chore: refactor .ort.yml to version-range resolutions

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -10,205 +10,172 @@ excludes:
 
 resolutions:
   rule_violations:
-    - message: ".*package curations.*not allowed.*"
+    # Core web framework / ASGI
+    - message: ".*PyPI::fastapi:0\\..*"
       reason: "CANT_FIX_EXCEPTION"
-      comment: "We use repository-level curations in .ort.yml as enabled by -P ort.enableRepositoryPackageCurations=true"
+      comment: "MIT License: https://github.com/fastapi/fastapi/blob/master/LICENSE"
+    - message: ".*PyPI::starlette:0\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/encode/starlette/blob/master/LICENSE.md"
+    - message: ".*PyPI::uvicorn:0\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/Kludex/uvicorn/blob/main/LICENSE.md"
+    - message: ".*PyPI::annotated-doc:0\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/fastapi/annotated-doc/blob/main/LICENSE"
 
-curations:
-  packages:
-    - id: "PyPI::pandas:2.3.3"
-      curations:
-        concluded_license: "BSD-3-Clause"
-        comment: "BSD 3-Clause License: https://github.com/pandas-dev/pandas/blob/v2.3.3/LICENSE"
-    - id: "PyPI::numpy:1.26.4"
-      curations:
-        concluded_license: "BSD-3-Clause"
-        comment: "BSD 3-Clause License: https://github.com/numpy/numpy/blob/v1.26.4/LICENSE.txt"
-    - id: "PyPI::httpcore:1.0.9"
-      curations:
-        concluded_license: "BSD-3-Clause"
-        comment: "BSD 3-Clause License: https://github.com/encode/httpcore/blob/1.0.9/LICENSE.md"
-    - id: "PyPI::tiktoken:0.12.0"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/openai/tiktoken/blob/0.12.0/LICENSE"
-    - id: "PyPI::urllib3:2.7.0"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/urllib3/urllib3/blob/2.7.0/LICENSE.txt"
-    - id: "PyPI::typing-extensions:4.15.0"
-      curations:
-        concluded_license: "PSF-2.0"
-        comment: "Python Software Foundation License: https://github.com/python/typing_extensions/blob/4.15.0/LICENSE"
-    - id: "PyPI::alembic:1.18.1"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/sqlalchemy/alembic/blob/rel_1_18_1/LICENSE"
-    - id: "PyPI::markupsafe:3.0.3"
-      curations:
-        concluded_license: "BSD-3-Clause"
-        comment: "BSD 3-Clause License: https://github.com/pallets/markupsafe/blob/3.0.3/LICENSE.txt"
-    - id: "PyPI::setuptools:80.9.0"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/pypa/setuptools/blob/v80.9.0/LICENSE"
-    - id: "PyPI::typing-inspection:0.4.2"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/pydantic/typing-inspection/blob/v0.4.2/LICENSE"
-    - id: "PyPI::markdown:3.10"
-      curations:
-        concluded_license: "BSD-3-Clause"
-        comment: "BSD 3-Clause License: https://github.com/Python-Markdown/markdown/blob/3.10.0/LICENSE.md"
-    - id: "PyPI::click:8.3.3"
-      curations:
-        concluded_license: "BSD-3-Clause"
-        comment: "BSD 3-Clause License: https://github.com/pallets/click/blob/8.3.3/LICENSE.txt"
-    - id: "PyPI::zipp:3.23.0"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/jaraco/zipp/blob/v3.23.0/pyproject.toml#L24"
-    - id: "PyPI::attrs:25.4.0"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/python-attrs/attrs/blob/25.4.0/LICENSE"
-    - id: "PyPI::mypy-extensions:1.1.0"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/python/mypy_extensions/blob/1.1.0/LICENSE"
-    - id: "PyPI::python-dateutil:2.9.0.post0"
-      curations:
-        concluded_license: "Apache-2.0 OR BSD-3-Clause"
-        comment: "Dual License (Apache 2.0 or BSD 3-Clause): https://github.com/dateutil/dateutil/blob/2.9.0.post0/LICENSE"
-    - id: "PyPI::packaging:25.0"
-      curations:
-        concluded_license: "Apache-2.0 OR BSD-2-Clause"
-        comment: "Dual License (Apache 2.0 or BSD 2-Clause): https://github.com/pypa/packaging/blob/25.0/LICENSE"
-    - id: "PyPI::fastapi:0.121.3"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/fastapi/fastapi/blob/0.121.3/LICENSE"
-    - id: "PyPI::starlette:0.50.0"
-      curations:
-        concluded_license: "BSD-3-Clause"
-        comment: "BSD 3-Clause License: https://github.com/encode/starlette/blob/0.50.0/LICENSE.md"
-    - id: "PyPI::azure-identity:1.25.1"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/Azure/azure-sdk-for-python/blob/azure-identity_1.25.1/sdk/identity/azure-identity/LICENSE"
-    - id: "PyPI::uuid-utils:0.13.0"
-      curations:
-        concluded_license: "BSD-3-Clause"
-        comment: "BSD 3-Clause License: https://github.com/aminalaee/uuid-utils/blob/0.13.0/LICENSE.md"
-    - id: "PyPI::idna:3.11"
-      curations:
-        concluded_license: "BSD-3-Clause"
-        comment: "BSD 3-Clause License: https://github.com/kjd/idna/blob/v3.11/LICENSE.md"
-    - id: "PyPI::annotated-doc:0.0.4"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/fastapi/annotated-doc/blob/0.0.4/LICENSE"
-    - id: "PyPI::regex:2026.1.15"
-      curations:
-        concluded_license: "Apache-2.0"
-        comment: "Apache 2.0 License: https://github.com/mrabarnett/mrab-regex/blob/2026.1.15/LICENSE.txt"
-    - id: "PyPI::pydantic-core:2.41.5"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/pydantic/pydantic-core/blob/v2.41.5/LICENSE"
-    - id: "PyPI::prometheus-client:0.24.1"
-      curations:
-        concluded_license: "Apache-2.0"
-        comment: "Apache 2.0 License: https://github.com/prometheus/client_python/blob/v0.24.1/LICENSE"
-    - id: "PyPI::uvicorn:0.40.0"
-      curations:
-        concluded_license: "BSD-3-Clause"
-        comment: "BSD 3-Clause License: https://github.com/Kludex/uvicorn/blob/0.40.0/LICENSE.md"
-    - id: "PyPI::zstandard:0.25.0"
-      curations:
-        concluded_license: "BSD-3-Clause"
-        comment: "BSD 3-Clause License: https://github.com/indygreg/python-zstandard/blob/0.25.0/LICENSE"
-    - id: "PyPI::psycopg-pool:3.3.0"
-      curations:
-        concluded_license: "LGPL-3.0-or-later"
-        comment: "LGPL 3.0 License: https://github.com/psycopg/psycopg/blob/3.3.0/LICENSE.txt"
-    - id: "PyPI::opentelemetry-exporter-otlp-proto-common:1.39.1"
-      curations:
-        concluded_license: "Apache-2.0"
-        comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/v1.39.1/LICENSE"
-    - id: "PyPI::python-dotenv:1.2.1"
-      curations:
-        concluded_license: "BSD-3-Clause"
-        comment: "BSD 3-Clause License: https://github.com/theskumar/python-dotenv/blob/v1.2.1/LICENSE"
-    - id: "PyPI::opentelemetry-proto:1.39.1"
-      curations:
-        concluded_license: "Apache-2.0"
-        comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/v1.39.1/opentelemetry-proto/LICENSE"
-    - id: "PyPI::opentelemetry-semantic-conventions:0.60b1"
-      curations:
-        concluded_license: "Apache-2.0"
-        comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/v1.39.1/opentelemetry-semantic-conventions/LICENSE"
-    - id: "PyPI::opentelemetry-api:1.39.1"
-      curations:
-        concluded_license: "Apache-2.0"
-        comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/v1.39.1/opentelemetry-api/LICENSE"
-    - id: "PyPI::cryptography:46.0.7"
-      curations:
-        concluded_license: "Apache-2.0 OR BSD-3-Clause"
-        comment: "Dual License (Apache 2.0 or BSD 3-Clause): https://github.com/pyca/cryptography/blob/46.0.7/LICENSE"
-    - id: "PyPI::psycopg:3.3.2"
-      curations:
-        concluded_license: "LGPL-3.0-or-later"
-        comment: "LGPL 3.0 License: https://github.com/psycopg/psycopg/blob/3.3.2/LICENSE.txt"
-    - id: "PyPI::opentelemetry-exporter-prometheus:0.60b1"
-      curations:
-        concluded_license: "Apache-2.0"
-        comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/v1.39.1/exporter/opentelemetry-exporter-prometheus/LICENSE"
-    - id: "PyPI::pydantic:2.12.5"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/pydantic/pydantic/blob/v2.12.5/LICENSE"
-    - id: "PyPI::psycopg-binary:3.3.2"
-      curations:
-        concluded_license: "LGPL-3.0-or-later"
-        comment: "LGPL 3.0 License: https://github.com/psycopg/psycopg/blob/3.3.2/LICENSE.txt"
-    - id: "PyPI::anyio:4.12.1"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/agronholm/anyio/blob/4.12.1/LICENSE"
-    - id: "PyPI::importlib-metadata:8.7.1"
-      curations:
-        concluded_license: "Apache-2.0"
-        comment: "Apache 2.0 License: https://github.com/python/importlib_metadata/blob/v8.7.1/pyproject.toml#L24"
-    - id: "PyPI::cffi:2.0.0"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/python-cffi/cffi/blob/v2.0.0/LICENSE"
-    - id: "PyPI::opentelemetry-sdk:1.39.1"
-      curations:
-        concluded_license: "Apache-2.0"
-        comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/v1.39.1/opentelemetry-sdk/LICENSE"
-    - id: "PyPI::opentelemetry-exporter-otlp-proto-grpc:1.39.1"
-      curations:
-        concluded_license: "Apache-2.0"
-        comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/v1.39.1/exporter/opentelemetry-exporter-otlp-proto-grpc/LICENSE"
-    - id: "PyPI::pyjwt:2.12.1"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/jpadilla/pyjwt/blob/2.12.1/LICENSE"
-    - id: "PyPI::langgraph:1.1.3"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/langchain-ai/langgraph/blob/1.1.3/LICENSE"
-    - id: "PyPI::langgraph-checkpoint:4.0.0"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/langchain-ai/langgraph/blob/checkpoint%3D%3D4.0.0/libs/checkpoint/LICENSE"
-    - id: "PyPI::langgraph-prebuilt:1.0.8"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/langchain-ai/langgraph/blob/prebuilt%3D%3D1.0.8/libs/prebuilt/LICENSE"
-    - id: "PyPI::langgraph-sdk:0.3.3"
-      curations:
-        concluded_license: "MIT"
-        comment: "MIT License: https://github.com/langchain-ai/langgraph/blob/sdk%3D%3D0.3.3/libs/sdk-py/LICENSE"
+    # HTTP / networking
+    - message: ".*PyPI::httpcore:1\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/encode/httpcore/blob/master/LICENSE.md"
+    - message: ".*PyPI::urllib3:2\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/urllib3/urllib3/blob/main/LICENSE.txt"
+    - message: ".*PyPI::idna:3\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/kjd/idna/blob/master/LICENSE.md"
+    - message: ".*PyPI::anyio:4\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/agronholm/anyio/blob/master/LICENSE"
+
+    # Pydantic ecosystem
+    - message: ".*PyPI::pydantic:2\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/pydantic/pydantic/blob/main/LICENSE"
+    - message: ".*PyPI::pydantic-core:2\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/pydantic/pydantic-core/blob/main/LICENSE"
+    - message: ".*PyPI::typing-inspection:0\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/pydantic/typing-inspection/blob/main/LICENSE"
+
+    # Data / scientific
+    - message: ".*PyPI::pandas:2\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/pandas-dev/pandas/blob/main/LICENSE"
+    - message: ".*PyPI::numpy:1\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/numpy/numpy/blob/main/LICENSE.txt"
+    - message: ".*PyPI::numpy:2\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/numpy/numpy/blob/main/LICENSE.txt"
+
+    # Database / ORM
+    - message: ".*PyPI::alembic:1\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/sqlalchemy/alembic/blob/main/LICENSE"
+    - message: ".*PyPI::psycopg:3\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "LGPL 3.0 License: https://github.com/psycopg/psycopg/blob/master/LICENSE.txt"
+    - message: ".*PyPI::psycopg-binary:3\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "LGPL 3.0 License: https://github.com/psycopg/psycopg/blob/master/LICENSE.txt"
+    - message: ".*PyPI::psycopg-pool:3\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "LGPL 3.0 License: https://github.com/psycopg/psycopg/blob/master/LICENSE.txt"
+
+    # Tooling / utilities
+    - message: ".*PyPI::click:8\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/pallets/click/blob/main/LICENSE.txt"
+    - message: ".*PyPI::markupsafe:3\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/pallets/markupsafe/blob/main/LICENSE.txt"
+    - message: ".*PyPI::markdown:3\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/Python-Markdown/markdown/blob/master/LICENSE.md"
+    - message: ".*PyPI::tiktoken:0\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/openai/tiktoken/blob/main/LICENSE"
+    - message: ".*PyPI::regex:2026\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Apache 2.0 License: https://github.com/mrabarnett/mrab-regex/blob/master/LICENSE.txt"
+    - message: ".*PyPI::python-dotenv:1\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/theskumar/python-dotenv/blob/main/LICENSE"
+    - message: ".*PyPI::uuid-utils:0\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/aminalaee/uuid-utils/blob/main/LICENSE.md"
+    - message: ".*PyPI::zstandard:0\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "BSD 3-Clause License: https://github.com/indygreg/python-zstandard/blob/main/LICENSE"
+    - message: ".*PyPI::setuptools:80\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/pypa/setuptools/blob/main/LICENSE"
+    - message: ".*PyPI::zipp:3\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License (declared in pyproject.toml): https://github.com/jaraco/zipp/blob/main/pyproject.toml"
+    - message: ".*PyPI::attrs:25\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/python-attrs/attrs/blob/main/LICENSE"
+    - message: ".*PyPI::importlib-metadata:8\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Apache 2.0 License (declared in pyproject.toml): https://github.com/python/importlib_metadata/blob/main/pyproject.toml"
+    - message: ".*PyPI::mypy-extensions:1\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/python/mypy_extensions/blob/master/LICENSE"
+    - message: ".*PyPI::typing-extensions:4\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Python Software Foundation License: https://github.com/python/typing_extensions/blob/main/LICENSE"
+    - message: ".*PyPI::cffi:2\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/python-cffi/cffi/blob/main/LICENSE"
+
+    # Auth / crypto
+    - message: ".*PyPI::pyjwt:2\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/jpadilla/pyjwt/blob/master/LICENSE"
+    - message: ".*PyPI::cryptography:46\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Dual (Apache 2.0 OR BSD 3-Clause): https://github.com/pyca/cryptography/blob/main/LICENSE"
+    - message: ".*PyPI::azure-identity:1\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity/LICENSE"
+
+    # Observability / OpenTelemetry
+    - message: ".*PyPI::opentelemetry-api:1\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/main/LICENSE"
+    - message: ".*PyPI::opentelemetry-sdk:1\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/main/LICENSE"
+    - message: ".*PyPI::opentelemetry-proto:1\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/main/LICENSE"
+    - message: ".*PyPI::opentelemetry-semantic-conventions:0\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/main/LICENSE"
+    - message: ".*PyPI::opentelemetry-exporter-otlp-proto-common:1\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/main/LICENSE"
+    - message: ".*PyPI::opentelemetry-exporter-otlp-proto-grpc:1\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/main/LICENSE"
+    - message: ".*PyPI::opentelemetry-exporter-prometheus:0\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Apache 2.0 License: https://github.com/open-telemetry/opentelemetry-python/blob/main/LICENSE"
+    - message: ".*PyPI::prometheus-client:0\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Apache 2.0 License: https://github.com/prometheus/client_python/blob/master/LICENSE"
+
+    # LangGraph ecosystem
+    - message: ".*PyPI::langgraph:1\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/langchain-ai/langgraph/blob/main/LICENSE"
+    - message: ".*PyPI::langgraph-checkpoint:4\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/langchain-ai/langgraph/blob/main/libs/checkpoint/LICENSE"
+    - message: ".*PyPI::langgraph-prebuilt:1\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/langchain-ai/langgraph/blob/main/libs/prebuilt/LICENSE"
+    - message: ".*PyPI::langgraph-sdk:0\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "MIT License: https://github.com/langchain-ai/langgraph/blob/main/libs/sdk-py/LICENSE"
+
+    # WARNINGS (dual-license packages)
+    - message: ".*PyPI::packaging:25\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Dual (Apache 2.0 OR BSD 2-Clause): https://github.com/pypa/packaging/blob/main/LICENSE"
+    - message: ".*PyPI::python-dateutil:2\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Dual (Apache 2.0 OR BSD 3-Clause): https://github.com/dateutil/dateutil/blob/master/LICENSE"


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

Replace exact-version package curations with regex-pattern `rule_violation` resolutions matching whole major versions, so dependency bumps within the same major line no longer require `.ort.yml` edits.

- Drop `curations.packages` (49 exact `name:version` entries) → switch to `resolutions.rule_violations` with patterns like `.*PyPI::pkg:<major>\..*`
- Drop the now-obsolete `package curations not allowed` resolution
- Use main/master-branch LICENSE URLs in comments (no version-pinned paths)
- Group entries by domain (web framework, HTTP, pydantic, data, DB, OTel, langgraph, etc.) for readability
- All 41 LICENSE URLs verified reachable

Conceptually mirrors the approach used in [`ai-dial-quickapps-backend/.ort.yml`](https://github.com/epam/ai-dial-quickapps-backend/blob/development/.ort.yml).

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.