### PR TITLE
feat: enable `list_datasets` for StatGPT SDMX proxy data source #393

### DIFF
--- a/statgpt/common/data/sdmx/v21/datasource.py
+++ b/statgpt/common/data/sdmx/v21/datasource.py
@@ -56,6 +56,7 @@ from statgpt.common.utils.timer import debug_timer
 from .dataset_hierarchy import CategorySchemaDataSetHierarchyCreator
 from .ratelimiter import SdmxRateLimiterFactory
 from .schemas import StructureMessage21, Urn
+from .urn_utils import lookup_urn
 
 
 class SdmxDataSetDescriptor(DataSetDescriptor):
@@ -228,22 +229,25 @@ class Sdmx21DataSourceHandler(
     async def list_datasets(self, auth_context: AuthContext) -> list[SdmxDataSetDescriptor]:
         client = await self.create_sdmx_client(auth_context)
 
-        message: StructureMessage = await client.dataflow(
+        sdmx_message: StructureMessage = await client.dataflow(
             agency_id="all",
             resource_id="all",
             version="latest",
             params={"references": "datastructure"},
         )
+        message = StructureMessage21.from_sdmx1(sdmx_message)
         dataflows: list[Dataflow] = list(message.dataflow.values())
 
-        res = [self._get_dataset_descriptor(dataflow) for dataflow in dataflows]
+        res = [self._get_dataset_descriptor(dataflow, message) for dataflow in dataflows]
         return res
 
-    def _get_dataset_descriptor(self, dataflow: Dataflow) -> SdmxDataSetDescriptor:
+    def _get_dataset_descriptor(
+        self, dataflow: Dataflow, message: StructureMessage21
+    ) -> SdmxDataSetDescriptor:
         urn = Urn.for_artifact(dataflow)
         urn_ref = UrnReference.model_validate(urn, from_attributes=True)
         try:
-            config = self._create_config_for(dataflow, urn_ref)
+            config = self._create_config_for(dataflow, urn_ref, message)
         except Exception:
             logger.warning(
                 f"Failed to create dataset config for dataflow urn={dataflow.urn!r}", exc_info=True
@@ -257,11 +261,15 @@ class Sdmx21DataSourceHandler(
         )
 
     @staticmethod
-    def _create_config_for(dataflow: Dataflow, urn_ref: UrnReference) -> SdmxDataSetConfigTemplate:
+    def _create_config_for(
+        dataflow: Dataflow, urn_ref: UrnReference, message: StructureMessage21
+    ) -> SdmxDataSetConfigTemplate:
         """We do our best to create a valid dataset configuration from the dataflow structure."""
 
+        dsd = lookup_urn(message.structure, Urn.for_artifact(dataflow.structure))
+
         dimensions: dict[str, BaseDimensionConfig] = {}
-        for dim in dataflow.structure.dimensions:
+        for dim in dsd.dimensions:
             entity_id = dim.id
             if isinstance(dim, TimeDimension):
                 dimensions[entity_id] = TimePeriodDimensionConfig()

--- a/statgpt/common/data/statgpt_sdmx_proxy/v30/datasource.py
+++ b/statgpt/common/data/statgpt_sdmx_proxy/v30/datasource.py
@@ -11,7 +11,7 @@ from statgpt.common.data.quanthub.config import QuanthubDataSetConfig
 from statgpt.common.data.sdmx.v21.attributes_creator import Sdmx21AttributesCreator
 from statgpt.common.data.sdmx.v21.dataflow_loader import DataflowLoader
 from statgpt.common.data.sdmx.v21.dataset import InvalidConfigurationError, SdmxOfflineDataSet
-from statgpt.common.data.sdmx.v21.datasource import Sdmx21DataSourceHandler, SdmxDataSetDescriptor
+from statgpt.common.data.sdmx.v21.datasource import Sdmx21DataSourceHandler
 from statgpt.common.data.sdmx.v21.dimensions_creator import DimensionsCreator
 from statgpt.common.data.sdmx.v21.ratelimiter import SdmxRateLimiterFactory
 from statgpt.common.data.sdmx.v21.schemas import Urn
@@ -216,13 +216,3 @@ class StatGptSdmxProxyDataSourceHandler(Sdmx21DataSourceHandler):
             return await self._get_dataset(
                 entity_id, title, config, auth_context, allow_offline=allow_offline
             )
-
-    async def list_datasets(self, auth_context: AuthContext) -> list[SdmxDataSetDescriptor]:
-        """
-        NOTE: The proxy SDMX 3.0 data source does not support querying across "all" agencies,
-        and the use of "latest" version is not supported by all registries.
-        Listing all datasets is unavailable in this handler.
-        """
-        raise NotImplementedError(
-            "Listing all datasets is unavailable for StatGPT SDMX proxy handler"
-        )


### PR DESCRIPTION
## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #393

## Description of changes

`StatGptSdmxProxyDataSourceHandler.list_datasets` was previously overridden to raise `NotImplementedError` because the proxy did not support querying across all agencies. The proxy now accepts `agencyID=all`, so the override is no longer needed.

Removed the override (and the now-unused `SdmxDataSetDescriptor` import). The handler inherits `Sdmx21DataSourceHandler.list_datasets` unchanged, which calls `client.dataflow(agency_id="all", resource_id="all", version="latest", params={"references": "datastructure"})` and builds descriptors via `_get_dataset_descriptor` / `_create_config_for`.

As a result:

- `GET /data-sources/{id}/available-datasets` now works for proxy-backed sources, unblocking the Admin UI `Add dataset` picker.
- The Admin MCP `get_available_datasets` tool works for proxy-backed sources, unblocking the LLM-assisted dataset onboarding flow.

### Bug fix surfaced during testing

Listing datasets through the proxy tripped a latent bug in the inherited `_create_config_for`: it iterated `dataflow.structure.dimensions` directly, but for the proxy `dataflow.structure` is a stub reference (sdmx1 doesn't resolve it in-place), so every dataflow fell back with `ValueError: Could not find any dimensions in dataflow ...`. The SDMX 2.1 sources we'd been using happened to avoid this because sdmx1's XML reader resolves the reference in-place there.

Fixed by resolving the DSD via `lookup_urn(message.structure, ...)` — the pattern already used elsewhere in the codebase.

## Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
