### PR TITLE
fix: prevent interleaved output in Hybrid Indicators Selection stage #397

### DIFF
--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -17,7 +17,7 @@ from statgpt.app.schemas.query_builder import (
     NamedEntity,
 )
 from statgpt.app.services.chat_facade import VersionedDataSet
-from statgpt.app.utils.dial_stages import BufferedStage, StageI
+from statgpt.app.utils.dial_stages import BufferedStagesManager, ContentStageI, StageI
 from statgpt.common.config.logging import logger
 from statgpt.common.data.base import DimensionQuery, QueryOperator
 from statgpt.common.hybrid_indexer.schemas import IndicatorIndex, MatchingIndex
@@ -118,7 +118,7 @@ class HybridSearcher:
 
         async def search(
             self,
-            stage: StageI,
+            stage: ContentStageI,
             query: str,
             version_ids: set[int],
             availability: DatasetDimTermsSetType,
@@ -171,7 +171,7 @@ class HybridSearcher:
             return lexical, semantic, llm_scored, selected, reasoning, timings
 
         async def _query_planner(
-            self, stage: StageI, query: str, version_ids: set[int]
+            self, stage: ContentStageI, query: str, version_ids: set[int]
         ) -> SearchParams:
             primaries, total, candidates, good_candidates = await self._outer.lexical_pre_match(
                 query=query,
@@ -670,7 +670,7 @@ class HybridSearcher:
 
         def _filter_candidates(
             self,
-            stage: StageI,
+            stage: ContentStageI,
             indexed,
             relevance,
             dataset_max_score,
@@ -878,7 +878,7 @@ class HybridSearcher:
 
     async def _search_by_query(
         self,
-        stage: StageI,
+        stage: ContentStageI,
         query: str,
         version_ids: set[int],
         availability: DatasetDimTermsSetType,
@@ -952,29 +952,28 @@ class HybridSearcher:
         timings.separate_subjects = time.perf_counter() - t_separate_subjects
         logger.info(f"[search], {queries=}, (elapsed {time.perf_counter() - t_total:0.3f} sec)")
 
-        # Each subquery runs in parallel; writing to a shared `stage` would
-        # interleave their output. Buffer per subquery and flush sequentially
-        # in the `finally` block so partial output survives errors.
-        buffered_stages = [BufferedStage() for _ in queries]
-        tasks = [
-            self._search_by_query(
-                stage=buffered_stages[i],
-                query=query,
-                version_ids=version_ids,
-                availability=availability_dict,
-            )
-            for i, query in enumerate(queries)
-        ]
-        t_parallel_subqueries = time.perf_counter()
-        try:
-            partial: list[HybridSearchResultInner] = await async_utils.gather_with_concurrency(
-                20, *tasks
-            )
-        finally:
-            timings.parallel_subqueries_wall = time.perf_counter() - t_parallel_subqueries
-            if stage:
-                for buffered in buffered_stages:
-                    buffered.flush_to(stage)
+        # Each subquery runs in parallel; writing to a shared real `stage`
+        # would interleave output. The manager hands every task its own
+        # buffered substitute and flushes them sequentially on exit (or a
+        # shared DummyStage when the outer stage is disabled).
+        with BufferedStagesManager(stage) as stage_manager:
+            tasks = [
+                self._search_by_query(
+                    stage=stage_manager.create(),
+                    query=query,
+                    version_ids=version_ids,
+                    availability=availability_dict,
+                )
+                for query in queries
+            ]
+            t_parallel_subqueries = time.perf_counter()
+            try:
+                partial: list[HybridSearchResultInner] = await async_utils.gather_with_concurrency(
+                    20, *tasks
+                )
+            finally:
+                timings.parallel_subqueries_wall = time.perf_counter() - t_parallel_subqueries
+
         timings.per_subquery = [item.timings for item in partial]
 
         lexical_merged = self._merge_scored_dicts([item.lexical for item in partial])

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -879,12 +879,13 @@ class HybridSearcher:
     async def _search_by_query(
         self,
         stage: ContentStageI,
+        index: int,
         query: str,
         version_ids: set[int],
         availability: DatasetDimTermsSetType,
     ) -> HybridSearchResultInner:
         if stage:
-            stage.append_content(f"\n1. {query}\n")
+            stage.append_content(f"\n{index}. {query}\n")
 
         hybrid_match = self.HybridMatch(self)
         lexical, semantic, llm_scored, selected, reasoning, timings = await hybrid_match.search(
@@ -960,19 +961,18 @@ class HybridSearcher:
             tasks = [
                 self._search_by_query(
                     stage=stage_manager.create(),
+                    index=index,
                     query=query,
                     version_ids=version_ids,
                     availability=availability_dict,
                 )
-                for query in queries
+                for index, query in enumerate(queries, start=1)
             ]
             t_parallel_subqueries = time.perf_counter()
-            try:
-                partial: list[HybridSearchResultInner] = await async_utils.gather_with_concurrency(
-                    20, *tasks
-                )
-            finally:
-                timings.parallel_subqueries_wall = time.perf_counter() - t_parallel_subqueries
+            partial: list[HybridSearchResultInner] = await async_utils.gather_with_concurrency(
+                20, *tasks
+            )
+            timings.parallel_subqueries_wall = time.perf_counter() - t_parallel_subqueries
 
         timings.per_subquery = [item.timings for item in partial]
 

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -6,7 +6,6 @@ import typing as t
 from collections.abc import Generator
 from typing import Any, NamedTuple
 
-from aidial_sdk.chat_completion import Stage
 from pydantic import BaseModel
 
 from statgpt.app.default_prompts import hybrid_search_default_prompts
@@ -18,6 +17,7 @@ from statgpt.app.schemas.query_builder import (
     NamedEntity,
 )
 from statgpt.app.services.chat_facade import VersionedDataSet
+from statgpt.app.utils.dial_stages import BufferedStage, StageI
 from statgpt.common.config.logging import logger
 from statgpt.common.data.base import DimensionQuery, QueryOperator
 from statgpt.common.hybrid_indexer.schemas import IndicatorIndex, MatchingIndex
@@ -117,7 +117,11 @@ class HybridSearcher:
             return result
 
         async def search(
-            self, stage, query: str, version_ids: set[int], availability: DatasetDimTermsSetType
+            self,
+            stage: StageI,
+            query: str,
+            version_ids: set[int],
+            availability: DatasetDimTermsSetType,
         ) -> tuple[
             HarmonizedItemsScoredDict,
             PlainItemsScoredDict,
@@ -167,7 +171,7 @@ class HybridSearcher:
             return lexical, semantic, llm_scored, selected, reasoning, timings
 
         async def _query_planner(
-            self, stage: Stage, query: str, version_ids: set[int]
+            self, stage: StageI, query: str, version_ids: set[int]
         ) -> SearchParams:
             primaries, total, candidates, good_candidates = await self._outer.lexical_pre_match(
                 query=query,
@@ -665,7 +669,12 @@ class HybridSearcher:
             return batches, indexed
 
         def _filter_candidates(
-            self, stage, indexed, relevance, dataset_max_score, is_only_one_dataset_available: bool
+            self,
+            stage: StageI,
+            indexed,
+            relevance,
+            dataset_max_score,
+            is_only_one_dataset_available: bool,
         ) -> tuple[list[dict[str, Any]], str]:
             result = []
             reasoning = ""
@@ -868,7 +877,11 @@ class HybridSearcher:
         return " ".join(t.token for t in tokens)
 
     async def _search_by_query(
-        self, stage: Stage, query: str, version_ids: set[int], availability: DatasetDimTermsSetType
+        self,
+        stage: StageI,
+        query: str,
+        version_ids: set[int],
+        availability: DatasetDimTermsSetType,
     ) -> HybridSearchResultInner:
         if stage:
             stage.append_content(f"\n1. {query}\n")
@@ -890,7 +903,7 @@ class HybridSearcher:
     async def search(
         self,
         *,
-        stage: Stage,
+        stage: StageI,
         query: str,
         datasets: dict[str, VersionedDataSet],
         named_entities: list[NamedEntity],
@@ -939,20 +952,29 @@ class HybridSearcher:
         timings.separate_subjects = time.perf_counter() - t_separate_subjects
         logger.info(f"[search], {queries=}, (elapsed {time.perf_counter() - t_total:0.3f} sec)")
 
+        # Each subquery runs in parallel; writing to a shared `stage` would
+        # interleave their output. Buffer per subquery and flush sequentially
+        # in the `finally` block so partial output survives errors.
+        buffered_stages = [BufferedStage() for _ in queries]
         tasks = [
             self._search_by_query(
-                stage=stage,
+                stage=buffered_stages[i],
                 query=query,
                 version_ids=version_ids,
                 availability=availability_dict,
             )
-            for query in queries
+            for i, query in enumerate(queries)
         ]
         t_parallel_subqueries = time.perf_counter()
-        partial: list[HybridSearchResultInner] = await async_utils.gather_with_concurrency(
-            20, *tasks
-        )
-        timings.parallel_subqueries_wall = time.perf_counter() - t_parallel_subqueries
+        try:
+            partial: list[HybridSearchResultInner] = await async_utils.gather_with_concurrency(
+                20, *tasks
+            )
+        finally:
+            timings.parallel_subqueries_wall = time.perf_counter() - t_parallel_subqueries
+            if stage:
+                for buffered in buffered_stages:
+                    buffered.flush_to(stage)
         timings.per_subquery = [item.timings for item in partial]
 
         lexical_merged = self._merge_scored_dicts([item.lexical for item in partial])

--- a/statgpt/app/utils/dial_stages.py
+++ b/statgpt/app/utils/dial_stages.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager
 from datetime import datetime
@@ -34,44 +33,34 @@ class ChoiceI(Protocol):
     def set_state(self, state: dict) -> Any: ...
 
 
-class StageInterface(ABC):
-    """Abstract interface for Stage-like classes."""
+@runtime_checkable
+class StageI(Protocol):
+    """Structural protocol for Stage-like objects.
 
-    @abstractmethod
-    def append_content(self, content: str):
-        pass
+    Satisfied by the DIAL SDK's ``aidial_sdk.chat_completion.Stage`` as well as
+    the internal wrappers in this module (``DelayedStage``, ``DummyStage``,
+    ``BufferedStage``). Use this for type hints when any of those may be passed.
+    """
 
-    @abstractmethod
-    def append_name(self, name: str):
-        pass
+    def append_content(self, content: str) -> Any: ...
 
-    @abstractmethod
-    def add_attachment(self, *args, **kwargs):
-        pass
+    def append_name(self, name: str) -> Any: ...
 
-    @abstractmethod
-    def open(self):
-        pass
+    def add_attachment(self, *args: Any, **kwargs: Any) -> Any: ...
 
-    @abstractmethod
-    def close(self, status: Status = Status.COMPLETED):
-        pass
+    def open(self) -> Any: ...
+
+    def close(self, status: Status = Status.COMPLETED) -> Any: ...
 
     @property
-    @abstractmethod
-    def content_stream(self) -> ContentStream:
-        pass
+    def content_stream(self) -> ContentStream: ...
 
-    @abstractmethod
-    def __enter__(self):
-        pass
+    def __enter__(self) -> Any: ...
 
-    @abstractmethod
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any, /) -> Any: ...
 
 
-class DelayedStage(StageInterface):
+class DelayedStage(StageI):
     """
     A Stage that delays the opening of the stage (and appending the name) until the first content is added.
     """
@@ -161,7 +150,7 @@ class DelayedStage(StageInterface):
         return False
 
 
-class DummyStage(StageInterface):
+class DummyStage(StageI):
     """A silent dummy stage that does nothing."""
 
     def append_content(self, content: str):
@@ -207,6 +196,57 @@ class WarningDummyStage(DummyStage):
 
     def add_attachment(self, *args, **kwargs):
         _log.warning("The attachment is being added to a dummy stage and will be ignored.")
+
+
+class BufferedStage(StageI):
+    """A stage that records appends in memory and flushes them later in order.
+
+    Used to keep content from concurrent tasks from interleaving on a shared
+    real stage: each task writes to its own BufferedStage; after the tasks
+    complete (or fail), the buffers are flushed to the real stage sequentially.
+    """
+
+    def __init__(self) -> None:
+        self._pending_content: list[str] = []
+        self._pending_names: list[str] = []
+        self._pending_attachments: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def append_content(self, content: str) -> None:
+        self._pending_content.append(content)
+
+    def append_name(self, name: str) -> None:
+        self._pending_names.append(name)
+
+    def add_attachment(self, *args: Any, **kwargs: Any) -> None:
+        self._pending_attachments.append((args, kwargs))
+
+    def open(self) -> None:
+        pass
+
+    def close(self, status: Status = Status.COMPLETED) -> None:
+        pass
+
+    @property
+    def content_stream(self) -> ContentStream:
+        raise NotImplementedError("BufferedStage does not support content_stream")
+
+    def __enter__(self) -> "BufferedStage":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        pass
+
+    def flush_to(self, stage: StageI) -> None:
+        """Drain buffered calls into the target stage, then clear the buffers."""
+        for name in self._pending_names:
+            stage.append_name(name)
+        self._pending_names.clear()
+        for content in self._pending_content:
+            stage.append_content(content)
+        self._pending_content.clear()
+        for args, kwargs in self._pending_attachments:
+            stage.add_attachment(*args, **kwargs)
+        self._pending_attachments.clear()
 
 
 class NullChoice:
@@ -260,7 +300,7 @@ def delayed_timed_stage(choice: ChoiceI, *args, **kwargs):
 
 
 @contextmanager
-def optional_stage(stage_generator: AbstractContextManager[StageInterface], enabled: bool):
+def optional_stage(stage_generator: AbstractContextManager[StageI], enabled: bool):
     if not enabled:
         # Create a dummy stage that logs warnings
         stage_generator = WarningDummyStage()

--- a/statgpt/app/utils/dial_stages.py
+++ b/statgpt/app/utils/dial_stages.py
@@ -34,12 +34,25 @@ class ChoiceI(Protocol):
 
 
 @runtime_checkable
+class ContentStageI(Protocol):
+    """Structural protocol for stage-like objects that accept content appends.
+
+    Narrower than ``StageI`` — only ``append_content`` is required. Every
+    ``StageI`` implementation satisfies this protocol structurally; so does
+    ``BufferedStage``, which deliberately does *not* implement the rest of the
+    stage surface.
+    """
+
+    def append_content(self, content: str) -> Any: ...
+
+
+@runtime_checkable
 class StageI(Protocol):
     """Structural protocol for Stage-like objects.
 
     Satisfied by the DIAL SDK's ``aidial_sdk.chat_completion.Stage`` as well as
-    the internal wrappers in this module (``DelayedStage``, ``DummyStage``,
-    ``BufferedStage``). Use this for type hints when any of those may be passed.
+    the internal wrappers in this module (``DelayedStage``, ``DummyStage``).
+    Use this for type hints when any of those may be passed.
     """
 
     def append_content(self, content: str) -> Any: ...
@@ -198,55 +211,60 @@ class WarningDummyStage(DummyStage):
         _log.warning("The attachment is being added to a dummy stage and will be ignored.")
 
 
-class BufferedStage(StageI):
-    """A stage that records appends in memory and flushes them later in order.
+class BufferedStage(ContentStageI):
+    """Records ``append_content`` calls in memory; flushes them to a real stage later.
 
     Used to keep content from concurrent tasks from interleaving on a shared
-    real stage: each task writes to its own BufferedStage; after the tasks
+    real stage: each task writes to its own ``BufferedStage``; after the tasks
     complete (or fail), the buffers are flushed to the real stage sequentially.
+
+    Intentionally narrower than ``StageI`` — only ``append_content`` is
+    supported. Other stage operations (``append_name``, ``add_attachment``,
+    lifecycle) must be performed on the real stage *before* the parallel
+    section, never on the buffered substitute.
     """
 
     def __init__(self) -> None:
         self._pending_content: list[str] = []
-        self._pending_names: list[str] = []
-        self._pending_attachments: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
 
     def append_content(self, content: str) -> None:
         self._pending_content.append(content)
 
-    def append_name(self, name: str) -> None:
-        self._pending_names.append(name)
-
-    def add_attachment(self, *args: Any, **kwargs: Any) -> None:
-        self._pending_attachments.append((args, kwargs))
-
-    def open(self) -> None:
-        pass
-
-    def close(self, status: Status = Status.COMPLETED) -> None:
-        pass
-
-    @property
-    def content_stream(self) -> ContentStream:
-        raise NotImplementedError("BufferedStage does not support content_stream")
-
-    def __enter__(self) -> "BufferedStage":
-        return self
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        pass
-
-    def flush_to(self, stage: StageI) -> None:
-        """Drain buffered calls into the target stage, then clear the buffers."""
-        for name in self._pending_names:
-            stage.append_name(name)
-        self._pending_names.clear()
+    def flush_to(self, stage: ContentStageI) -> None:
+        """Drain buffered content into the target stage, then clear the buffer."""
         for content in self._pending_content:
             stage.append_content(content)
         self._pending_content.clear()
-        for args, kwargs in self._pending_attachments:
-            stage.add_attachment(*args, **kwargs)
-        self._pending_attachments.clear()
+
+
+class BufferedStagesManager:
+    """Hands out per-task stages and flushes them in order on exit.
+
+    Each task receives its own ``ContentStageI`` from :meth:`create`. On
+    ``__exit__``, all buffered content is appended to ``to_stage`` sequentially,
+    preventing the interleaving that happens when concurrent tasks share a real
+    stage. If ``to_stage`` is falsy (disabled), :meth:`create` returns a shared
+    ``DummyStage`` and exit flushes nothing.
+    """
+
+    def __init__(self, to_stage: StageI) -> None:
+        self._to_stage = to_stage
+        self._buffers: list[BufferedStage] = []
+        self._dummy = DummyStage()
+
+    def create(self) -> ContentStageI:
+        if not self._to_stage:
+            return self._dummy
+        buf = BufferedStage()
+        self._buffers.append(buf)
+        return buf
+
+    def __enter__(self) -> "BufferedStagesManager":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        for buf in self._buffers:
+            buf.flush_to(self._to_stage)
 
 
 class NullChoice:

--- a/statgpt/app/utils/dial_stages.py
+++ b/statgpt/app/utils/dial_stages.py
@@ -265,6 +265,7 @@ class BufferedStagesManager:
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         for buf in self._buffers:
             buf.flush_to(self._to_stage)
+        self._buffers.clear()
 
 
 class NullChoice:


### PR DESCRIPTION
## Applicable issues

- fixes #397

## Description of changes

`HybridSearcher.search` ran subqueries in parallel via `gather_with_concurrency(20, ...)`, with every task sharing the same DIAL `stage` object. The SDK's `Stage.append_content` writes to a shared queue without synchronization, so chunks from different subqueries interleaved and the `Hybrid Indicators Selection` stage rendered as malformed, mixed-up blocks.

Each subquery now writes to its own `BufferedStage` (a new in-memory recorder). After the gather completes — or fails — the buffers are flushed to the real stage in subquery order inside a `finally` block, so partial output survives errors. Single user-facing stage, parallelism preserved, output coherent per subquery.

Type plumbing: replaced the `StageInterface` ABC with a runtime-checkable `StageI` Protocol (mirrors the existing `ChoiceI` pattern in the same module). The DIAL SDK's `Stage` satisfies `StageI` structurally, and the internal wrappers (`DelayedStage`, `DummyStage`, `BufferedStage`) declare conformance explicitly. The relevant `HybridSearcher` / `HybridMatch` method signatures now take `StageI` so `BufferedStage` is accepted without type ignores.

## Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
