### PR TITLE
feat: include last_auto_update_job in channel datasets response #383

### DIFF
--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -1404,6 +1404,9 @@ class AdminPortalDataSetService(DataSetService):
         last_completed_versions = await self._get_latest_successful_dataset_version(
             channel_dataset_ids=[ch_ds.id for ch_ds in channel_datasets]
         )
+        latest_auto_update_jobs = await self._get_latest_auto_update_jobs(
+            channel_dataset_ids=[ch_ds.id for ch_ds in channel_datasets]
+        )
         return [
             ChannelDataSetSerializer.db_to_schema(
                 item_db=ch_ds,
@@ -1412,6 +1415,7 @@ class AdminPortalDataSetService(DataSetService):
                     new_versions[ch_ds.id], from_attributes=True
                 ),
                 last_completed_versions=last_completed_versions[ch_ds.dataset_id],
+                last_auto_update_job=latest_auto_update_jobs.get(ch_ds.id),
             )
             for ch_ds in channel_datasets
         ]
@@ -1479,8 +1483,15 @@ class AdminPortalDataSetService(DataSetService):
             )
         )
         last_completed_versions = last_completed_versions_mapping[channel_dataset.id]
+        latest_auto_update_jobs = await self._get_latest_auto_update_jobs(
+            channel_dataset_ids=[channel_dataset.id]
+        )
         return ChannelDataSetSerializer.db_to_schema(
-            channel_dataset, dataset, latest_version, last_completed_versions
+            channel_dataset,
+            dataset,
+            latest_version,
+            last_completed_versions,
+            latest_auto_update_jobs.get(channel_dataset.id),
         )
 
     @classmethod

--- a/statgpt/common/schemas/channel_dataset.py
+++ b/statgpt/common/schemas/channel_dataset.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field, computed_field
 
+from .auto_update import AutoUpdateJob
 from .base import DbDefaultBase
 from .dataset import DataSet
 from .enums import PreprocessingStatusEnum
@@ -65,6 +66,12 @@ class ChannelDatasetExpanded(ChannelDatasetBase):
         )
     )
     latest_version: ChannelDatasetVersion | None
+    last_auto_update_job: AutoUpdateJob | None = Field(
+        description=(
+            "The most recent auto-update job for this channel dataset,"
+            " or null if no auto-update job has ever been created."
+        )
+    )
 
 
 class BaseChange(BaseModel):

--- a/statgpt/common/services/dataset.py
+++ b/statgpt/common/services/dataset.py
@@ -60,6 +60,7 @@ class ChannelDataSetSerializer:
         dataset: schemas.DataSet,
         latest_version: schemas.ChannelDatasetVersion | None,
         last_completed_versions: LastCompletedVersions,
+        last_auto_update_job: schemas.AutoUpdateJob | None,
     ) -> schemas.ChannelDatasetExpanded:
         preprocessing_status = (
             StatusEnum.NOT_STARTED
@@ -79,6 +80,7 @@ class ChannelDataSetSerializer:
             latest_version=latest_version,
             last_completed_version=last_completed_versions.last_completed_version,
             previous_completed_version=last_completed_versions.previous_completed_version,
+            last_auto_update_job=last_auto_update_job,
         )
 
 
@@ -288,6 +290,7 @@ class DataSetService(DbServiceBase):
         latest_successful_versions = await self._get_latest_successful_channel_dataset_versions(
             channel_dataset_ids
         )
+        latest_auto_update_jobs = await self._get_latest_auto_update_jobs(channel_dataset_ids)
 
         res = []
         for item in items:
@@ -296,7 +299,11 @@ class DataSetService(DbServiceBase):
             dataset = next(d for d in datasets if d.id == item.dataset_id)
             res.append(
                 ChannelDataSetSerializer.db_to_schema(
-                    item, dataset, latest_version, ds_completed_versions
+                    item,
+                    dataset,
+                    latest_version,
+                    ds_completed_versions,
+                    latest_auto_update_jobs.get(item.id),
                 )
             )
         return res
@@ -346,8 +353,15 @@ class DataSetService(DbServiceBase):
         last_completed_versions = await self._get_latest_successful_channel_dataset_versions(
             channel_dataset_ids=[item.id]
         )
+        latest_auto_update_jobs = await self._get_latest_auto_update_jobs(
+            channel_dataset_ids=[item.id]
+        )
         return ChannelDataSetSerializer.db_to_schema(
-            item, dataset, latest_version, last_completed_versions[item.id]
+            item,
+            dataset,
+            latest_version,
+            last_completed_versions[item.id],
+            latest_auto_update_jobs.get(item.id),
         )
 
     async def _get_channel_dataset_version_or_raise(
@@ -427,6 +441,39 @@ class DataSetService(DbServiceBase):
         for row in versions:
             version = schemas.ChannelDatasetVersion.model_validate(row, from_attributes=True)
             result_dict[version.channel_dataset_id] = version
+
+        return result_dict
+
+    async def _get_latest_auto_update_jobs(
+        self, channel_dataset_ids: list[int]
+    ) -> dict[int, schemas.AutoUpdateJob]:
+        """Get the most recent auto-update job for each channel dataset."""
+        if not channel_dataset_ids:
+            return {}
+
+        ranked_jobs = (
+            select(
+                models.AutoUpdateJob,
+                func.row_number()
+                .over(
+                    partition_by=models.AutoUpdateJob.channel_dataset_id,
+                    order_by=models.AutoUpdateJob.id.desc(),
+                )
+                .label("rank"),
+            )
+            .where(models.AutoUpdateJob.channel_dataset_id.in_(channel_dataset_ids))
+            .subquery()
+        )
+
+        query = select(ranked_jobs).where(ranked_jobs.c.rank == 1)
+
+        result = await self._session.execute(query)
+        jobs = result.fetchall()
+
+        result_dict: dict[int, schemas.AutoUpdateJob] = {}
+        for row in jobs:
+            job = schemas.AutoUpdateJob.model_validate(row, from_attributes=True)
+            result_dict[job.channel_dataset_id] = job
 
         return result_dict
 

--- a/tests/integration/services/test_sdmx_datasets.py
+++ b/tests/integration/services/test_sdmx_datasets.py
@@ -11,7 +11,7 @@ from statgpt.admin.services.dataset import (
     clear_channel_dataset_data_in_background_task,
     reload_indicators_in_background_task,
 )
-from statgpt.common import schemas
+from statgpt.common import models, schemas
 from statgpt.common.data.base import DatasetCitation, IndexerConfig, IndexerIndicatorConfig
 from statgpt.common.settings.langchain import langchain_settings
 
@@ -530,6 +530,87 @@ async def test_reload_all_indicators(session, clear_all, sdmx_clint_mock):
             == "Manually initiated reindexing of all datasets in a channel."
         )
         assert channel_ds.latest_version.reason_for_failure is None
+
+
+@pytest.mark.asyncio
+async def test_last_auto_update_job_in_channel_datasets(session, clear_all, sdmx_clint_mock):
+    channel = await get_channel(session)
+    data_source = await get_data_source(session)
+
+    dataset_service = DataSetService(session)
+
+    ds1 = await dataset_service.create_dataset(
+        schemas.DataSetBase(
+            id_=uuid.uuid4(),
+            title='CPI v4.0.0',
+            data_source_id=data_source.id,
+            details={'urn': URN_CPI_4_0_0, 'dimensions': DIMENSIONS},
+        ),
+        auth_context=SystemUserAuthContext(),
+    )
+    ds2 = await dataset_service.create_dataset(
+        schemas.DataSetBase(
+            id_=uuid.uuid4(),
+            title='CPI v3.0.1',
+            data_source_id=data_source.id,
+            details={'urn': URN_CPI_3_0_1, 'dimensions': DIMENSIONS},
+        ),
+        auth_context=SystemUserAuthContext(),
+    )
+
+    cd1 = await dataset_service.add_dataset_to_channel(channel.id, ds1.id)
+    cd2 = await dataset_service.add_dataset_to_channel(channel.id, ds2.id)
+
+    listed = await dataset_service.get_channel_dataset_schemas(
+        limit=100, offset=0, channel_id=channel.id, auth_context=SystemUserAuthContext()
+    )
+    assert len(listed) == 2
+    assert all(item.last_auto_update_job is None for item in listed)
+
+    single = await dataset_service.get_channel_dataset_schema(
+        channel.id, ds1.id, auth_context=SystemUserAuthContext()
+    )
+    assert single.last_auto_update_job is None
+
+    job1 = models.AutoUpdateJob(
+        channel_dataset_id=cd1.id,
+        status=schemas.PreprocessingStatusEnum.QUEUED,
+    )
+    session.add(job1)
+    await session.commit()
+    await session.refresh(job1)
+
+    listed = await dataset_service.get_channel_dataset_schemas(
+        limit=100, offset=0, channel_id=channel.id, auth_context=SystemUserAuthContext()
+    )
+    by_id = {item.id: item for item in listed}
+    assert by_id[cd1.id].last_auto_update_job is not None
+    assert by_id[cd1.id].last_auto_update_job.id == job1.id
+    assert by_id[cd2.id].last_auto_update_job is None
+
+    single = await dataset_service.get_channel_dataset_schema(
+        channel.id, ds1.id, auth_context=SystemUserAuthContext()
+    )
+    assert single.last_auto_update_job is not None
+    assert single.last_auto_update_job.id == job1.id
+
+    job2 = models.AutoUpdateJob(
+        channel_dataset_id=cd1.id,
+        status=schemas.PreprocessingStatusEnum.COMPLETED,
+        result=schemas.AutoUpdateResult.NO_CHANGES,
+    )
+    session.add(job2)
+    await session.commit()
+    await session.refresh(job2)
+
+    listed = await dataset_service.get_channel_dataset_schemas(
+        limit=100, offset=0, channel_id=channel.id, auth_context=SystemUserAuthContext()
+    )
+    by_id = {item.id: item for item in listed}
+    assert by_id[cd1.id].last_auto_update_job is not None
+    assert by_id[cd1.id].last_auto_update_job.id == job2.id
+    assert by_id[cd1.id].last_auto_update_job.status == schemas.PreprocessingStatusEnum.COMPLETED
+    assert by_id[cd1.id].last_auto_update_job.result == schemas.AutoUpdateResult.NO_CHANGES
 
 
 # ~~~ Testing the background tasks ~~~


### PR DESCRIPTION
## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #383

## Description of changes

<!-- Please explain the changes you made right below this line. -->
Extends `ChannelDatasetExpanded` with a new `last_auto_update_job` field that surfaces the most recent `AutoUpdateJob` for each channel dataset (or `null` if none has been created). Previously, the Admin UI had to make a separate `GET /channels/{id}/datasets/{ds_id}/versions/auto-update-jobs` call per dataset to render auto-update state in the dataset list — an N+1 pattern.

### API changes

- `ChannelDatasetExpanded.last_auto_update_job: AutoUpdateJob | null` — returned by every endpoint that produces this schema:
  - `GET /channels/{channel_id}/datasets`
  - `GET /channels/{channel_id}/datasets/{dataset_id}`
  - `POST /channels/{channel_id}/reload-indicators`
  - `POST /channels/{channel_id}/datasets/{dataset_id}/reload-indicators`

## Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
