### PR TITLE
hotfix: set `providerDiscovery: dataflows` for IMF_SDMX21 sample config

### DIFF
--- a/configurations/clients/sample/data_sources.yaml
+++ b/configurations/clients/sample/data_sources.yaml
@@ -10,6 +10,7 @@ dataSources:
       availabilityViaPostUrl: null
       dataExplorerUrl: "https://data.imf.org/en/Data-Explorer"
       sdmx1Source: "IMF_DATA"
+      providerDiscovery: dataflows
       sdmxConfig:
         id: "IMF_SDMX21"
         name: "Public IMF SDMX 21 Registry"


### PR DESCRIPTION
## Applicable issues

- Refs PR #389

## Description of changes

Sets `providerDiscovery: dataflows` on the IMF_SDMX21 data source in the sample client configuration.

The `provider_discovery` field was introduced in #389 . The IMF SDMX 2.1 registry does not expose an agency scheme endpoint, so the default `agencyscheme` mode would fail to enumerate providers. Switching to `dataflows` lists all dataflows and groups them by `agency_id`, which is the supported path for SDMX 2.1 registries without agency schemes.

## Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
