### PR TITLE
feat: extend conversation starters with title, input placeholder, and live indicator count #404

### DIFF
--- a/configurations/clients/sample/channels.yaml
+++ b/configurations/clients/sample/channels.yaml
@@ -33,7 +33,9 @@ channels:
         - "Currency/Unit of measure"
       country_named_entity_type: "Country/Reference area"
       conversation_starters:
-        intro_text: "What would you like to learn about?"
+        title: "What would you like to learn about?"
+        intro_text: "Search {indicators_total} official indicators from the IMF"
+        input_placeholder: "Ask about GDP, inflation or any other IMF indicator"
         buttons:
           - title: "Check available data"
             text: "What datasets are available?"

--- a/statgpt/app/README.md
+++ b/statgpt/app/README.md
@@ -24,6 +24,7 @@ the [common README file](../common/README.md).
 | DIAL_RAG_PGVECTOR_URL          |    No    | URL for the RAG with pgvector, only for local development                                                                                                                                                                                            |                                              |                     |
 | DIAL_RAG_PGVECTOR_API_KEY      |    No    | API key for the RAG with pgvector, only for local development                                                                                                                                                                                        |                                              |                     |
 | TTYD_TOOL_PLAIN_CONTENT_*      |    No    | Environment variables for the Plain Content tool to replace in the files content. Replace `*` with the variable name.                                                                                                                                |                                              |                     |
+| INDICATORS_TOTAL_CACHE_TTL     |    No    | TTL in seconds for the in-process cache of the per-channel indicators total (used to substitute the `{indicators_total}` token in conversation-starter texts). The figure is non-transactional; staleness within this window is acceptable.          | integer (seconds)                            | `60`                |
 
 ## MCP Server
 

--- a/statgpt/app/application/channel_completion.py
+++ b/statgpt/app/application/channel_completion.py
@@ -82,7 +82,10 @@ class ChannelCompletion(ChatCompletion):
                 code="deployment_not_found",
                 message="The API deployment for this resource does not exist.",
             )
-        auth_context = await create_auth_context(request)
+        auth_context = await create_auth_context(
+            request,
+            bearer_token_required=service.channel_config.bearer_token_required,
+        )
         return await service.get_dial_channel_configuration(auth_context)
 
     @classmethod

--- a/statgpt/app/application/channel_completion.py
+++ b/statgpt/app/application/channel_completion.py
@@ -82,7 +82,8 @@ class ChannelCompletion(ChatCompletion):
                 code="deployment_not_found",
                 message="The API deployment for this resource does not exist.",
             )
-        return service.dial_channel_configuration
+        auth_context = await create_auth_context(request)
+        return await service.get_dial_channel_configuration(auth_context)
 
     @classmethod
     async def _channel_completion(

--- a/statgpt/app/services/chat_facade.py
+++ b/statgpt/app/services/chat_facade.py
@@ -45,6 +45,15 @@ from statgpt.common.vectorstore import ScoredVectorStoreDocument, VectorStore, V
 
 _log = logging.getLogger(__name__)
 
+_INDICATORS_TOTAL_TOKEN = "{indicators_total}"
+
+
+def _substitute_indicators_total(text: str | None, count: int) -> str | None:
+    """Replace the supported `{indicators_total}` token with the live count."""
+    if text is None:
+        return None
+    return text.replace(_INDICATORS_TOTAL_TOKEN, str(count))
+
 
 @dataclass
 class VectorStoreIndicator:
@@ -261,8 +270,7 @@ class ChannelServiceFacade:
     def channel_config(self) -> ChannelConfig:
         return self._channel.details
 
-    @property
-    def dial_channel_configuration(self) -> dict[str, Any]:
+    async def get_dial_channel_configuration(self, auth_context: AuthContext) -> dict[str, Any]:
         conversation_starters_config = self.channel_config.conversation_starters
         if conversation_starters_config is None:
             _log.info(
@@ -270,10 +278,24 @@ class ChannelServiceFacade:
             )
 
             return BaseChannelConfiguration.model_json_schema()
-        intro_text: str = conversation_starters_config.intro_text
+
         _log.info(
             f"Conversation starters configuration found for channel {self._channel.title}, {conversation_starters_config=}"
         )
+        intro_text: str = conversation_starters_config.intro_text
+        title = conversation_starters_config.title
+        input_placeholder = conversation_starters_config.input_placeholder
+
+        needs_count = any(
+            s is not None and _INDICATORS_TOTAL_TOKEN in s
+            for s in (intro_text, title, input_placeholder)
+        )
+        if needs_count:
+            count = await self.get_indicators_total(auth_context)
+            intro_text = _substitute_indicators_total(intro_text, count)  # type: ignore[assignment]
+            title = _substitute_indicators_total(title, count)
+            input_placeholder = _substitute_indicators_total(input_placeholder, count)
+
         buttons = [
             Button(
                 const=i,
@@ -284,12 +306,18 @@ class ChannelServiceFacade:
             for i, button in enumerate(conversation_starters_config.buttons)
         ]
 
+        field_kwargs: dict[str, Any] = {
+            "default": None,
+            "description": intro_text,
+            "buttons": buttons,
+        }
+        if title is not None:
+            field_kwargs["title"] = title
+        if input_placeholder is not None:
+            field_kwargs["json_schema_extra"] = {"statgpt:inputPlaceholder": input_placeholder}
+
         class StatGPTConfiguration(BaseChannelConfiguration):
-            starter: int | None = DialField(
-                default=None,
-                description=intro_text,
-                buttons=buttons,
-            )
+            starter: int | None = DialField(**field_kwargs)
 
         return StatGPTConfiguration.model_json_schema()
 
@@ -439,6 +467,28 @@ class ChannelServiceFacade:
             for vid, count in counts_by_version.items()
             if vid in version_to_entity
         }
+
+    async def get_indicators_total(self, auth_context: AuthContext) -> int:
+        """Total indicator count across the channel's latest successful dataset versions.
+
+        Lightweight DB-only count: skips per-handler `is_dataset_available` checks
+        (no external SDMX/QuantHub calls). May include indicators from datasets
+        that are temporarily offline.
+        """
+        async with get_readonly_session_context_manager() as session:
+            dataset_service = DataSetService(session, session_lock=None)
+            latest = await dataset_service.get_latest_successful_dataset_versions_for_channel(
+                channel_id=self._channel.id
+            )
+        version_ids = {
+            item.last_completed_version.version_data_id
+            for item in latest.values()
+            if item.last_completed_version is not None
+        }
+        if not version_ids:
+            return 0
+        vector_store = await self._get_indicators_vector_store(auth_context)
+        return await vector_store.get_size(version_ids)
 
     async def get_dataset_hierarchy(self, auth_context: AuthContext) -> DatasetHierarchy | None:
         """Get first available dataset hierarchy from the channel data sources."""

--- a/statgpt/app/services/chat_facade.py
+++ b/statgpt/app/services/chat_facade.py
@@ -40,6 +40,7 @@ from statgpt.common.settings.document import (
     IndicatorDocumentMetadataFields,
     SpecialDimensionValueDocumentMetadataFields,
 )
+from statgpt.common.utils import AsyncLoadingCache
 from statgpt.common.utils.timer import debug_timer
 from statgpt.common.vectorstore import ScoredVectorStoreDocument, VectorStore, VectorStoreFactory
 
@@ -209,6 +210,10 @@ class BaseChannelConfiguration(BaseModel, metaclass=FormMetaclass):
 
 
 class ChannelServiceFacade:
+    _indicators_total_cache: AsyncLoadingCache[int] = AsyncLoadingCache(
+        ttl=dial_app_settings.indicators_total_cache_ttl
+    )
+
     def __init__(self, channel: schemas.Channel) -> None:
         self._channel = channel
         self._handler_classes: dict[int, type[DataSourceHandler]] = {}
@@ -282,7 +287,7 @@ class ChannelServiceFacade:
         _log.info(
             f"Conversation starters configuration found for channel {self._channel.title}, {conversation_starters_config=}"
         )
-        intro_text: str = conversation_starters_config.intro_text
+        intro_text: str | None = conversation_starters_config.intro_text
         title = conversation_starters_config.title
         input_placeholder = conversation_starters_config.input_placeholder
 
@@ -291,8 +296,8 @@ class ChannelServiceFacade:
             for s in (intro_text, title, input_placeholder)
         )
         if needs_count:
-            count = await self.get_indicators_total(auth_context)
-            intro_text = _substitute_indicators_total(intro_text, count)  # type: ignore[assignment]
+            count = await self._get_indicators_total(auth_context)
+            intro_text = _substitute_indicators_total(intro_text, count)
             title = _substitute_indicators_total(title, count)
             input_placeholder = _substitute_indicators_total(input_placeholder, count)
 
@@ -306,18 +311,16 @@ class ChannelServiceFacade:
             for i, button in enumerate(conversation_starters_config.buttons)
         ]
 
-        field_kwargs: dict[str, Any] = {
-            "default": None,
-            "description": intro_text,
-            "buttons": buttons,
-        }
+        other_fields: dict[str, Any] = {}
         if title is not None:
-            field_kwargs["title"] = title
+            other_fields["title"] = title
         if input_placeholder is not None:
-            field_kwargs["json_schema_extra"] = {"statgpt:inputPlaceholder": input_placeholder}
+            other_fields["json_schema_extra"] = {"statgpt:inputPlaceholder": input_placeholder}
 
         class StatGPTConfiguration(BaseChannelConfiguration):
-            starter: int | None = DialField(**field_kwargs)
+            starter: int | None = DialField(
+                default=None, description=intro_text, buttons=buttons, **other_fields
+            )
 
         return StatGPTConfiguration.model_json_schema()
 
@@ -468,27 +471,35 @@ class ChannelServiceFacade:
             if vid in version_to_entity
         }
 
-    async def get_indicators_total(self, auth_context: AuthContext) -> int:
+    async def _get_indicators_total(self, auth_context: AuthContext) -> int:
         """Total indicator count across the channel's latest successful dataset versions.
 
         Lightweight DB-only count: skips per-handler `is_dataset_available` checks
         (no external SDMX/QuantHub calls). May include indicators from datasets
         that are temporarily offline.
+
+        Result is cached in-process per channel for `indicators_total_cache_ttl`
+        seconds. The count is auth-context-independent — concurrent callers share
+        a single load via `AsyncLoadingCache`'s per-key lock.
         """
-        async with get_readonly_session_context_manager() as session:
-            dataset_service = DataSetService(session, session_lock=None)
-            latest = await dataset_service.get_latest_successful_dataset_versions_for_channel(
-                channel_id=self._channel.id
-            )
-        version_ids = {
-            item.last_completed_version.version_data_id
-            for item in latest.values()
-            if item.last_completed_version is not None
-        }
-        if not version_ids:
-            return 0
-        vector_store = await self._get_indicators_vector_store(auth_context)
-        return await vector_store.get_size(version_ids)
+
+        async def _load() -> int:
+            async with get_readonly_session_context_manager() as session:
+                dataset_service = DataSetService(session, session_lock=None)
+                latest = await dataset_service.get_latest_successful_dataset_versions_for_channel(
+                    channel_id=self._channel.id
+                )
+            version_ids = {
+                item.last_completed_version.version_data_id
+                for item in latest.values()
+                if item.last_completed_version is not None
+            }
+            if not version_ids:
+                return 0
+            vector_store = await self._get_indicators_vector_store(auth_context)
+            return await vector_store.get_size(version_ids)
+
+        return await self._indicators_total_cache.get(str(self._channel.id), _load)
 
     async def get_dataset_hierarchy(self, auth_context: AuthContext) -> DatasetHierarchy | None:
         """Get first available dataset hierarchy from the channel data sources."""

--- a/statgpt/app/settings/dial_app.py
+++ b/statgpt/app/settings/dial_app.py
@@ -77,6 +77,15 @@ class DialAppSettings(BaseSettings):
         description="Track and report LLM call durations per model in debug performance stage and DIAL state",
     )
 
+    indicators_total_cache_ttl: int = Field(
+        default=60,
+        alias="INDICATORS_TOTAL_CACHE_TTL",
+        description=(
+            "TTL in seconds for the in-process cache of the per-channel indicators total. "
+            "The figure is non-transactional; staleness within this window is acceptable."
+        ),
+    )
+
     dial_system_user_context_roles: str | None = Field(
         default=None,
         alias="DIAL_SYSTEM_USER_CONTEXT_ROLES",

--- a/statgpt/common/schemas/channel.py
+++ b/statgpt/common/schemas/channel.py
@@ -133,6 +133,20 @@ class ConversationStartersConfig(BaseYamlModel):
     intro_text: str = Field(
         description="The text displayed to the user when the conversation starts."
     )
+    title: str | None = Field(
+        default=None,
+        description=(
+            "Optional override for the conversation-starter widget title. "
+            "If unset, the default JSON-schema title is used."
+        ),
+    )
+    input_placeholder: str | None = Field(
+        default=None,
+        description=(
+            "Optional placeholder text for the chat input field. "
+            "Rendered as the 'statgpt:inputPlaceholder' JSON-schema extension."
+        ),
+    )
     buttons: list[ConversationStarterConfig] = Field(
         description="The buttons displayed to the user when the conversation starts."
     )


### PR DESCRIPTION
### Applicable issues

- fixes #404

### Description of changes

Adds two optional fields to `ConversationStartersConfig` — `title` and `input_placeholder` — surfaced in the channel `/configuration` JSON schema as `title` and the `statgpt:inputPlaceholder` extension.

Supports a single `{indicators_total}` placeholder in `intro_text`, `title`, and `input_placeholder`. The token is replaced at response time with the channel's live indicator count (counted from the DB across the latest successful dataset versions). The count is fetched only when the placeholder is actually present, so channels that don't use it pay no extra cost.

Sample channel config updated to demonstrate the new fields.

Frontend rendering of the new attributes is tracked separately.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.