### PR TITLE
feat: make data query pipeline stage names configurable per channel #409

### DIFF
--- a/configurations/clients/sample/tools.yaml
+++ b/configurations/clients/sample/tools.yaml
@@ -147,15 +147,15 @@ tools:
         toolCallName: "Searching for data: {query}"
         toolResultName: "Data search result: {query}"
         rules:
-          - pattern: "Constructing Data Queries"
+          - key: constructing_data_query
             debugOnly: false
-          - pattern: "Extracting Named Entities"
+          - key: extracting_named_entities
             debugOnly: false
-          - pattern: "Executing Data Queries"
+          - key: executing_data_query
             debugOnly: false
-          - pattern: "Normalizing Query"
+          - key: normalizing_query
             debugOnly: false
-          - pattern: "Selecting Indicators"
+          - key: selecting_indicators
             debugOnly: false
       messages:
         noDataForCountry: >-

--- a/statgpt/app/chains/data_query/query_builder/dimensions/indicators.py
+++ b/statgpt/app/chains/data_query/query_builder/dimensions/indicators.py
@@ -64,11 +64,11 @@ class IndicatorsSearchChainFactory(DimensionSearchChainFactoryBase):
         return chain
 
     def create(self) -> Runnable:
-        selecting_indicators_stage_name = "Selecting Indicators"
+        stage = self._config.pipeline_stage_names.selecting_indicators
         selecting_indicators_stage_callback = StageCallback(
-            stage_name=selecting_indicators_stage_name,
+            stage_name=stage.name,
             content_appender=None,
-            debug_only=self._config.stages_config.is_stage_debug(selecting_indicators_stage_name),
+            debug_only=stage.is_debug(self._config.stages_config),
         )
 
         return (

--- a/statgpt/app/chains/data_query/query_builder/dimensions/special.py
+++ b/statgpt/app/chains/data_query/query_builder/dimensions/special.py
@@ -46,13 +46,14 @@ class SpecialDimensionsSearchChainFactory(DimensionSearchChainFactoryBase):
             f'{list(chains_dict.keys())}'
         )
 
+        stage = self._config.pipeline_stage_names.selecting_special_dimensions
         return chain.with_config(
             config=RunnableConfig(
                 callbacks=[
                     StageCallback(
-                        stage_name="Selecting Special Dimensions",
+                        stage_name=stage.name,
                         content_appender=None,
-                        debug_only=True,
+                        debug_only=stage.is_debug(self._config.stages_config),
                     )
                 ]
             )

--- a/statgpt/app/chains/data_query/query_builder/indicator_selection/indicators_hybrid.py
+++ b/statgpt/app/chains/data_query/query_builder/indicator_selection/indicators_hybrid.py
@@ -49,8 +49,6 @@ class IndicatorsSelectionHybrid(IndicatorSelectionBase):
             description='Final search results, filtered by availability',
         ),
     ]
-    _HYBRID_SELECTION_STAGE_NAME = "Hybrid Indicators Selection"
-
     _search: HybridSearcher
 
     def __init__(self, config: DataQueryDetails, search: HybridSearcher):
@@ -60,11 +58,12 @@ class IndicatorsSelectionHybrid(IndicatorSelectionBase):
     async def _get_search_result(self, inputs: dict) -> HybridSearchResult:
         chain_state = ChainState.model_validate(inputs)
 
-        is_debug = self._config.stages_config.is_stage_debug(self._HYBRID_SELECTION_STAGE_NAME)
+        stage_descriptor = self._config.pipeline_stage_names.hybrid_indicators_selection
+        is_debug = stage_descriptor.is_debug(self._config.stages_config)
         enabled = (is_debug and chain_state.show_debug_stages) or not is_debug
 
         with optional_timed_stage(
-            choice=chain_state.choice, name=self._HYBRID_SELECTION_STAGE_NAME, enabled=enabled
+            choice=chain_state.choice, name=stage_descriptor.name, enabled=enabled
         ) as stage:
             return await self._search.search(
                 stage=stage,

--- a/statgpt/app/chains/data_query/query_builder/misc/search_preparation.py
+++ b/statgpt/app/chains/data_query/query_builder/misc/search_preparation.py
@@ -132,18 +132,19 @@ class SearchPreparationChainFactory:
         stage.append_content(content)
 
     def create(self) -> Runnable:
-        normalizing_stage_name = "Normalizing Query"
+        stage_names = self._config.pipeline_stage_names
+        stages_config = self._config.stages_config
+
         normalizing_query_stage_callback = StageCallback(
-            stage_name=normalizing_stage_name,
+            stage_name=stage_names.normalizing_query.name,
             content_appender=self._populate_normalization,
-            debug_only=self._config.stages_config.is_stage_debug(normalizing_stage_name),
+            debug_only=stage_names.normalizing_query.is_debug(stages_config),
         )
 
-        named_entities_stage_name = "Extracting Named Entities"
         named_entities_stage_callback = StageCallback(
-            stage_name=named_entities_stage_name,
+            stage_name=stage_names.extracting_named_entities.name,
             content_appender=self._populate_named_entities,
-            debug_only=self._config.stages_config.is_stage_debug(named_entities_stage_name),
+            debug_only=stage_names.extracting_named_entities.is_debug(stages_config),
         )
 
         chain = (

--- a/statgpt/app/chains/data_query/query_builder/query/execute_query.py
+++ b/statgpt/app/chains/data_query/query_builder/query/execute_query.py
@@ -17,6 +17,7 @@ from statgpt.app.utils.formatters import DatasetQueryFormatter, DatasetQueryForm
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.data.base import DataSetQuery
 from statgpt.common.schemas import StagesConfig
+from statgpt.common.schemas.tool_details import StageDescriptor
 
 from .summarize_query import SummarizeQueriesChain
 
@@ -25,10 +26,12 @@ class ExecuteQueryChain:
     def __init__(
         self,
         stages_config: StagesConfig,
+        stage: StageDescriptor,
         executed_message_agent_only: str | None,
         summarize_queries_chain: SummarizeQueriesChain,
     ):
         self._stages_config = stages_config
+        self._stage = stage
         self._executed_message_agent_only = executed_message_agent_only
         self._summarize_queries_chain = summarize_queries_chain
 
@@ -110,11 +113,10 @@ class ExecuteQueryChain:
             | self.summarize_dataset_queries
         )
 
-        stage_name = "Executing Data Query"
         callback = StageCallback(
-            stage_name=stage_name,
+            stage_name=self._stage.name,
             content_appender=self.append_data_responses_stage,
-            debug_only=self._stages_config.is_stage_debug(stage_name),
+            debug_only=self._stage.is_debug(self._stages_config),
         )
 
         chain = chain.with_config(RunnableConfig(callbacks=[callback]))  # type: ignore[assignment]

--- a/statgpt/app/chains/data_query/query_builder/query/finalize_query.py
+++ b/statgpt/app/chains/data_query/query_builder/query/finalize_query.py
@@ -53,6 +53,7 @@ class FinalizeQueryChainFactory:
         )
         self._execute_query_chain = ExecuteQueryChain(
             stages_config=self._config.stages_config,
+            stage=self._config.pipeline_stage_names.executing_data_query,
             executed_message_agent_only=messages.data_query_executed_agent_only,
             summarize_queries_chain=self._summarize_queries_chain,
         )
@@ -436,7 +437,7 @@ class FinalizeQueryChainFactory:
 
     def _create_finalization_chain(self) -> Runnable:
         """Create the actual finalization chain."""
-        construct_data_query_stage_name = "Constructing Data Query"
+        stage = self._config.pipeline_stage_names.constructing_data_query
 
         return (
             (
@@ -451,11 +452,9 @@ class FinalizeQueryChainFactory:
                 config=RunnableConfig(
                     callbacks=[
                         StageCallback(
-                            stage_name=construct_data_query_stage_name,
+                            stage_name=stage.name,
                             content_appender=self._populate_dataset_queries,
-                            debug_only=self._config.stages_config.is_stage_debug(
-                                construct_data_query_stage_name
-                            ),
+                            debug_only=stage.is_debug(self._config.stages_config),
                         )
                     ]
                 )

--- a/statgpt/common/schemas/data_query_tool.py
+++ b/statgpt/common/schemas/data_query_tool.py
@@ -1,4 +1,6 @@
-from pydantic import Field, PositiveInt, TypeAdapter, field_validator
+from typing import Any
+
+from pydantic import Field, PositiveInt, TypeAdapter, field_validator, model_validator
 from pydantic_core.core_schema import FieldValidationInfo
 
 from statgpt.common.config import LLMModelsEnum
@@ -12,7 +14,7 @@ from .enums import (
     TimePeriodStrategy,
 )
 from .model_config import LLMModelConfig
-from .tool_details import BaseToolDetails
+from .tool_details import BaseToolDetails, StageDescriptor
 
 
 def bool_from_str(value: str) -> bool:
@@ -238,6 +240,61 @@ class HybridSearchConfig(BaseYamlModel):
     prompts: HybridSearchPrompts = Field(default_factory=HybridSearchPrompts)
 
 
+class DataQueryStageNames(BaseYamlModel):
+    """Descriptors for the primary non-debug pipeline stages of the data_query tool.
+
+    In YAML, each stage is written as a plain string giving its display name; the
+    field name is the stable logical key used by `StagesConfig.rules[].key` and is
+    bound here as a private attribute so it cannot be overridden from YAML and call
+    sites never have to type the key as a string literal.
+
+    Example YAML:
+        pipelineStageNames:
+          normalizingQuery: "Preparing your query"
+    """
+
+    normalizing_query: StageDescriptor = Field(
+        default_factory=lambda: StageDescriptor(name="Normalizing Query")
+    )
+    extracting_named_entities: StageDescriptor = Field(
+        default_factory=lambda: StageDescriptor(name="Extracting Named Entities")
+    )
+    hybrid_indicators_selection: StageDescriptor = Field(
+        default_factory=lambda: StageDescriptor(name="Hybrid Indicators Selection")
+    )
+    selecting_indicators: StageDescriptor = Field(
+        default_factory=lambda: StageDescriptor(name="Selecting Indicators")
+    )
+    selecting_special_dimensions: StageDescriptor = Field(
+        default_factory=lambda: StageDescriptor(name="Selecting Special Dimensions")
+    )
+    constructing_data_query: StageDescriptor = Field(
+        default_factory=lambda: StageDescriptor(name="Constructing Data Query")
+    )
+    executing_data_query: StageDescriptor = Field(
+        default_factory=lambda: StageDescriptor(name="Executing Data Query")
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_strings(cls, data: Any) -> Any:
+        """Accept a plain string per field as shorthand for {"name": <string>}."""
+        if not isinstance(data, dict):
+            return data
+        out = dict(data)
+        for field_name in cls.model_fields:
+            value = out.get(field_name)
+            if isinstance(value, str):
+                out[field_name] = {"name": value}
+        return out
+
+    def model_post_init(self, __context: Any) -> None:
+        """Bind each descriptor's `_key` private attribute to its field name."""
+        for field_name in self.__class__.model_fields:
+            descriptor: StageDescriptor = getattr(self, field_name)
+            descriptor._key = field_name
+
+
 class DataQueryDetails(BaseToolDetails):
     indexer_version: IndexerVersion = Field(
         default=IndexerVersion.semantic, description="The version of the indexer"
@@ -271,6 +328,7 @@ class DataQueryDetails(BaseToolDetails):
     prompts: DataQueryPrompts = Field(default_factory=DataQueryPrompts)  # type: ignore
     messages: DataQueryMessages = Field(default_factory=DataQueryMessages)  # type: ignore
     attachments: DataQueryAttachments = Field(default_factory=DataQueryAttachments)  # type: ignore
+    pipeline_stage_names: DataQueryStageNames = Field(default_factory=DataQueryStageNames)
     allow_auto_update: bool = Field(
         default=False,
         description="Whether datasets in this channel should be auto-updated by the batch auto-update script.",

--- a/statgpt/common/schemas/data_query_tool.py
+++ b/statgpt/common/schemas/data_query_tool.py
@@ -278,14 +278,22 @@ class DataQueryStageNames(BaseYamlModel):
     @model_validator(mode="before")
     @classmethod
     def _coerce_strings(cls, data: Any) -> Any:
-        """Accept a plain string per field as shorthand for {"name": <string>}."""
+        """Accept a plain string per field as shorthand for {"name": <string>}.
+
+        Handles both the snake_case field name and its camelCase alias, since
+        `BaseYamlModel` enables `populate_by_name=True` and channel YAMLs are
+        written in camelCase.
+        """
         if not isinstance(data, dict):
             return data
         out = dict(data)
-        for field_name in cls.model_fields:
-            value = out.get(field_name)
-            if isinstance(value, str):
-                out[field_name] = {"name": value}
+        for field_name, field_info in cls.model_fields.items():
+            for key in (field_name, field_info.alias):
+                if key is None:
+                    continue
+                value = out.get(key)
+                if isinstance(value, str):
+                    out[key] = {"name": value}
         return out
 
     def model_post_init(self, __context: Any) -> None:

--- a/statgpt/common/schemas/tool_details.py
+++ b/statgpt/common/schemas/tool_details.py
@@ -1,7 +1,7 @@
 import re
 from typing import Any
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, PrivateAttr, model_validator
 
 from statgpt.common.config import LLMModelsEnum
 from statgpt.common.config import utils as config_utils
@@ -17,10 +17,29 @@ class FakeCall(BaseYamlModel):
 
 
 class StageRules(BaseYamlModel):
-    pattern: str = Field(description="The regex pattern to match the stage")
+    pattern: str | None = Field(
+        default=None,
+        description=(
+            "Regex pattern matched against the rendered display name of a stage."
+            " Prefer `key` instead when matching pipeline stages, since display names can be renamed via config."
+        ),
+    )
+    key: str | None = Field(
+        default=None,
+        description=(
+            "Stable logical key of the stage, matched exactly."
+            " Use this for pipeline stages so visibility rules survive display-name renames."
+        ),
+    )
     debug_only: bool = Field(
         description="Whether the stage is only shown in debug mode. If False, it is always shown."
     )
+
+    @model_validator(mode="after")
+    def _require_pattern_or_key(self) -> "StageRules":
+        if (self.pattern is None) == (self.key is None):
+            raise ValueError("StageRules must specify exactly one of `pattern` or `key`.")
+        return self
 
 
 class StagesConfig(BaseYamlModel):
@@ -43,12 +62,38 @@ class StagesConfig(BaseYamlModel):
         default_factory=list, description="The rules for displaying stages"
     )
 
-    def is_stage_debug(self, stage_name: str) -> bool:
-        """Check if the stage should be displayed in debug mode only."""
+    def is_stage_debug(self, key: str | None = None, name: str | None = None) -> bool:
+        """Check if the stage should be displayed in debug mode only.
+
+        Rules with `key` are matched exactly against `key`; rules with `pattern` are
+        regex-matched against `name`. The first matching rule wins. Falls back to the
+        config-level `debug_only` default.
+        """
         for rule in self.rules:
-            if re.match(rule.pattern, stage_name):
+            if rule.key is not None and key is not None and rule.key == key:
+                return rule.debug_only
+            if rule.pattern is not None and name is not None and re.match(rule.pattern, name):
                 return rule.debug_only
         return self.debug_only
+
+
+class StageDescriptor(BaseYamlModel):
+    """Runtime descriptor for a configured stage.
+
+    `name` is the (configurable) display name set via YAML.
+    `key` is the stable logical key — a private attribute set by the parent model
+    based on the descriptor's field name, so it cannot be overridden from YAML.
+    """
+
+    name: str
+    _key: str = PrivateAttr(default="")
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def is_debug(self, stages_config: StagesConfig) -> bool:
+        return stages_config.is_stage_debug(key=self._key, name=self.name)
 
 
 class BaseToolDetails(BaseYamlModel):

--- a/tests/unit/common/test_stage_config.py
+++ b/tests/unit/common/test_stage_config.py
@@ -1,0 +1,156 @@
+import pytest
+from pydantic import ValidationError
+
+from statgpt.common.schemas.data_query_tool import DataQueryDetails, DataQueryStageNames
+from statgpt.common.schemas.tool_details import StageDescriptor, StageRules, StagesConfig
+
+
+class TestDataQueryStageNamesDefaults:
+    """The default display names must match the strings used historically as hardcoded
+    literals so that channels that don't configure overrides keep their current display names.
+    Each stage descriptor's `key` must equal the field name."""
+
+    @pytest.mark.parametrize(
+        "field, expected",
+        [
+            ("normalizing_query", "Normalizing Query"),
+            ("extracting_named_entities", "Extracting Named Entities"),
+            ("hybrid_indicators_selection", "Hybrid Indicators Selection"),
+            ("selecting_indicators", "Selecting Indicators"),
+            ("selecting_special_dimensions", "Selecting Special Dimensions"),
+            ("constructing_data_query", "Constructing Data Query"),
+            ("executing_data_query", "Executing Data Query"),
+        ],
+    )
+    def test_default_descriptor_matches_legacy_string(self, field: str, expected: str):
+        stage_names = DataQueryStageNames()
+        descriptor: StageDescriptor = getattr(stage_names, field)
+        assert descriptor.key == field
+        assert descriptor.name == expected
+
+    def test_data_query_details_exposes_pipeline_stage_names(self):
+        details = DataQueryDetails()
+        assert isinstance(details.pipeline_stage_names, DataQueryStageNames)
+        assert details.pipeline_stage_names.normalizing_query.name == "Normalizing Query"
+        assert details.pipeline_stage_names.normalizing_query.key == "normalizing_query"
+
+    def test_yaml_string_override_roundtrip(self):
+        """YAML can override a stage by writing a plain string for its display name."""
+        details = DataQueryDetails.model_validate(
+            {"pipeline_stage_names": {"normalizing_query": "Preparing your query"}}
+        )
+        descriptor = details.pipeline_stage_names.normalizing_query
+        assert descriptor.key == "normalizing_query"
+        assert descriptor.name == "Preparing your query"
+        # Non-overridden fields keep their defaults
+        assert (
+            details.pipeline_stage_names.extracting_named_entities.name
+            == "Extracting Named Entities"
+        )
+
+    def test_user_supplied_key_is_ignored(self):
+        """Even if YAML tries to set `key`, it is locked to the field name."""
+        details = DataQueryDetails.model_validate(
+            {
+                "pipeline_stage_names": {
+                    "normalizing_query": {"key": "bogus_key", "name": "Foo"},
+                }
+            }
+        )
+        descriptor = details.pipeline_stage_names.normalizing_query
+        assert descriptor.key == "normalizing_query"
+        assert descriptor.name == "Foo"
+
+    def test_descriptor_is_debug_delegates_to_stages_config(self):
+        details = DataQueryDetails.model_validate(
+            {
+                "stages_config": {
+                    "debug_only": True,
+                    "rules": [{"key": "normalizing_query", "debug_only": False}],
+                }
+            }
+        )
+        stage_names = details.pipeline_stage_names
+        assert stage_names.normalizing_query.is_debug(details.stages_config) is False
+        assert stage_names.executing_data_query.is_debug(details.stages_config) is True
+
+
+class TestStageRulesValidation:
+    def test_pattern_only_is_valid(self):
+        rule = StageRules(pattern="^Normalizing", debug_only=False)
+        assert rule.pattern == "^Normalizing"
+        assert rule.key is None
+
+    def test_key_only_is_valid(self):
+        rule = StageRules(key="normalizing_query", debug_only=False)
+        assert rule.key == "normalizing_query"
+        assert rule.pattern is None
+
+    def test_both_pattern_and_key_raises(self):
+        with pytest.raises(ValidationError):
+            StageRules(pattern="^Normalizing", key="normalizing_query", debug_only=False)
+
+    def test_neither_pattern_nor_key_raises(self):
+        with pytest.raises(ValidationError):
+            StageRules(debug_only=False)
+
+
+class TestStagesConfigIsStageDebug:
+    def test_default_when_no_rules(self):
+        config = StagesConfig(debug_only=True)
+        assert config.is_stage_debug(key="normalizing_query", name="Normalizing Query") is True
+
+        config = StagesConfig(debug_only=False)
+        assert config.is_stage_debug(key="normalizing_query", name="Normalizing Query") is False
+
+    def test_key_rule_matches_by_key(self):
+        config = StagesConfig(
+            debug_only=True,
+            rules=[StageRules(key="normalizing_query", debug_only=False)],
+        )
+        assert config.is_stage_debug(key="normalizing_query", name="Anything") is False
+
+    def test_key_rule_does_not_match_when_key_mismatches(self):
+        config = StagesConfig(
+            debug_only=True,
+            rules=[StageRules(key="normalizing_query", debug_only=False)],
+        )
+        assert config.is_stage_debug(key="other_key", name="Normalizing Query") is True
+
+    def test_pattern_rule_matches_display_name(self):
+        config = StagesConfig(
+            debug_only=True,
+            rules=[StageRules(pattern="^Normalizing", debug_only=False)],
+        )
+        assert config.is_stage_debug(key="normalizing_query", name="Normalizing Query") is False
+
+    def test_pattern_rule_ignores_key(self):
+        """A pattern rule should not coincidentally match because key string
+        happens to match the regex."""
+        config = StagesConfig(
+            debug_only=True,
+            rules=[StageRules(pattern="^normalizing_query$", debug_only=False)],
+        )
+        # name is the display name, which doesn't match the regex
+        assert config.is_stage_debug(key="normalizing_query", name="Normalizing Query") is True
+
+    def test_first_matching_rule_wins(self):
+        config = StagesConfig(
+            debug_only=True,
+            rules=[
+                StageRules(key="normalizing_query", debug_only=False),
+                StageRules(pattern=".*", debug_only=True),
+            ],
+        )
+        assert config.is_stage_debug(key="normalizing_query", name="Normalizing Query") is False
+
+    def test_backward_compat_pattern_only_yaml(self):
+        """Legacy YAMLs that only define `pattern:` continue to work."""
+        config = StagesConfig.model_validate(
+            {
+                "debug_only": True,
+                "rules": [{"pattern": "^Constructing", "debug_only": False}],
+            }
+        )
+        assert config.is_stage_debug(name="Constructing Data Query") is False
+        assert config.is_stage_debug(name="Other Stage") is True

--- a/tests/unit/common/test_stage_config.py
+++ b/tests/unit/common/test_stage_config.py
@@ -34,8 +34,10 @@ class TestDataQueryStageNamesDefaults:
         assert details.pipeline_stage_names.normalizing_query.name == "Normalizing Query"
         assert details.pipeline_stage_names.normalizing_query.key == "normalizing_query"
 
-    def test_yaml_string_override_roundtrip(self):
-        """YAML can override a stage by writing a plain string for its display name."""
+    def test_yaml_string_override_roundtrip_snake_case(self):
+        """YAML can override a stage by writing a plain string for its display name,
+        using the snake_case field names directly (allowed by `populate_by_name=True`).
+        """
         details = DataQueryDetails.model_validate(
             {"pipeline_stage_names": {"normalizing_query": "Preparing your query"}}
         )
@@ -43,6 +45,22 @@ class TestDataQueryStageNamesDefaults:
         assert descriptor.key == "normalizing_query"
         assert descriptor.name == "Preparing your query"
         # Non-overridden fields keep their defaults
+        assert (
+            details.pipeline_stage_names.extracting_named_entities.name
+            == "Extracting Named Entities"
+        )
+
+    def test_yaml_string_override_roundtrip_camel_case(self):
+        """The string shorthand must also work when YAML uses the camelCase aliases,
+        since `BaseYamlModel` configures `alias_generator=to_camel` and channel YAMLs
+        are written in camelCase (this is the form shown in the docstring example).
+        """
+        details = DataQueryDetails.model_validate(
+            {"pipelineStageNames": {"normalizingQuery": "Preparing your query"}}
+        )
+        descriptor = details.pipeline_stage_names.normalizing_query
+        assert descriptor.key == "normalizing_query"
+        assert descriptor.name == "Preparing your query"
         assert (
             details.pipeline_stage_names.extracting_named_entities.name
             == "Extracting Named Entities"


### PR DESCRIPTION
### Applicable issues
- fixes #409

### Description of changes

- Expose the seven primary non-debug pipeline stages of the `data_query` tool as channel-level configuration under `details.pipelineStageNames`. Each field defaults to its previous hardcoded display name, so existing channels render unchanged.
- Introduce `StageDescriptor` bundling a (configurable) display name with a stable logical key — the key is a private attribute bound to the field name and cannot be overridden from YAML, so chain call sites never hardcode key strings.
- Extend `StagesConfig.rules[]` with an optional `key` field for visibility rules that survive display-name renames. Legacy `pattern:` rules continue to work for backward compatibility.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.