### PR TITLE
fix: allow detaching dataset when embedding model is unavailable #412

### DIFF
--- a/statgpt/admin/auto_update.py
+++ b/statgpt/admin/auto_update.py
@@ -85,7 +85,7 @@ async def _log_results(job_ids: list[int]) -> bool:
     return failed == 0
 
 
-async def _deduplicate_channels(channel_ids: set[int], auth_context: AuthContext) -> None:
+async def _deduplicate_channels(channel_ids: set[int]) -> None:
     """Run deduplication for channels that had a reindex.
 
     NOTE: The number of concurrent executions is limited by the semaphore
@@ -96,9 +96,7 @@ async def _deduplicate_channels(channel_ids: set[int], auth_context: AuthContext
     _log.info(f"Running deduplication for {len(sorted_ids)} channel(s) with reindex: {sorted_ids}")
     results = await asyncio.gather(
         *(
-            deduplicate_dimensions_in_background_task(
-                channel_id=channel_id, auth_context=auth_context
-            )
+            deduplicate_dimensions_in_background_task(channel_id=channel_id)
             for channel_id in sorted_ids
         ),
         return_exceptions=True,
@@ -128,7 +126,7 @@ async def run_auto_update() -> bool:
 
     reindex_channel_ids = await _get_reindex_channel_ids(job_ids)
     if reindex_channel_ids:
-        await _deduplicate_channels(reindex_channel_ids, auth_context)
+        await _deduplicate_channels(reindex_channel_ids)
 
     return await _log_results(job_ids)
 

--- a/statgpt/admin/routers/channel.py
+++ b/statgpt/admin/routers/channel.py
@@ -238,7 +238,7 @@ async def delete_channel(
 ) -> None:
     """Delete channel by id"""
 
-    await ChannelService(session).delete(item_id, auth_context=SystemUserAuthContext())
+    await ChannelService(session).delete(item_id)
 
 
 @router.get("/{channel_id}/datasets")
@@ -334,9 +334,7 @@ async def deduplicate_channel(
     async with get_session_context_manager() as session:
         service = ChannelService(session)
         return await service.deduplicate_all_dimensions(
-            background_tasks=background_tasks,
-            channel_id=channel_id,
-            auth_context=SystemUserAuthContext(),
+            background_tasks=background_tasks, channel_id=channel_id
         )
 
 
@@ -350,11 +348,7 @@ async def get_index_status(
     """Get the index status for the specified channel."""
 
     service = DataSetService(session)
-    return await service.check_index_status(
-        channel_id=channel_id,
-        auth_context=SystemUserAuthContext(),
-        scope=scope,
-    )
+    return await service.check_index_status(channel_id=channel_id, scope=scope)
 
 
 @router.get("/{channel_id}/datasets/{dataset_id}")
@@ -415,9 +409,7 @@ async def reload_indicators_for_channel_dataset(
 
 @router.delete("/{channel_id}/datasets/{dataset_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def remove_channel_dataset(channel_id: int, dataset_id: int):
-    await DataSetService().remove_channel_dataset(
-        channel_id=channel_id, dataset_id=dataset_id, auth_context=SystemUserAuthContext()
-    )
+    await DataSetService().remove_channel_dataset(channel_id=channel_id, dataset_id=dataset_id)
 
 
 @router.get("/{channel_id}/datasets/{dataset_id}/versions")
@@ -487,7 +479,7 @@ async def clear_channel_dataset_versions_data(
 ):
     """Clears the data for all versions except the latest completed one for the specified dataset in the channel."""
     await DataSetService(session).clear_channel_dataset_versions_data(
-        channel_id=channel_id, dataset_id=dataset_id, auth_context=SystemUserAuthContext()
+        channel_id=channel_id, dataset_id=dataset_id
     )
 
 

--- a/statgpt/admin/services/channel.py
+++ b/statgpt/admin/services/channel.py
@@ -113,12 +113,12 @@ class AdminPortalChannelService(ChannelService):
         return ChannelSerializer.db_to_schema(item)
 
     @audit_action(entity_type=AuditEntityType.CHANNEL, action_type=AuditActionType.DELETE)
-    async def delete(self, item_id: int, auth_context: AuthContext) -> schemas.Channel:
+    async def delete(self, item_id: int) -> schemas.Channel:
         item = await self._get_item_or_raise(item_id)
         deleted_item = ChannelSerializer.db_to_schema(item)
         _log.info(f"Deleting {item}")
 
-        await self._clear_vector_store(item, auth_context)
+        await self._clear_vector_store(item)
 
         if self.is_channel_hybrid(deleted_item):
             await self._clear_elastic_indexes(item)
@@ -127,7 +127,7 @@ class AdminPortalChannelService(ChannelService):
         await self._session.flush()
         return deleted_item
 
-    async def _clear_vector_store(self, channel: models.Channel, auth_context: AuthContext) -> None:
+    async def _clear_vector_store(self, channel: models.Channel) -> None:
         vector_store_factory = VectorStoreFactory()
 
         collections = [
@@ -136,10 +136,8 @@ class AdminPortalChannelService(ChannelService):
             channel.special_dimensions_table_name,
         ]
         for collection in collections:
-            vector_store = await vector_store_factory.get_vector_store(
-                collection_name=collection,
-                auth_context=auth_context,
-                embedding_model_name=channel.llm_model,
+            vector_store = await vector_store_factory.get_embedding_free_vector_store(
+                collection_name=collection
             )
             await vector_store.clear()
 
@@ -215,7 +213,7 @@ class AdminPortalChannelService(ChannelService):
         if scope.includes_configs():
             channel_data = await self._load_channel_data_from_zip(zip_file)
             if clean_up:
-                await self._cleanup_existing_channel(channel_data.deployment_id, auth_context)
+                await self._cleanup_existing_channel(channel_data.deployment_id)
             created_channel = await self.create_channel(channel_data)
             await self._session.commit()
             return await self.get_model_by_id(created_channel.id)
@@ -251,15 +249,13 @@ class AdminPortalChannelService(ChannelService):
         _log.info(f"Importing channel: {channel_data!r}")
         return channel_data
 
-    async def _cleanup_existing_channel(
-        self, deployment_id: str, auth_context: AuthContext
-    ) -> None:
+    async def _cleanup_existing_channel(self, deployment_id: str) -> None:
         try:
             existing_channel = await self.get_channel_by_deployment_id(deployment_id)
         except NoResultFound:
             pass  # No channel found, nothing to delete
         else:
-            await self.delete(existing_channel.id, auth_context=auth_context)
+            await self.delete(existing_channel.id)
 
     async def _get_existing_channel_by_deployment_id(
         self, deployment_id: str | None
@@ -271,9 +267,7 @@ class AdminPortalChannelService(ChannelService):
         except NoResultFound:
             raise ValueError(f"Channel with deployment_id {deployment_id} not found during import.")
 
-    async def deduplicate_channel_dimensions(
-        self, channel_id: int, auth_context: AuthContext
-    ) -> None:
+    async def deduplicate_channel_dimensions(self, channel_id: int) -> None:
         """Deduplicates the non-indicator and special dimensions vector stores for the channel.
 
         Deduplication is performed based on document content.
@@ -284,30 +278,25 @@ class AdminPortalChannelService(ChannelService):
             # Extract scalar values while still inside the session scope:
             non_indicator_dims_table = channel.non_indicator_dimensions_table_name
             special_dims_table = channel.special_dimensions_table_name
-            llm_model = channel.llm_model
 
         vector_store_factory = VectorStoreFactory()
 
         _log.info(f"Deduplicating non_indicator_dimensions for channel {channel_id}")
-        non_indicator_dims_store = await vector_store_factory.get_vector_store(
+        non_indicator_dims_store = await vector_store_factory.get_embedding_free_vector_store(
             collection_name=non_indicator_dims_table,
-            auth_context=auth_context,
-            embedding_model_name=llm_model,
         )
         await non_indicator_dims_store.deduplicate_by_document_content()
 
         _log.info(f"Deduplicating special_dimensions for channel {channel_id}")
-        special_dims_store = await vector_store_factory.get_vector_store(
+        special_dims_store = await vector_store_factory.get_embedding_free_vector_store(
             collection_name=special_dims_table,
-            auth_context=auth_context,
-            embedding_model_name=llm_model,
         )
         await special_dims_store.deduplicate_by_document_content()
 
         _log.info(f"Deduplication completed for channel {channel_id}")
 
     async def deduplicate_all_dimensions(
-        self, background_tasks: BackgroundTasks, channel_id: int, auth_context: AuthContext
+        self, background_tasks: BackgroundTasks, channel_id: int
     ) -> schemas.Channel:
         """Deduplicates dimension vector stores for all datasets in a channel.
 
@@ -318,22 +307,15 @@ class AdminPortalChannelService(ChannelService):
         background_tasks.add_task(
             deduplicate_dimensions_in_background_task,
             channel_id=channel_id,
-            auth_context=auth_context,
         )
 
         return ChannelSerializer.db_to_schema(channel)
 
 
 @background_task
-async def deduplicate_dimensions_in_background_task(
-    channel_id: int,
-    auth_context: AuthContext,
-) -> None:
+async def deduplicate_dimensions_in_background_task(channel_id: int) -> None:
     try:
         service = AdminPortalChannelService()
-        await service.deduplicate_channel_dimensions(
-            channel_id=channel_id,
-            auth_context=auth_context,
-        )
+        await service.deduplicate_channel_dimensions(channel_id=channel_id)
     except Exception:
         _log.exception(f"Failed to deduplicate dimensions for channel {channel_id}")

--- a/statgpt/admin/services/channel.py
+++ b/statgpt/admin/services/channel.py
@@ -136,7 +136,7 @@ class AdminPortalChannelService(ChannelService):
             channel.special_dimensions_table_name,
         ]
         for collection in collections:
-            vector_store = await vector_store_factory.get_embedding_free_vector_store(
+            vector_store = await vector_store_factory.get_embeddingless_vector_store(
                 collection_name=collection
             )
             await vector_store.clear()
@@ -282,13 +282,13 @@ class AdminPortalChannelService(ChannelService):
         vector_store_factory = VectorStoreFactory()
 
         _log.info(f"Deduplicating non_indicator_dimensions for channel {channel_id}")
-        non_indicator_dims_store = await vector_store_factory.get_embedding_free_vector_store(
+        non_indicator_dims_store = await vector_store_factory.get_embeddingless_vector_store(
             collection_name=non_indicator_dims_table,
         )
         await non_indicator_dims_store.deduplicate_by_document_content()
 
         _log.info(f"Deduplicating special_dimensions for channel {channel_id}")
-        special_dims_store = await vector_store_factory.get_embedding_free_vector_store(
+        special_dims_store = await vector_store_factory.get_embeddingless_vector_store(
             collection_name=special_dims_table,
         )
         await special_dims_store.deduplicate_by_document_content()

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -46,7 +46,7 @@ from statgpt.common.settings.document import (
 )
 from statgpt.common.utils import async_utils, crc32_hash_incremental_async
 from statgpt.common.utils.elastic import ElasticIndex, ElasticSearchFactory, SearchResult
-from statgpt.common.vectorstore import VectorStore, VectorStoreFactory
+from statgpt.common.vectorstore import VectorStore, VectorStoreEmbeddingFree, VectorStoreFactory
 
 from .background_tasks import background_task
 from .channel import AdminPortalChannelService as ChannelService
@@ -891,9 +891,7 @@ class AdminPortalDataSetService(DataSetService):
 
         return schemas.ChannelDatasetBase.model_validate(item, from_attributes=True)
 
-    async def remove_channel_dataset(
-        self, channel_id: int, dataset_id: int, auth_context: AuthContext
-    ) -> None:
+    async def remove_channel_dataset(self, channel_id: int, dataset_id: int) -> None:
         # Phase A: DB reads
         async with self._scoped_session():
             channel: schemas.Channel = await ChannelService(self._session).get_schema_by_id(
@@ -909,9 +907,7 @@ class AdminPortalDataSetService(DataSetService):
             channel_dataset_id = channel_dataset.id
 
         # Phase B: Clear data — no DB session held
-        await self._clear_channel_dataset_data(
-            channel, auth_context=auth_context, dataset_id=dataset_uuid, version_ids=None
-        )
+        await self._clear_channel_dataset_data(channel, dataset_id=dataset_uuid, version_ids=None)
 
         # Phase C: DB write — delete channel_dataset
         async with self._scoped_session():
@@ -922,15 +918,12 @@ class AdminPortalDataSetService(DataSetService):
     async def _clear_channel_dataset_data(
         self,
         channel: schemas.Channel,
-        auth_context: AuthContext,
         *,
         dataset_id: uuid.UUID | None,
         version_ids: list[int] | None,
     ) -> None:
         """Clears all data related to a dataset or specific versions of a dataset"""
-        await self._clear_vector_stores(
-            channel, auth_context=auth_context, dataset_id=dataset_id, version_ids=version_ids
-        )
+        await self._clear_vector_stores(channel, dataset_id=dataset_id, version_ids=version_ids)
         if ChannelService.is_channel_hybrid(channel):
             await self._clear_elastic_indices(
                 channel, dataset_id=dataset_id, version_ids=version_ids
@@ -939,7 +932,6 @@ class AdminPortalDataSetService(DataSetService):
     async def _clear_vector_stores(
         self,
         channel: schemas.Channel,
-        auth_context: AuthContext,
         dataset_id: uuid.UUID | None,
         version_ids: list[int] | None,
     ) -> None:
@@ -951,10 +943,8 @@ class AdminPortalDataSetService(DataSetService):
             channel.non_indicator_dimensions_table_name,
         ]
         for collection_name in collections:
-            vector_store = await vector_store_factory.get_vector_store(
+            vector_store = await vector_store_factory.get_embedding_free_vector_store(
                 collection_name=collection_name,
-                auth_context=auth_context,
-                embedding_model_name=channel.llm_model,
             )
             await vector_store.remove_documents_by(dataset_id=dataset_id, version_ids=version_ids)
 
@@ -1238,9 +1228,7 @@ class AdminPortalDataSetService(DataSetService):
                 versions_to_clear.append(version.id)
         return versions_to_clear
 
-    async def clear_channel_dataset_versions_data(
-        self, channel_id: int, dataset_id: int, auth_context: AuthContext
-    ):
+    async def clear_channel_dataset_versions_data(self, channel_id: int, dataset_id: int):
         channel: schemas.Channel = await ChannelService(self._session).get_schema_by_id(channel_id)
         dataset: models.DataSet = await self.get_model_by_id(dataset_id)
         channel_dataset = await self.get_channel_dataset_model_or_raise(
@@ -1256,7 +1244,7 @@ class AdminPortalDataSetService(DataSetService):
 
         if versions_to_clear:
             await self._clear_channel_dataset_data(
-                channel, auth_context=auth_context, dataset_id=None, version_ids=versions_to_clear
+                channel, dataset_id=None, version_ids=versions_to_clear
             )
         else:
             _log.info("No versions to clear data for.")
@@ -1389,7 +1377,6 @@ class AdminPortalDataSetService(DataSetService):
             background_tasks.add_task(
                 clear_channel_dataset_data_in_background_task,
                 channel_dataset_id=ch_ds.id,
-                auth_context=auth_context,
             )
             await self._update_channel_dataset_status(
                 ch_ds, StatusEnum.NOT_STARTED, do_commit=False
@@ -1472,7 +1459,6 @@ class AdminPortalDataSetService(DataSetService):
         background_tasks.add_task(
             clear_channel_dataset_data_in_background_task,
             channel_dataset_id=channel_dataset.id,
-            auth_context=auth_context,
         )
         await self._update_channel_dataset_status(channel_dataset, StatusEnum.NOT_STARTED)
 
@@ -1883,9 +1869,7 @@ class AdminPortalDataSetService(DataSetService):
                     version, new_status=StatusEnum.FAILED, reason_for_failure=str(e)
                 )
 
-    async def clear_channel_dataset_data_in_background(
-        self, channel_dataset_id: int, auth_context: AuthContext
-    ) -> None:
+    async def clear_channel_dataset_data_in_background(self, channel_dataset_id: int) -> None:
         _log.info(f"Clear data after reindexing channel_dataset_id={channel_dataset_id}")
         try:
             # Phase A: DB reads — load entities, set status, determine versions to clear
@@ -1908,7 +1892,6 @@ class AdminPortalDataSetService(DataSetService):
             if versions_to_clear:
                 await self._clear_channel_dataset_data(
                     channel,
-                    auth_context=auth_context,
                     dataset_id=None,
                     version_ids=versions_to_clear,
                 )
@@ -1933,9 +1916,9 @@ class AdminPortalDataSetService(DataSetService):
 
     async def _get_deduplication_status_by_versions(
         self,
-        non_indicator_dims_store: VectorStore,
-        special_dims_store: VectorStore,
-        indicator_dims_store: VectorStore,
+        non_indicator_dims_store: VectorStoreEmbeddingFree,
+        special_dims_store: VectorStoreEmbeddingFree,
+        indicator_dims_store: VectorStoreEmbeddingFree,
         versions: set[int],
     ) -> schemas.DeduplicationStatus:
         non_indicator_has_duplicates, non_indicator_count = (
@@ -1962,9 +1945,9 @@ class AdminPortalDataSetService(DataSetService):
 
     async def _get_full_deduplication_status(
         self,
-        non_indicator_dims_store: VectorStore,
-        special_dims_store: VectorStore,
-        indicator_dims_store: VectorStore,
+        non_indicator_dims_store: VectorStoreEmbeddingFree,
+        special_dims_store: VectorStoreEmbeddingFree,
+        indicator_dims_store: VectorStoreEmbeddingFree,
     ) -> schemas.DeduplicationStatus:
         non_indicator_has_duplicates, non_indicator_count = (
             await non_indicator_dims_store.has_duplicates()
@@ -1987,9 +1970,9 @@ class AdminPortalDataSetService(DataSetService):
     async def _check_latest_versions_status(
         self,
         channel: models.Channel,
-        non_indicator_dims_store: VectorStore,
-        special_dims_store: VectorStore,
-        indicator_dims_store: VectorStore,
+        non_indicator_dims_store: VectorStoreEmbeddingFree,
+        special_dims_store: VectorStoreEmbeddingFree,
+        indicator_dims_store: VectorStoreEmbeddingFree,
     ) -> schemas.ChannelIndexStatus:
         latest_successful_versions = await self.get_latest_successful_dataset_versions_for_channel(
             channel_id=channel.id
@@ -2026,9 +2009,9 @@ class AdminPortalDataSetService(DataSetService):
     async def _check_full_index_status(
         self,
         channel: models.Channel,
-        non_indicator_dims_store: VectorStore,
-        special_dims_store: VectorStore,
-        indicator_dims_store: VectorStore,
+        non_indicator_dims_store: VectorStoreEmbeddingFree,
+        special_dims_store: VectorStoreEmbeddingFree,
+        indicator_dims_store: VectorStoreEmbeddingFree,
     ) -> schemas.ChannelIndexStatus:
         deduplication_status = await self._get_full_deduplication_status(
             non_indicator_dims_store,
@@ -2052,27 +2035,20 @@ class AdminPortalDataSetService(DataSetService):
     async def check_index_status(
         self,
         channel_id: int,
-        auth_context: AuthContext,
         scope: schemas.ChannelIndexStatusScope,
     ) -> schemas.ChannelIndexStatus:
         """Checks index status for channel"""
         channel = await ChannelService(self._session).get_model_by_id(channel_id)
         vector_store_factory = VectorStoreFactory()
 
-        non_indicator_dims_store = await vector_store_factory.get_vector_store(
+        non_indicator_dims_store = await vector_store_factory.get_embedding_free_vector_store(
             collection_name=channel.non_indicator_dimensions_table_name,
-            auth_context=auth_context,
-            embedding_model_name=channel.llm_model,
         )
-        special_dims_store = await vector_store_factory.get_vector_store(
+        special_dims_store = await vector_store_factory.get_embedding_free_vector_store(
             collection_name=channel.special_dimensions_table_name,
-            auth_context=auth_context,
-            embedding_model_name=channel.llm_model,
         )
-        indicator_dims_store = await vector_store_factory.get_vector_store(
+        indicator_dims_store = await vector_store_factory.get_embedding_free_vector_store(
             collection_name=channel.indicator_table_name,
-            auth_context=auth_context,
-            embedding_model_name=channel.llm_model,
         )
 
         if scope == schemas.ChannelIndexStatusScope.FULL:
@@ -2430,7 +2406,6 @@ class AdminPortalDataSetService(DataSetService):
 
         await self.clear_channel_dataset_data_in_background(
             channel_dataset_id=params.channel_dataset_id,
-            auth_context=auth_context,
         )
 
         async with self._scoped_session():
@@ -2631,14 +2606,11 @@ async def reload_indicators_in_background_task(
 
 
 @background_task
-async def clear_channel_dataset_data_in_background_task(
-    channel_dataset_id: int, auth_context: AuthContext
-) -> None:
+async def clear_channel_dataset_data_in_background_task(channel_dataset_id: int) -> None:
     try:
         service = AdminPortalDataSetService()
         await service.clear_channel_dataset_data_in_background(
             channel_dataset_id=channel_dataset_id,
-            auth_context=auth_context,
         )
     except Exception as e:
         _log.exception(e)

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -46,7 +46,7 @@ from statgpt.common.settings.document import (
 )
 from statgpt.common.utils import async_utils, crc32_hash_incremental_async
 from statgpt.common.utils.elastic import ElasticIndex, ElasticSearchFactory, SearchResult
-from statgpt.common.vectorstore import VectorStore, VectorStoreEmbeddingFree, VectorStoreFactory
+from statgpt.common.vectorstore import EmbeddinglessVectorStore, VectorStore, VectorStoreFactory
 
 from .background_tasks import background_task
 from .channel import AdminPortalChannelService as ChannelService
@@ -943,7 +943,7 @@ class AdminPortalDataSetService(DataSetService):
             channel.non_indicator_dimensions_table_name,
         ]
         for collection_name in collections:
-            vector_store = await vector_store_factory.get_embedding_free_vector_store(
+            vector_store = await vector_store_factory.get_embeddingless_vector_store(
                 collection_name=collection_name,
             )
             await vector_store.remove_documents_by(dataset_id=dataset_id, version_ids=version_ids)
@@ -1916,9 +1916,9 @@ class AdminPortalDataSetService(DataSetService):
 
     async def _get_deduplication_status_by_versions(
         self,
-        non_indicator_dims_store: VectorStoreEmbeddingFree,
-        special_dims_store: VectorStoreEmbeddingFree,
-        indicator_dims_store: VectorStoreEmbeddingFree,
+        non_indicator_dims_store: EmbeddinglessVectorStore,
+        special_dims_store: EmbeddinglessVectorStore,
+        indicator_dims_store: EmbeddinglessVectorStore,
         versions: set[int],
     ) -> schemas.DeduplicationStatus:
         non_indicator_has_duplicates, non_indicator_count = (
@@ -1945,9 +1945,9 @@ class AdminPortalDataSetService(DataSetService):
 
     async def _get_full_deduplication_status(
         self,
-        non_indicator_dims_store: VectorStoreEmbeddingFree,
-        special_dims_store: VectorStoreEmbeddingFree,
-        indicator_dims_store: VectorStoreEmbeddingFree,
+        non_indicator_dims_store: EmbeddinglessVectorStore,
+        special_dims_store: EmbeddinglessVectorStore,
+        indicator_dims_store: EmbeddinglessVectorStore,
     ) -> schemas.DeduplicationStatus:
         non_indicator_has_duplicates, non_indicator_count = (
             await non_indicator_dims_store.has_duplicates()
@@ -1970,9 +1970,9 @@ class AdminPortalDataSetService(DataSetService):
     async def _check_latest_versions_status(
         self,
         channel: models.Channel,
-        non_indicator_dims_store: VectorStoreEmbeddingFree,
-        special_dims_store: VectorStoreEmbeddingFree,
-        indicator_dims_store: VectorStoreEmbeddingFree,
+        non_indicator_dims_store: EmbeddinglessVectorStore,
+        special_dims_store: EmbeddinglessVectorStore,
+        indicator_dims_store: EmbeddinglessVectorStore,
     ) -> schemas.ChannelIndexStatus:
         latest_successful_versions = await self.get_latest_successful_dataset_versions_for_channel(
             channel_id=channel.id
@@ -2009,9 +2009,9 @@ class AdminPortalDataSetService(DataSetService):
     async def _check_full_index_status(
         self,
         channel: models.Channel,
-        non_indicator_dims_store: VectorStoreEmbeddingFree,
-        special_dims_store: VectorStoreEmbeddingFree,
-        indicator_dims_store: VectorStoreEmbeddingFree,
+        non_indicator_dims_store: EmbeddinglessVectorStore,
+        special_dims_store: EmbeddinglessVectorStore,
+        indicator_dims_store: EmbeddinglessVectorStore,
     ) -> schemas.ChannelIndexStatus:
         deduplication_status = await self._get_full_deduplication_status(
             non_indicator_dims_store,
@@ -2041,13 +2041,13 @@ class AdminPortalDataSetService(DataSetService):
         channel = await ChannelService(self._session).get_model_by_id(channel_id)
         vector_store_factory = VectorStoreFactory()
 
-        non_indicator_dims_store = await vector_store_factory.get_embedding_free_vector_store(
+        non_indicator_dims_store = await vector_store_factory.get_embeddingless_vector_store(
             collection_name=channel.non_indicator_dimensions_table_name,
         )
-        special_dims_store = await vector_store_factory.get_embedding_free_vector_store(
+        special_dims_store = await vector_store_factory.get_embeddingless_vector_store(
             collection_name=channel.special_dimensions_table_name,
         )
-        indicator_dims_store = await vector_store_factory.get_embedding_free_vector_store(
+        indicator_dims_store = await vector_store_factory.get_embeddingless_vector_store(
             collection_name=channel.indicator_table_name,
         )
 

--- a/statgpt/common/vectorstore/__init__.py
+++ b/statgpt/common/vectorstore/__init__.py
@@ -1,3 +1,3 @@
-from .base import VectorStore
+from .base import VectorStore, VectorStoreEmbeddingFree
 from .document import EmbeddedDocument, ScoredVectorStoreDocument
 from .factory import VectorStoreFactory

--- a/statgpt/common/vectorstore/__init__.py
+++ b/statgpt/common/vectorstore/__init__.py
@@ -1,3 +1,3 @@
-from .base import VectorStore, VectorStoreEmbeddingFree
+from .base import EmbeddinglessVectorStore, VectorStore
 from .document import EmbeddedDocument, ScoredVectorStoreDocument
 from .factory import VectorStoreFactory

--- a/statgpt/common/vectorstore/base.py
+++ b/statgpt/common/vectorstore/base.py
@@ -9,24 +9,18 @@ from .document import ScoredVectorStoreDocument
 from .embeddings import EmbeddingModel
 
 
-class VectorStore(ABC):
-    def __init__(
-        self,
-        collection_name: str,
-        embedding_model: EmbeddingModel,
-        **kwargs,
-    ) -> None:
+class VectorStoreEmbeddingFree(ABC):
+    """Narrower vector store interface for operations that do not need an embedding model.
+
+    Use this for delete, status, and dedup paths that should remain available
+    even when the channel's embedding deployment is unreachable.
+    """
+
+    def __init__(self, collection_name: str, **kwargs) -> None:
         self._collection_name = collection_name
-        self._embedding_model = embedding_model
 
     @abstractmethod
     async def clear(self) -> None:
-        pass
-
-    @abstractmethod
-    async def add_documents(
-        self, documents: Iterable[Document], dataset_id: uuid.UUID, version_id: int
-    ) -> None:
         pass
 
     @abstractmethod
@@ -34,17 +28,6 @@ class VectorStore(ABC):
         self, *, dataset_id: uuid.UUID | None = None, version_ids: list[int] | None = None
     ) -> None:
         """Removes all documents by dataset_id or version_ids."""
-
-    @abstractmethod
-    async def search_with_similarity_score(
-        self,
-        query: str,
-        *,
-        k: int = 10,
-        version_ids: set[int],
-        metadata_filters: dict[str, set] | None = None,
-    ) -> list[ScoredVectorStoreDocument]:
-        """For a given query, get its nearest neighbors with similarity scores."""
 
     @abstractmethod
     async def deduplicate_by_document_content(self) -> None:
@@ -69,6 +52,34 @@ class VectorStore(ABC):
     @abstractmethod
     async def get_size_per_version(self, version_ids: set[int]) -> dict[int, int]:
         """Returns the number of documents per version_id."""
+
+
+class VectorStore(VectorStoreEmbeddingFree):
+    def __init__(
+        self,
+        collection_name: str,
+        embedding_model: EmbeddingModel,
+        **kwargs,
+    ) -> None:
+        super().__init__(collection_name, **kwargs)
+        self._embedding_model = embedding_model
+
+    @abstractmethod
+    async def add_documents(
+        self, documents: Iterable[Document], dataset_id: uuid.UUID, version_id: int
+    ) -> None:
+        pass
+
+    @abstractmethod
+    async def search_with_similarity_score(
+        self,
+        query: str,
+        *,
+        k: int = 10,
+        version_ids: set[int],
+        metadata_filters: dict[str, set] | None = None,
+    ) -> list[ScoredVectorStoreDocument]:
+        """For a given query, get its nearest neighbors with similarity scores."""
 
     @abstractmethod
     async def export_to_folder(self, folder_path: str, version_ids: set[int]) -> None:

--- a/statgpt/common/vectorstore/base.py
+++ b/statgpt/common/vectorstore/base.py
@@ -9,7 +9,7 @@ from .document import ScoredVectorStoreDocument
 from .embeddings import EmbeddingModel
 
 
-class VectorStoreEmbeddingFree(ABC):
+class EmbeddinglessVectorStore(ABC):
     """Narrower vector store interface for operations that do not need an embedding model.
 
     Use this for delete, status, and dedup paths that should remain available
@@ -54,7 +54,14 @@ class VectorStoreEmbeddingFree(ABC):
         """Returns the number of documents per version_id."""
 
 
-class VectorStore(VectorStoreEmbeddingFree):
+class VectorStore(EmbeddinglessVectorStore):
+    """Full vector store interface.
+
+    Extends `EmbeddinglessVectorStore` with operations that require an embedding model:
+    ingest (`add_documents`), similarity search (`search_with_similarity_score`),
+    and export/import that round-trip embeddings.
+    """
+
     def __init__(
         self,
         collection_name: str,

--- a/statgpt/common/vectorstore/factory.py
+++ b/statgpt/common/vectorstore/factory.py
@@ -2,9 +2,9 @@ from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.config import multiline_logger as logger
 from statgpt.common.settings.langchain import langchain_settings
 
-from .base import VectorStore
+from .base import VectorStore, VectorStoreEmbeddingFree
 from .embeddings import EmbeddingModels
-from .pg_vector_store import PgVectorStore
+from .pg_vector_store import PgVectorStore, PgVectorStoreEmbeddingFree
 
 
 class VectorStoreFactory:
@@ -13,6 +13,9 @@ class VectorStoreFactory:
     _embedding_models: EmbeddingModels = EmbeddingModels()
     _vector_stores: dict[str, type[VectorStore]] = {
         PG_VECTOR_STORE: PgVectorStore,
+    }
+    _embedding_free_vector_stores: dict[str, type[VectorStoreEmbeddingFree]] = {
+        PG_VECTOR_STORE: PgVectorStoreEmbeddingFree,
     }
 
     def __init__(self, **kwargs):
@@ -35,6 +38,27 @@ class VectorStoreFactory:
             f'Initializing pgvector storage with following options: {storage_name=} {embedding_model=}'
         )
         return self._vector_stores[storage_name](collection_name, embedding_model, **kwargs)
+
+    async def get_embedding_free_vector_store(
+        self,
+        collection_name: str,
+        storage_name: str = PG_VECTOR_STORE,
+        **kwargs,
+    ) -> VectorStoreEmbeddingFree:
+        """Return a vector store that supports only embedding-free operations.
+
+        Use this for delete, status, and dedup paths. It does not resolve an
+        embedding model, so it works even when the channel's embedding deployment
+        is unreachable.
+        """
+        for key, value in self._kwargs.items():
+            if key not in kwargs:
+                kwargs[key] = value
+
+        logger.info(
+            f'Initializing embedding-free pgvector storage with following options: {storage_name=}'
+        )
+        return self._embedding_free_vector_stores[storage_name](collection_name, **kwargs)
 
     def deepcopy(self):
         cls = self.__class__

--- a/statgpt/common/vectorstore/factory.py
+++ b/statgpt/common/vectorstore/factory.py
@@ -2,9 +2,9 @@ from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.config import multiline_logger as logger
 from statgpt.common.settings.langchain import langchain_settings
 
-from .base import VectorStore, VectorStoreEmbeddingFree
+from .base import EmbeddinglessVectorStore, VectorStore
 from .embeddings import EmbeddingModels
-from .pg_vector_store import PgVectorStore, PgVectorStoreEmbeddingFree
+from .pg_vector_store import PgEmbeddinglessVectorStore, PgVectorStore
 
 
 class VectorStoreFactory:
@@ -14,8 +14,8 @@ class VectorStoreFactory:
     _vector_stores: dict[str, type[VectorStore]] = {
         PG_VECTOR_STORE: PgVectorStore,
     }
-    _embedding_free_vector_stores: dict[str, type[VectorStoreEmbeddingFree]] = {
-        PG_VECTOR_STORE: PgVectorStoreEmbeddingFree,
+    _embeddingless_vector_stores: dict[str, type[EmbeddinglessVectorStore]] = {
+        PG_VECTOR_STORE: PgEmbeddinglessVectorStore,
     }
 
     def __init__(self, **kwargs):
@@ -39,13 +39,13 @@ class VectorStoreFactory:
         )
         return self._vector_stores[storage_name](collection_name, embedding_model, **kwargs)
 
-    async def get_embedding_free_vector_store(
+    async def get_embeddingless_vector_store(
         self,
         collection_name: str,
         storage_name: str = PG_VECTOR_STORE,
         **kwargs,
-    ) -> VectorStoreEmbeddingFree:
-        """Return a vector store that supports only embedding-free operations.
+    ) -> EmbeddinglessVectorStore:
+        """Return a vector store that supports only embeddingless operations.
 
         Use this for delete, status, and dedup paths. It does not resolve an
         embedding model, so it works even when the channel's embedding deployment
@@ -56,9 +56,9 @@ class VectorStoreFactory:
                 kwargs[key] = value
 
         logger.info(
-            f'Initializing embedding-free pgvector storage with following options: {storage_name=}'
+            f'Initializing embeddingless pgvector storage with following options: {storage_name=}'
         )
-        return self._embedding_free_vector_stores[storage_name](collection_name, **kwargs)
+        return self._embeddingless_vector_stores[storage_name](collection_name, **kwargs)
 
     def deepcopy(self):
         cls = self.__class__

--- a/statgpt/common/vectorstore/pg_vector_store/__init__.py
+++ b/statgpt/common/vectorstore/pg_vector_store/__init__.py
@@ -1,1 +1,1 @@
-from .pg_vector_store import PgVectorStore
+from .pg_vector_store import PgVectorStore, PgVectorStoreEmbeddingFree

--- a/statgpt/common/vectorstore/pg_vector_store/__init__.py
+++ b/statgpt/common/vectorstore/pg_vector_store/__init__.py
@@ -1,1 +1,1 @@
-from .pg_vector_store import PgVectorStore, PgVectorStoreEmbeddingFree
+from .pg_vector_store import PgEmbeddinglessVectorStore, PgVectorStore

--- a/statgpt/common/vectorstore/pg_vector_store/models.py
+++ b/statgpt/common/vectorstore/pg_vector_store/models.py
@@ -13,6 +13,16 @@ class Base(AsyncAttrs, DeclarativeBase):
     __table_args__ = {"schema": "collections"}
 
 
+class NoEmbeddingsBase(AsyncAttrs, DeclarativeBase):
+    """Separate SQLAlchemy metadata for document models that omit the vector column.
+
+    Lives in its own MetaData so a no-embeddings concrete model can share a
+    `__tablename__` with the full document model without conflicting.
+    """
+
+    __table_args__ = {"schema": "collections"}
+
+
 class BaseModel(IdMixin, DateMixin, Base):
     __abstract__ = True
 
@@ -24,6 +34,18 @@ class BaseDocument(BaseModel):
 
     document: Mapped[str]
     embeddings: Mapped[list[float]] = mapped_column(Vector(None))
+
+
+class BaseDocumentNoEmbeddings(IdMixin, DateMixin, NoEmbeddingsBase):
+    """Document model without the `embeddings` column.
+
+    Used by code paths that only need `id` / `document` (delete, dedup, duplicate checks)
+    so they do not have to know the embedding length and do not require an embedding model.
+    """
+
+    __abstract__ = True  # this line is necessary
+
+    document: Mapped[str]
 
 
 class BaseDocumentMetadata(BaseModel):
@@ -46,6 +68,15 @@ class ModelsStore:
                 name, (BaseDocument,), {"__tablename__": name, "embeddings": embeddings}
             )
         return cls._models[name]
+
+    @classmethod
+    def get_document_no_embeddings_model(cls, name: str) -> type[BaseDocumentNoEmbeddings]:
+        cache_key = f"{name}:no_embeddings"
+        if cache_key not in cls._models:
+            cls._models[cache_key] = type(
+                name, (BaseDocumentNoEmbeddings,), {"__tablename__": name}
+            )
+        return cls._models[cache_key]
 
     @classmethod
     def get_document_metadata_model(cls, name: str) -> type[BaseDocumentMetadata]:

--- a/statgpt/common/vectorstore/pg_vector_store/models.py
+++ b/statgpt/common/vectorstore/pg_vector_store/models.py
@@ -71,10 +71,10 @@ class ModelsStore:
 
     @classmethod
     def get_document_no_embeddings_model(cls, name: str) -> type[BaseDocumentNoEmbeddings]:
-        cache_key = f"{name}:no_embeddings"
+        cache_key = f"{name}__no_embeddings"
         if cache_key not in cls._models:
             cls._models[cache_key] = type(
-                name, (BaseDocumentNoEmbeddings,), {"__tablename__": name}
+                cache_key, (BaseDocumentNoEmbeddings,), {"__tablename__": name}
             )
         return cls._models[cache_key]
 

--- a/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
+++ b/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
@@ -31,24 +31,36 @@ from statgpt.common.settings.document import DimensionValueDocumentMetadataField
 from statgpt.common.utils import batched
 from statgpt.common.utils.llm_call_duration_context import get_llm_call_duration_manager
 from statgpt.common.utils.timer import debug_timer
-from statgpt.common.vectorstore.base import VectorStore
+from statgpt.common.vectorstore.base import VectorStore, VectorStoreEmbeddingFree
 from statgpt.common.vectorstore.document import ScoredVectorStoreDocument
 from statgpt.common.vectorstore.embeddings import EmbeddingModel
 
 from .document_converter import DocumentConverter
-from .models import BaseDocument, BaseDocumentMetadata, BaseModel, ModelsStore
+from .models import (
+    BaseDocument,
+    BaseDocumentMetadata,
+    BaseDocumentNoEmbeddings,
+    BaseModel,
+    ModelsStore,
+)
 
 _log = logging.getLogger(__name__)
 
 
-class PgVectorStore(VectorStore):
+class PgVectorStoreEmbeddingFree(VectorStoreEmbeddingFree):
+    """Postgres implementation of `VectorStoreEmbeddingFree`.
+
+    Implements only the operations that can run without an embedding model
+    (clear, delete, dedup, status). The full `PgVectorStore` subclass adds
+    ingest/search/export/import on top.
+    """
+
     def __init__(
         self,
         collection_name: str,
-        embedding_model: EmbeddingModel,
         **kwargs,
     ):
-        super().__init__(collection_name, embedding_model, **kwargs)
+        super().__init__(collection_name, **kwargs)
         self._postgres_settings = PostgresSettings()
 
     @property
@@ -59,12 +71,9 @@ class PgVectorStore(VectorStore):
     def _metadata_table_name(self) -> str:
         return f"{self._table_name}_metadata"
 
-    async def _get_document_model(self) -> type[BaseDocument]:
-        with debug_timer("_get_document_model.model"):
-            model = ModelsStore.get_document_model(
-                self._table_name, self._embedding_model.embedding_length
-            )
-        return model
+    async def _get_document_no_embeddings_model(self) -> type[BaseDocumentNoEmbeddings]:
+        with debug_timer("_get_document_no_embeddings_model.model"):
+            return ModelsStore.get_document_no_embeddings_model(self._table_name)
 
     async def _get_metadata_model(self) -> type[BaseDocumentMetadata]:
         with debug_timer("_get_metadata_model.model"):
@@ -251,52 +260,6 @@ class PgVectorStore(VectorStore):
             for lock_key in lock_keys:
                 await self._release_dataset_lock(session, lock_key)
 
-    async def add_documents(
-        self, documents: Iterable[Document], dataset_id: uuid.UUID, version_id: int
-    ) -> None:
-        # Phase 1: Compute ALL embeddings outside any session
-        batches_with_embeddings: list[tuple[list[Document], list[list[float]]]] = []
-        for batch in batched(documents, self._postgres_settings.batch_size):
-            embeddings = await self._embedding_model.model.aembed_documents(
-                [doc.page_content for doc in batch]
-            )
-            batches_with_embeddings.append((batch, embeddings))
-
-        # Phase 2: DB writes in a single session (advisory lock + inserts)
-        async with get_session_context_manager() as session:
-            async with self._dataset_lock(session, dataset_id):
-                document_model: type[BaseDocument] = await self._get_document_model()
-                metadata_model: type[BaseDocumentMetadata] = await self._get_metadata_model()
-
-                await self._create_table_if_not_exist(session, document_model)
-                await self._create_table_if_not_exist(session, metadata_model)
-
-                for batch, embeddings in batches_with_embeddings:
-                    items = [
-                        document_model(
-                            document=self._sanitize_text(doc.page_content),
-                            embeddings=emb,
-                        )
-                        for doc, emb in zip(batch, embeddings)
-                    ]
-
-                    session.add_all(items)
-                    await session.commit()
-                    _log.info(f"Added {len(items)} documents")
-
-                    mappings = [
-                        metadata_model(
-                            document_id=item.id,
-                            dataset_id=dataset_id,
-                            version_id=version_id,
-                            details=self._sanitize_metadata(doc.metadata),
-                        )
-                        for item, doc in zip(items, batch)
-                    ]
-                    session.add_all(mappings)
-                    await session.commit()
-                    _log.info(f"Added {len(mappings)} document mappings")
-
     async def _get_dataset_ids_by_version_ids(
         self, session: AsyncSession, version_ids: list[int]
     ) -> list[uuid.UUID]:
@@ -369,7 +332,7 @@ class PgVectorStore(VectorStore):
         Should be called within the same transaction as metadata deletion
         to ensure atomicity and prevent race conditions.
         """
-        doc_model: type[BaseDocument] = await self._get_document_model()
+        doc_model: type[BaseDocumentNoEmbeddings] = await self._get_document_no_embeddings_model()
         metadata_model: type[BaseDocumentMetadata] = await self._get_metadata_model()
 
         query = (
@@ -383,87 +346,6 @@ class PgVectorStore(VectorStore):
         _log.info(
             f"Deleted {len(deleted_ids)} documents without mapping from {doc_model.__tablename__!r} table"
         )
-
-    async def search_with_similarity_score(
-        self,
-        query: str,
-        *,
-        k: int = 10,
-        version_ids: set[int],
-        metadata_filters: dict[str, set] | None = None,
-    ) -> list[ScoredVectorStoreDocument]:
-
-        with debug_timer("vector_store._get_document_model"):
-            model = await self._get_document_model()
-
-        with debug_timer("vector_store._get_mapping_model"):
-            mapping_model = await self._get_metadata_model()
-
-        # Embedding computation outside any session
-        with debug_timer("vector_store.prepare_embeddings"):
-            embed_start = time.monotonic()
-            embedding = (await self._embedding_model.model.aembed_documents([query]))[0]
-            embed_duration = time.monotonic() - embed_start
-
-        duration_manager = get_llm_call_duration_manager()
-        if duration_manager is not None:
-            duration_manager.add_duration(
-                LLMCallDurationItem(
-                    deployment=self._embedding_model.name,
-                    duration_s=embed_duration,
-                )
-            )
-
-        with debug_timer("vector_store.prepare_sql_query"):
-
-            if self._embedding_model.is_normalized_to_one:
-                distance = model.embeddings.max_inner_product(embedding)
-            else:
-                distance = model.embeddings.cosine_distance(embedding)
-
-            matching_docs_query = select(mapping_model.document_id.distinct()).where(
-                mapping_model.version_id.in_(version_ids)
-            )
-            if metadata_filters:
-                for field, values in metadata_filters.items():
-                    matching_docs_query = matching_docs_query.where(
-                        mapping_model.details[field].astext.in_(values)
-                    )
-
-            # Distance is calculated once per document, not per metadata record
-            top_k_docs_cte = (
-                select(model.id.label("doc_id"), distance.label("distance"))
-                .where(model.id.in_(matching_docs_query.scalar_subquery()))
-                .order_by(distance)
-                .limit(k)
-                .cte("top_k_docs")
-            )
-
-            sql_query = (
-                select(model, mapping_model, top_k_docs_cte.c.distance)
-                .select_from(top_k_docs_cte)
-                .join(model, model.id == top_k_docs_cte.c.doc_id)
-                .join(mapping_model, mapping_model.document_id == top_k_docs_cte.c.doc_id)
-                .where(mapping_model.version_id.in_(version_ids))
-                .order_by(top_k_docs_cte.c.distance, mapping_model.id)
-            )
-
-        # DB query in its own session
-        with debug_timer("vector_store.search.sql"):
-            async with get_readonly_session_context_manager() as session:
-                res = await session.execute(sql_query)
-
-        with debug_timer("vector_store.search.process"):
-            # `1 - cosine distance` gives cosine similarity score.
-            # NOTE: for other distances, formula to get similarity score is different.
-            # see notes for similar functions above.
-            result = [
-                DocumentConverter.to_scored_vector_store_document(
-                    pg_document=doc, pg_metadata=meta, score=(1 - dist)
-                )
-                for doc, meta, dist in res.all()
-            ]
-        return result
 
     async def get_dataset_ids_by_documents_ids(self, ids: Iterable[int]) -> list[uuid.UUID]:
         model = await self._get_metadata_model()
@@ -509,7 +391,7 @@ class PgVectorStore(VectorStore):
 
     async def has_duplicates(self) -> tuple[bool, int]:
         """Checks if there are duplicate documents based on document content."""
-        document_model = await self._get_document_model()
+        document_model = await self._get_document_no_embeddings_model()
         metadata_model = await self._get_metadata_model()
 
         async with get_readonly_session_context_manager() as session:
@@ -539,7 +421,7 @@ class PgVectorStore(VectorStore):
         Returns:
             tuple[bool, int]: (has_duplicates, duplicate_count)
         """
-        document_model = await self._get_document_model()
+        document_model = await self._get_document_no_embeddings_model()
         metadata_model = await self._get_metadata_model()
 
         async with get_readonly_session_context_manager() as session:
@@ -631,8 +513,8 @@ class PgVectorStore(VectorStore):
             3. Remaps all metadata references from duplicates to the keeper (lowest document_id)
             4. Deletes orphaned duplicate documents
         """
-        with debug_timer("deduplicate_content._get_document_model"):
-            document_model = await self._get_document_model()
+        with debug_timer("deduplicate_content._get_document_no_embeddings_model"):
+            document_model = await self._get_document_no_embeddings_model()
 
         with debug_timer("deduplicate_content._get_metadata_model"):
             metadata_model = await self._get_metadata_model()
@@ -699,6 +581,153 @@ class PgVectorStore(VectorStore):
             except Exception:
                 _log.exception("Content deduplication failed. Transaction will be rolled back.")
                 raise
+
+
+class PgVectorStore(PgVectorStoreEmbeddingFree, VectorStore):
+    """Full Postgres vector store with ingest, search, export, and import on top of the
+    embedding-free operations from `PgVectorStoreEmbeddingFree`.
+    """
+
+    def __init__(
+        self,
+        collection_name: str,
+        embedding_model: EmbeddingModel,
+        **kwargs,
+    ):
+        super().__init__(collection_name, embedding_model=embedding_model, **kwargs)
+
+    async def _get_document_model(self) -> type[BaseDocument]:
+        with debug_timer("_get_document_model.model"):
+            return ModelsStore.get_document_model(
+                self._table_name, self._embedding_model.embedding_length
+            )
+
+    async def add_documents(
+        self, documents: Iterable[Document], dataset_id: uuid.UUID, version_id: int
+    ) -> None:
+        # Phase 1: Compute ALL embeddings outside any session
+        batches_with_embeddings: list[tuple[list[Document], list[list[float]]]] = []
+        for batch in batched(documents, self._postgres_settings.batch_size):
+            embeddings = await self._embedding_model.model.aembed_documents(
+                [doc.page_content for doc in batch]
+            )
+            batches_with_embeddings.append((batch, embeddings))
+
+        # Phase 2: DB writes in a single session (advisory lock + inserts)
+        async with get_session_context_manager() as session:
+            async with self._dataset_lock(session, dataset_id):
+                document_model: type[BaseDocument] = await self._get_document_model()
+                metadata_model: type[BaseDocumentMetadata] = await self._get_metadata_model()
+
+                await self._create_table_if_not_exist(session, document_model)
+                await self._create_table_if_not_exist(session, metadata_model)
+
+                for batch, embeddings in batches_with_embeddings:
+                    items = [
+                        document_model(
+                            document=self._sanitize_text(doc.page_content),
+                            embeddings=emb,
+                        )
+                        for doc, emb in zip(batch, embeddings)
+                    ]
+
+                    session.add_all(items)
+                    await session.commit()
+                    _log.info(f"Added {len(items)} documents")
+
+                    mappings = [
+                        metadata_model(
+                            document_id=item.id,
+                            dataset_id=dataset_id,
+                            version_id=version_id,
+                            details=self._sanitize_metadata(doc.metadata),
+                        )
+                        for item, doc in zip(items, batch)
+                    ]
+                    session.add_all(mappings)
+                    await session.commit()
+                    _log.info(f"Added {len(mappings)} document mappings")
+
+    async def search_with_similarity_score(
+        self,
+        query: str,
+        *,
+        k: int = 10,
+        version_ids: set[int],
+        metadata_filters: dict[str, set] | None = None,
+    ) -> list[ScoredVectorStoreDocument]:
+
+        with debug_timer("vector_store._get_document_model"):
+            model = await self._get_document_model()
+
+        with debug_timer("vector_store._get_mapping_model"):
+            mapping_model = await self._get_metadata_model()
+
+        # Embedding computation outside any session
+        with debug_timer("vector_store.prepare_embeddings"):
+            embed_start = time.monotonic()
+            embedding = (await self._embedding_model.model.aembed_documents([query]))[0]
+            embed_duration = time.monotonic() - embed_start
+
+        duration_manager = get_llm_call_duration_manager()
+        if duration_manager is not None:
+            duration_manager.add_duration(
+                LLMCallDurationItem(
+                    deployment=self._embedding_model.name,
+                    duration_s=embed_duration,
+                )
+            )
+
+        with debug_timer("vector_store.prepare_sql_query"):
+
+            if self._embedding_model.is_normalized_to_one:
+                distance = model.embeddings.max_inner_product(embedding)
+            else:
+                distance = model.embeddings.cosine_distance(embedding)
+
+            matching_docs_query = select(mapping_model.document_id.distinct()).where(
+                mapping_model.version_id.in_(version_ids)
+            )
+            if metadata_filters:
+                for field, values in metadata_filters.items():
+                    matching_docs_query = matching_docs_query.where(
+                        mapping_model.details[field].astext.in_(values)
+                    )
+
+            # Distance is calculated once per document, not per metadata record
+            top_k_docs_cte = (
+                select(model.id.label("doc_id"), distance.label("distance"))
+                .where(model.id.in_(matching_docs_query.scalar_subquery()))
+                .order_by(distance)
+                .limit(k)
+                .cte("top_k_docs")
+            )
+
+            sql_query = (
+                select(model, mapping_model, top_k_docs_cte.c.distance)
+                .select_from(top_k_docs_cte)
+                .join(model, model.id == top_k_docs_cte.c.doc_id)
+                .join(mapping_model, mapping_model.document_id == top_k_docs_cte.c.doc_id)
+                .where(mapping_model.version_id.in_(version_ids))
+                .order_by(top_k_docs_cte.c.distance, mapping_model.id)
+            )
+
+        # DB query in its own session
+        with debug_timer("vector_store.search.sql"):
+            async with get_readonly_session_context_manager() as session:
+                res = await session.execute(sql_query)
+
+        with debug_timer("vector_store.search.process"):
+            # `1 - cosine distance` gives cosine similarity score.
+            # NOTE: for other distances, formula to get similarity score is different.
+            # see notes for similar functions above.
+            result = [
+                DocumentConverter.to_scored_vector_store_document(
+                    pg_document=doc, pg_metadata=meta, score=(1 - dist)
+                )
+                for doc, meta, dist in res.all()
+            ]
+        return result
 
     async def _export_documents_to_file(
         self,

--- a/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
+++ b/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
@@ -31,7 +31,7 @@ from statgpt.common.settings.document import DimensionValueDocumentMetadataField
 from statgpt.common.utils import batched
 from statgpt.common.utils.llm_call_duration_context import get_llm_call_duration_manager
 from statgpt.common.utils.timer import debug_timer
-from statgpt.common.vectorstore.base import VectorStore, VectorStoreEmbeddingFree
+from statgpt.common.vectorstore.base import EmbeddinglessVectorStore, VectorStore
 from statgpt.common.vectorstore.document import ScoredVectorStoreDocument
 from statgpt.common.vectorstore.embeddings import EmbeddingModel
 
@@ -47,8 +47,8 @@ from .models import (
 _log = logging.getLogger(__name__)
 
 
-class PgVectorStoreEmbeddingFree(VectorStoreEmbeddingFree):
-    """Postgres implementation of `VectorStoreEmbeddingFree`.
+class PgEmbeddinglessVectorStore(EmbeddinglessVectorStore):
+    """Postgres implementation of `EmbeddinglessVectorStore`.
 
     Implements only the operations that can run without an embedding model
     (clear, delete, dedup, status). The full `PgVectorStore` subclass adds
@@ -583,9 +583,9 @@ class PgVectorStoreEmbeddingFree(VectorStoreEmbeddingFree):
                 raise
 
 
-class PgVectorStore(PgVectorStoreEmbeddingFree, VectorStore):
+class PgVectorStore(PgEmbeddinglessVectorStore, VectorStore):
     """Full Postgres vector store with ingest, search, export, and import on top of the
-    embedding-free operations from `PgVectorStoreEmbeddingFree`.
+    embeddingless operations from `PgEmbeddinglessVectorStore`.
     """
 
     def __init__(

--- a/tests/integration/services/test_channels.py
+++ b/tests/integration/services/test_channels.py
@@ -2,7 +2,6 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy.exc import NoResultFound
 
-from statgpt.admin.auth.auth_context import SystemUserAuthContext
 from statgpt.admin.services import AdminPortalChannelService as ChannelService
 from statgpt.common import schemas
 from statgpt.common.schemas.data_query_tool import DataQueryPrompts
@@ -273,7 +272,7 @@ async def test_delete_channel(session, clear_channels):
     channels = await channel_service.get_channels_schemas(100, 0)
     assert channels == [res]
 
-    await channel_service.delete(res.id, auth_context=SystemUserAuthContext())
+    await channel_service.delete(res.id)
 
     with pytest.raises(HTTPException) as e:
         await channel_service.get_schema_by_id(res.id)


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #412

### Description of changes

<!-- Please explain the changes you made right below this line. -->
`DELETE /channels/{channel_id}/datasets/{dataset_id}` failed when the channel's embedding deployment was unreachable: `VectorStoreFactory.get_vector_store` eagerly resolved the embedding model via DIAL Core and raised before any cleanup ran. The actual delete SQL in `PgVectorStore.remove_documents_by` never uses embeddings — only `_get_document_model`'s `Vector(embedding_length)` column tied the path to the deployment.

Split the interface so embedding-free operations don't require DIAL:

- New `VectorStoreEmbeddingFree` protocol exposes only ops that don't need embeddings (`clear`, `remove_documents_by`, `has_duplicates`, size getters, `deduplicate_by_document_content`). `VectorStore` extends it with the embedding-requiring methods.
- New `VectorStoreFactory.get_embedding_free_vector_store(...)` constructs the narrower store without contacting DIAL.
- Migrated admin callers that only use embedding-free ops (`_clear_vector_stores`, `check_index_status`, `_clear_vector_store`, `deduplicate_channel_dimensions`) and dropped the now-unused `auth_context` plumbing along their call chains.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
