### PR TITLE
fix: pass bearer_token_required to auth context in MCP provider #415

### DIFF
--- a/statgpt/app/mcp/provider.py
+++ b/statgpt/app/mcp/provider.py
@@ -90,11 +90,14 @@ class ChannelToolProvider(Provider):
     """MCP Provider that dynamically serves tools from a StatGPT channel config."""
 
     async def _resolve_context(self, request: Request) -> tuple[AuthContext, ChannelServiceFacade]:
-        auth_context = await create_auth_context(DialAuthCredentials.from_headers(request.headers))
         deployment_id = request.path_params.get("deployment_id")
         if not deployment_id:
             raise ValueError("Missing deployment_id in path")
         channel_service = await ChannelServiceFacade.get_channel(deployment_id)
+        auth_context = await create_auth_context(
+            DialAuthCredentials.from_headers(request.headers),
+            bearer_token_required=channel_service.channel_config.bearer_token_required,
+        )
         return auth_context, channel_service
 
     def _create_mcp_tool(


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #415 

### Description of changes

<!-- Please explain the changes you made right below this line. -->
The MCP provider's `_resolve_context` called `create_auth_context` without forwarding `bearer_token_required`, so the parameter defaulted to `False`. This skipped the system-role check and always produced a `UserAuthContext` with `dial_access_token=None` when no bearer token was present, causing downstream `QuanthubAuthorizer` calls to fail with `AuthorizationError: DIAL access token is required for user authorization` — even for API keys with a role permitted to access the channel as a system user.

The MCP provider now resolves the channel first, then passes `channel_service.channel_config.bearer_token_required` into `create_auth_context`, matching the behavior of `channel_completion.configuration`, `_channel_completion`, and `channel_onboarding_completion`.

Side effect (intended): API keys that lack a system-access role on a channel with `bearer_token_required: true` no longer see the channel's MCP tools — the role check now runs as it does for the non-MCP endpoints.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
