### PR TITLE
fix: SDMX 3.0 proxy data queries request attributes=all #419

### DIFF
--- a/statgpt/common/data/sdmx/common/query.py
+++ b/statgpt/common/data/sdmx/common/query.py
@@ -60,16 +60,28 @@ class SdmxDataSetQuery(BaseModel):
             key[dimension_id] = values
         return key
 
-    def get_params(self) -> dict:
-        result = {
-            "detail": "full",
-        }
+    def get_params_v21(self) -> dict:
+        """SDMX 2.1 REST data query params."""
+        result = {"detail": "full"}
         if self.time_dimension_query:
             if self.time_dimension_query.start_period:
                 result['startPeriod'] = self.time_dimension_query.start_period
             if self.time_dimension_query.end_period:
                 result['endPeriod'] = self.time_dimension_query.end_period
         return result
+
+    def get_params_v30(self) -> dict:
+        """SDMX 3.0 REST data query params (proxy)."""
+        params: dict = {"attributes": "all"}
+        time_filters: list[str] = []
+        if self.time_dimension_query:
+            if self.time_dimension_query.start_period:
+                time_filters.append(f"ge:{self.time_dimension_query.start_period}")
+            if self.time_dimension_query.end_period:
+                time_filters.append(f"le:{self.time_dimension_query.end_period}")
+        if time_filters:
+            params["c[TIME_PERIOD]"] = "+".join(time_filters)
+        return params
 
     def merge(self, other: 'SdmxDataSetQuery') -> 'SdmxDataSetQuery':
         """Create a new query by merging two queries.

--- a/statgpt/common/data/sdmx/common/query.py
+++ b/statgpt/common/data/sdmx/common/query.py
@@ -60,7 +60,7 @@ class SdmxDataSetQuery(BaseModel):
             key[dimension_id] = values
         return key
 
-    def get_params_v21(self) -> dict:
+    def get_params_v21(self) -> dict[str, str]:
         """SDMX 2.1 REST data query params."""
         result = {"detail": "full"}
         if self.time_dimension_query:
@@ -70,9 +70,9 @@ class SdmxDataSetQuery(BaseModel):
                 result['endPeriod'] = self.time_dimension_query.end_period
         return result
 
-    def get_params_v30(self) -> dict:
+    def get_params_v30(self) -> dict[str, str]:
         """SDMX 3.0 REST data query params (proxy)."""
-        params: dict = {"attributes": "all"}
+        params: dict[str, str] = {"attributes": "all"}
         time_filters: list[str] = []
         if self.time_dimension_query:
             if self.time_dimension_query.start_period:
@@ -80,7 +80,8 @@ class SdmxDataSetQuery(BaseModel):
             if self.time_dimension_query.end_period:
                 time_filters.append(f"le:{self.time_dimension_query.end_period}")
         if time_filters:
-            params["c[TIME_PERIOD]"] = "+".join(time_filters)
+            time_dimension_id = self.time_dimension_query.time_dimension_id  # type: ignore[union-attr]
+            params[f"c[{time_dimension_id}]"] = "+".join(time_filters)
         return params
 
     def merge(self, other: 'SdmxDataSetQuery') -> 'SdmxDataSetQuery':

--- a/statgpt/common/data/sdmx/v21/dataset.py
+++ b/statgpt/common/data/sdmx/v21/dataset.py
@@ -1211,7 +1211,7 @@ class Sdmx21DataSet(
         return await asyncio.to_thread(self._include_attributes_sync, df)
 
     def _get_query_params(self, sdmx_query: SdmxDataSetQuery) -> dict:
-        return sdmx_query.get_params()
+        return sdmx_query.get_params_v21()
 
     async def _query_sdmx_data(
         self, sdmx_query: SdmxDataSetQuery, auth_context: AuthContext
@@ -1334,7 +1334,7 @@ class Sdmx21DataSet(
             provider=provider,
             flow_ref=flow_ref,
             key=key_string,
-            params=sdmx_query.get_params(),
+            params=sdmx_query.get_params_v21(),
             suffix=suffix,
         )
 

--- a/statgpt/common/data/statgpt_sdmx_proxy/v30/dataset.py
+++ b/statgpt/common/data/statgpt_sdmx_proxy/v30/dataset.py
@@ -45,11 +45,7 @@ class StatGptSdmxProxyDataSet(UpdatedAtMixin, Sdmx21DataSet):
         self._annotations = list(annotations)
 
     def _get_query_params(self, sdmx_query: SdmxDataSetQuery) -> dict:
-        params = sdmx_query.get_params()
-        if "detail" in params:
-            params = dict(params)
-            params.pop("detail", None)
-        return params
+        return sdmx_query.get_params_v30()
 
     def _get_annotation_by_id(self, annotation_id: str) -> Sdmx30AnnotationModel | None:
         return next((a for a in self._annotations if a.id == annotation_id), None)

--- a/statgpt/common/data/statgpt_sdmx_proxy/v30/reader.py
+++ b/statgpt/common/data/statgpt_sdmx_proxy/v30/reader.py
@@ -1,26 +1,28 @@
 """SDMX-JSON data message reader supporting both proxy and standard SDMX 3.0 APIs.
 
-Supports two SDMX-JSON data message variants:
+Both the ``dimensionGroup`` attribute category and the ``dimensionGroupAttributes``
+data container are part of the standard SDMX-JSON 2.0.0 data schema — the schema
+permits the attribute levels ``dataSet``, ``dimensionGroup``, ``series`` and
+``observation``, and a ``dataSet`` may carry ``attributes``,
+``dimensionGroupAttributes``, ``series`` and ``observations``.  The reader
+therefore supports both variants seen in practice:
 
 1. **Proxy SDMX-JSON** (e.g. IMF proxy API):
 
-   - Attributes may use the ``dimensionGroup`` category in addition to ``series``
-     and ``observation``.
-   - ``dimensionGroup`` attributes appear in the structure metadata but are **not**
-     indexed in the series-level data attribute arrays.  Only ``series``-level
-     attributes have corresponding positions in those arrays.
+   - Group attributes use the ``dimensionGroup`` category and their values are
+     carried in ``dataSets[].dimensionGroupAttributes``, keyed by a partial
+     dimension key (e.g. ``"0:0::"`` for COUNTRY+INDICATOR, ``":0::"`` for
+     INDICATOR only).  They are **not** indexed in the series-level data
+     attribute arrays — only ``series``-level attributes are.
    - Observation dimension values may use the uncoded ``{"value": "2026"}`` syntax.
    - Uncoded attribute values (e.g. ``COUNTRY_UPDATE_DATE``) may appear as raw
      strings directly in the data attribute arrays rather than integer indices.
 
-2. **Standard SDMX-JSON 2.0.0** (SDMX 3.0):
+2. **Standard / alternative SDMX-JSON 2.0.0** (some SDMX 3.0 servers):
 
-   - Attributes are categorised as ``dataSet`` (or ``dataset``), ``series``,
-     ``observation``.  There is **no** ``dimensionGroup`` category.  Attributes
-     that the proxy format places under ``dimensionGroup`` are instead listed
-     under ``series`` with their ``relationship.dimensions`` metadata preserved.
-   - Because all dimension-related attributes are under ``series``, the data
-     attribute arrays for each series contain positions for **all** series-level
+   - Servers may omit ``dimensionGroup`` and instead list those attributes under
+     ``series`` with their ``relationship.dimensions`` metadata preserved.  The
+     per-series data attribute arrays then carry positions for **all** series
      attributes, producing longer arrays with many ``null`` entries for
      attributes whose coded values don't apply to the given series.
    - Dimension values always use the coded ``{"id": "2026", "name": "2026"}``
@@ -83,9 +85,9 @@ are not accepted by :class:`Code` and would raise :exc:`TypeError`.
 class StatGptSdmxProxyDataReader(Reader):
     """Read SDMX-JSON and expose it as instances from :mod:`sdmx.model`.
 
-    Handles both the proxy SDMX-JSON format (with ``dimensionGroup`` attribute
-    category) and the standard SDMX-JSON 2.0.0 format (where all
-    dimension-related attributes are under ``series``).
+    Handles group attributes carried in ``dimensionGroupAttributes`` (proxy
+    SDMX-JSON, using the standard ``dimensionGroup`` category) as well as the
+    variant where servers fold those attributes under ``series`` instead.
 
     See the module docstring for a detailed comparison of both formats.
     """
@@ -234,10 +236,18 @@ class StatGptSdmxProxyDataReader(Reader):
         )
         ds.attrib.update(self._make_dataset_level_attrs(root.get("attributes", [])))
 
+        # Proxy format only: attributes grouped by a subset of the series
+        # dimensions (e.g. per INDICATOR or per COUNTRY+INDICATOR).  Each group
+        # is applied to every series whose key matches the group's partial key.
+        dim_group_attrs = self._make_dimension_group_attrs(root.get("dimensionGroupAttributes", {}))
+
         # Process series
         for key_values, elem in root.get("series", {}).items():
             series_key = self._make_key("series", key_values, base=ds_key)
             series_key.attrib = self._make_attrs("series", elem.get("attributes", []))
+            for dim_filter, attrs in dim_group_attrs:
+                if self._series_matches_dimension_group(series_key, dim_filter):
+                    series_key.attrib.update(attrs)
             ds.add_obs(self.read_obs(elem, series_key=series_key), series_key)
 
         # Process bare observations
@@ -328,7 +338,7 @@ class StatGptSdmxProxyDataReader(Reader):
             return AttributeValue(value=raw, value_for=attr)
 
         if isinstance(raw, list):
-            joined = ", ".join(str(v) for v in raw if v is not None) or None
+            joined = _inline_attr_text(raw)
             if joined is None:
                 return AttributeValue(value=None, value_for=attr)  # type: ignore[arg-type]
             return AttributeValue(value=joined, value_for=attr)
@@ -340,6 +350,94 @@ class StatGptSdmxProxyDataReader(Reader):
         if not len(coded) or raw >= len(coded):
             return AttributeValue(value=None, value_for=attr)  # type: ignore[arg-type]
         return coded[raw]
+
+    def _make_dimension_group_attrs(
+        self, raw: dict[str, list[Any]]
+    ) -> list[tuple[dict[str, str | None], dict[str, AttributeValue]]]:
+        """Resolve ``dataSets[].dimensionGroupAttributes`` into ``(filter, attrs)`` pairs.
+
+        Group attributes (SDMX-JSON 2.0.0 ``dimensionGroup`` category) are attached
+        to a *subset* of the series dimensions.  Each entry is keyed by a partial
+        dimension key (e.g. ``"0:0::"`` for the COUNTRY+INDICATOR group, ``":0::"``
+        for the INDICATOR-only group); empty segments are wildcards.  The value
+        array aligns positionally to the ``dimensionGroup`` attributes declared in
+        the structure, using the same encoding as :meth:`_resolve_dataset_level_slot`
+        (``null``, an integer index into the coded value list, or an inline list).
+
+        Returns ``(dim_filter, attrs)`` pairs where ``dim_filter`` maps a dimension
+        id to the required dimension value for each non-wildcard position, and
+        ``attrs`` is the resolved attribute dict applied to every matching series.
+        """
+        if not raw:
+            return []
+
+        dg_attrs = [
+            a for a in self.msg.structure.attributes if self._attr_level[a] == "dimensionGroup"
+        ]
+        dims_ordered = sorted(self.msg.structure.dimensions, key=lambda d: d.order)
+
+        resolved: list[tuple[dict[str, str | None], dict[str, AttributeValue]]] = []
+        for partial_key, values in raw.items():
+            dim_filter = self._dimension_group_filter(partial_key, dims_ordered)
+            attrs: dict[str, AttributeValue] = {}
+            for slot, attr in zip(values, dg_attrs):
+                if slot is None:
+                    continue
+                av = self._resolve_dataset_level_slot(attr, slot)
+                if av is not None and av.value is not None:
+                    attrs[attr.id] = av
+            if attrs:
+                resolved.append((dim_filter, attrs))
+        return resolved
+
+    def _dimension_group_filter(
+        self, partial_key: str, dims_ordered: list[Any]
+    ) -> dict[str, str | None]:
+        """Map a partial dimension key (``"0:0::"``) to ``{dim_id: dim_value}``.
+
+        Each colon-separated segment is an index into the dimension's value list
+        at the matching ``keyPosition``; empty segments are wildcards and omitted.
+        """
+        dim_filter: dict[str, str | None] = {}
+        for position, segment in enumerate(partial_key.split(":")):
+            if segment == "" or position >= len(dims_ordered):
+                continue
+            try:
+                index = int(segment)
+            except ValueError:
+                continue
+            dim = dims_ordered[position]
+            values = self._dim_values.get(dim, [])
+            if 0 <= index < len(values):
+                dim_filter[dim.id] = values[index].value
+        return dim_filter
+
+    @staticmethod
+    def _series_matches_dimension_group(series_key: Any, dim_filter: dict[str, str | None]) -> bool:
+        """True when the series key matches the group filter on every constrained dimension."""
+        series_values = {dim_id: kv.value for dim_id, kv in series_key.values.items()}
+        return all(series_values.get(dim_id) == value for dim_id, value in dim_filter.items())
+
+
+def _inline_attr_text(values: list[Any]) -> str | None:
+    """Render an inline (uncoded) attribute value list to a display string.
+
+    The proxy SDMX-JSON format stores uncoded attribute values inline as a list
+    whose elements are plain scalars or localized-text objects
+    (e.g. ``{"en": "Nominal GDP"}``).  Localized objects are unwrapped to their
+    first available localization.  Returns ``None`` when nothing renders.
+    """
+    parts: list[str] = []
+    for item in values:
+        if item is None:
+            continue
+        if isinstance(item, dict):
+            text = next((str(v) for v in item.values() if v is not None), None)
+            if text is not None:
+                parts.append(text)
+        else:
+            parts.append(str(item))
+    return ", ".join(parts) or None
 
 
 def _code_from_value(v: dict) -> Code:

--- a/statgpt/common/data/statgpt_sdmx_proxy/v30/sdmx_client.py
+++ b/statgpt/common/data/statgpt_sdmx_proxy/v30/sdmx_client.py
@@ -52,7 +52,6 @@ _SDMX_v30_STRUCTURE_ACCEPT_HEADER = "application/vnd.sdmx.structure+json;version
 class AsyncStatGptSdmxProxyClient(AsyncSdmxClient):
     """Async client for StatGPT SDMX proxy (SDMX 3.0 API, SDMX-JSON parsed as SDMX 2.1 models)."""
 
-    _DATA_PARAM_ALLOWLIST = {"startPeriod", "endPeriod", "firstNObservations", "lastNObservations"}
     _DATA_ACCEPT_DEFAULT = "application/vnd.sdmx.data+json;version=2.0.0"
     _attributes_cache: TtlCache[dict[str, str | None]] = TtlCache()
 
@@ -261,11 +260,9 @@ class AsyncStatGptSdmxProxyClient(AsyncSdmxClient):
         dsd: DataStructureDefinition | None,
     ) -> DataMessage:
         key_segment = self._build_key_segment(key=key, dsd=dsd, require_dsd=True)
-        filtered = self._filter_params(params, self._DATA_PARAM_ALLOWLIST)
-        converted = self._convert_time_params(filtered)
         url = self._build_url(
             path=f"/data/dataflow/{agency_id}/{resource_id}/{version}/{key_segment}",
-            params=converted,
+            params=params or None,
         )
 
         response, req = await self._perform_get(url, Resource.data)
@@ -325,32 +322,6 @@ class AsyncStatGptSdmxProxyClient(AsyncSdmxClient):
         if params:
             return f"{url}?{urlencode(params)}"
         return url
-
-    @staticmethod
-    def _filter_params(params: dict[str, str] | None, allowlist: set[str]) -> dict[str, str] | None:
-        if not params:
-            return None
-        return {k: v for k, v in params.items() if k in allowlist}
-
-    @staticmethod
-    def _convert_time_params(
-        params: dict[str, str] | None,
-    ) -> dict[str, str] | None:
-        """Convert startPeriod/endPeriod to SDMX 3.0 c[TIME_PERIOD] filter syntax."""
-        if not params:
-            return None
-        result: dict[str, str] = {}
-        time_filters: list[str] = []
-        for k, v in params.items():
-            if k == "startPeriod":
-                time_filters.append(f"ge:{v}")
-            elif k == "endPeriod":
-                time_filters.append(f"le:{v}")
-            else:
-                result[k] = v
-        if time_filters:
-            result["c[TIME_PERIOD]"] = "+".join(time_filters)
-        return result or None
 
     async def _perform_get(
         self, url: str, resource: Resource

--- a/statgpt/common/data/statgpt_sdmx_proxy/v30/sdmx_client.py
+++ b/statgpt/common/data/statgpt_sdmx_proxy/v30/sdmx_client.py
@@ -262,7 +262,7 @@ class AsyncStatGptSdmxProxyClient(AsyncSdmxClient):
         key_segment = self._build_key_segment(key=key, dsd=dsd, require_dsd=True)
         url = self._build_url(
             path=f"/data/dataflow/{agency_id}/{resource_id}/{version}/{key_segment}",
-            params=params or None,
+            params=params,
         )
 
         response, req = await self._perform_get(url, Resource.data)

--- a/tests/unit/common/data/sdmx/common/test_query_params.py
+++ b/tests/unit/common/data/sdmx/common/test_query_params.py
@@ -1,0 +1,69 @@
+"""Tests for version-specific SDMX data query params on SdmxDataSetQuery."""
+
+from statgpt.common.data.sdmx.common import (
+    SdmxDataSetQuery,
+    SdmxQueryReadinessStatus,
+    TimeDimensionQuery,
+)
+
+
+def _query(start: str | None = None, end: str | None = None) -> SdmxDataSetQuery:
+    time_query = None
+    if start is not None or end is not None:
+        time_query = TimeDimensionQuery(
+            time_dimension_id="TIME_PERIOD", start_period=start, end_period=end
+        )
+    return SdmxDataSetQuery(
+        status=SdmxQueryReadinessStatus.READY,
+        categorical_dimensions={},
+        time_dimension_query=time_query,
+        missing_dimensions=[],
+    )
+
+
+class TestGetParamsV21:
+    def test_no_time(self) -> None:
+        assert _query().get_params_v21() == {"detail": "full"}
+
+    def test_start_and_end(self) -> None:
+        assert _query(start="2020", end="2024").get_params_v21() == {
+            "detail": "full",
+            "startPeriod": "2020",
+            "endPeriod": "2024",
+        }
+
+    def test_start_only(self) -> None:
+        assert _query(start="2020").get_params_v21() == {
+            "detail": "full",
+            "startPeriod": "2020",
+        }
+
+    def test_end_only(self) -> None:
+        assert _query(end="2024").get_params_v21() == {
+            "detail": "full",
+            "endPeriod": "2024",
+        }
+
+
+class TestGetParamsV30:
+    def test_no_time(self) -> None:
+        assert _query().get_params_v30() == {"attributes": "all"}
+
+    def test_start_and_end(self) -> None:
+        params = _query(start="2020", end="2024").get_params_v30()
+        assert params == {"attributes": "all", "c[TIME_PERIOD]": "ge:2020+le:2024"}
+
+    def test_start_only(self) -> None:
+        assert _query(start="2020").get_params_v30() == {
+            "attributes": "all",
+            "c[TIME_PERIOD]": "ge:2020",
+        }
+
+    def test_end_only(self) -> None:
+        assert _query(end="2024").get_params_v30() == {
+            "attributes": "all",
+            "c[TIME_PERIOD]": "le:2024",
+        }
+
+    def test_never_includes_detail(self) -> None:
+        assert "detail" not in _query(start="2020", end="2024").get_params_v30()

--- a/tests/unit/common/data/statgpt_sdmx_proxy/v30/data_all_attribute_levels.json
+++ b/tests/unit/common/data/statgpt_sdmx_proxy/v30/data_all_attribute_levels.json
@@ -1,0 +1,73 @@
+{
+  "meta": {
+    "id": "TEST-ALL-ATTRIBUTE-LEVELS",
+    "prepared": "2026-06-02T00:00:00",
+    "sender": {"id": "TEST"}
+  },
+  "data": {
+    "dataSets": [
+      {
+        "action": "Replace",
+        "attributes": [0, ["data@imf.org"], [{"en": "World Economic Outlook"}], null],
+        "dimensionGroupAttributes": {
+          ":0:": [1, [{"en": "Gross Domestic Product"}], null],
+          "0:0:": [null, null, ["2015"]]
+        },
+        "series": {
+          "0:0": {
+            "attributes": [0, 0],
+            "observations": {
+              "0": ["100", 0, 0],
+              "1": ["110", 1, null]
+            }
+          },
+          "1:0": {
+            "attributes": [0, null],
+            "observations": {
+              "0": ["200"]
+            }
+          }
+        }
+      }
+    ],
+    "structures": [
+      {
+        "dimensions": {
+          "series": [
+            {"id": "COUNTRY", "keyPosition": 0, "values": [{"id": "USA"}, {"id": "FRA"}]},
+            {"id": "INDICATOR", "keyPosition": 1, "values": [{"id": "GDP"}]}
+          ],
+          "observation": [
+            {"id": "TIME_PERIOD", "keyPosition": 2, "values": [{"value": "2020"}, {"value": "2021"}]}
+          ]
+        },
+        "attributes": {
+          "dataSet": [
+            {"id": "SOURCE_DATASET", "values": [{"id": "IMF"}]},
+            {"id": "CONTACT", "values": []},
+            {"id": "TITLE", "values": []},
+            {"id": "NOTE", "values": []}
+          ],
+          "dimensionGroup": [
+            {"id": "NA_STO", "relationship": {"dimensions": ["INDICATOR"]}, "values": [{"id": "B1G"}, {"id": "B1GQ"}]},
+            {"id": "SERIES_NAME", "relationship": {"dimensions": ["INDICATOR"]}, "values": []},
+            {"id": "BASE_YEAR", "relationship": {"dimensions": ["COUNTRY", "INDICATOR"]}, "values": []}
+          ],
+          "series": [
+            {"id": "SCALE", "relationship": {"dimensions": ["COUNTRY", "INDICATOR"]}, "values": [{"id": "9"}]},
+            {"id": "DECIMALS", "relationship": {"dimensions": ["COUNTRY", "INDICATOR"]}, "values": [{"id": "3"}]}
+          ],
+          "observation": [
+            {"id": "OBS_STATUS", "relationship": {"observation": {}}, "values": [{"id": "A"}, {"id": "H"}]},
+            {"id": "OBS_CONF", "relationship": {"observation": {}}, "values": [{"id": "F"}]}
+          ]
+        },
+        "measures": {
+          "observation": [
+            {"id": "OBS_VALUE", "values": []}
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/tests/unit/common/data/statgpt_sdmx_proxy/v30/test_reader.py
+++ b/tests/unit/common/data/statgpt_sdmx_proxy/v30/test_reader.py
@@ -1,0 +1,108 @@
+"""Tests for :class:`StatGptSdmxProxyDataReader`.
+
+``data_all_attribute_levels.json`` is a small hand-crafted proxy SDMX-JSON data
+message that exercises all four SDMX-JSON 2.0.0 attribute levels and every value
+encoding the reader supports:
+
+* ``dataSet`` — coded index, inline string, inline localized text, ``null``.
+* ``dimensionGroup`` — group attributes carried in ``dimensionGroupAttributes``
+  keyed by partial dimension keys; a wildcard (INDICATOR-only) group that matches
+  both series and a specific (COUNTRY+INDICATOR) group that matches one.
+* ``series`` — coded index and ``null`` skip.
+* ``observation`` — coded index and ``null`` skip.
+
+It has two series (``USA, GDP`` and ``FRA, GDP``) over two time periods, with
+just enough values to cover each case without redundancy.
+"""
+
+import io
+from pathlib import Path
+
+from sdmx.message import DataMessage
+
+from statgpt.common.data.statgpt_sdmx_proxy.v30.reader import StatGptSdmxProxyDataReader
+
+FIXTURE = Path(__file__).parent / "data_all_attribute_levels.json"
+
+
+def _parse_fixture() -> DataMessage:
+    return StatGptSdmxProxyDataReader().convert(io.BytesIO(FIXTURE.read_bytes()), structure=None)
+
+
+def _attr_display(attrib: dict) -> dict[str, str | None]:
+    return {
+        key: (value.value.id if hasattr(value.value, "id") else value.value)
+        for key, value in attrib.items()
+    }
+
+
+def _series_by_country(dataset) -> dict:
+    return {sk.values["COUNTRY"].value: (sk, obs) for sk, obs in dataset.series.items()}
+
+
+def _obs_by_time(observations) -> dict:
+    return {o.dimension.values["TIME_PERIOD"].value: o for o in observations}
+
+
+def test_reader_parses_dataset_level_attributes() -> None:
+    """dataSet-level attributes resolve across coded, inline-string, localized and null slots."""
+    attrib = _attr_display(_parse_fixture().data[0].attrib)
+
+    assert attrib["SOURCE_DATASET"] == "IMF"  # coded index -> code id
+    assert attrib["CONTACT"] == "data@imf.org"  # inline plain string
+    assert attrib["TITLE"] == "World Economic Outlook"  # inline localized {"en": ...}
+    assert attrib["NOTE"] is None  # null slot
+
+
+def test_reader_parses_series_level_attributes() -> None:
+    """Series-level attributes resolve per series; null slots are skipped."""
+    dataset = _parse_fixture().data[0]
+    assert len(dataset.series) == 2
+    series = _series_by_country(dataset)
+
+    usa_key, _ = series["USA"]
+    usa_attrib = _attr_display(usa_key.attrib)
+    assert usa_attrib["SCALE"] == "9"
+    assert usa_attrib["DECIMALS"] == "3"
+
+    fra_key, _ = series["FRA"]
+    fra_attrib = _attr_display(fra_key.attrib)
+    assert fra_attrib["SCALE"] == "9"
+    assert "DECIMALS" not in fra_attrib  # null slot skipped
+
+
+def test_reader_reads_dimension_group_attributes_onto_matching_series() -> None:
+    """``dimensionGroupAttributes`` are resolved and attached to every matching series.
+
+    The INDICATOR-only group (``":0:"``) is a wildcard on COUNTRY, so it attaches
+    to both series; the COUNTRY+INDICATOR group (``"0:0:"``) attaches only to USA.
+    Coded slots resolve to the code id; inline slots (plain string and localized
+    text) resolve to a display string.
+    """
+    series = _series_by_country(_parse_fixture().data[0])
+
+    usa_attrib = _attr_display(series["USA"][0].attrib)
+    assert usa_attrib["NA_STO"] == "B1GQ"  # coded index 1 (not 0), INDICATOR group
+    assert usa_attrib["SERIES_NAME"] == "Gross Domestic Product"  # localized, INDICATOR group
+    assert usa_attrib["BASE_YEAR"] == "2015"  # inline string, COUNTRY+INDICATOR group
+
+    fra_attrib = _attr_display(series["FRA"][0].attrib)
+    assert fra_attrib["NA_STO"] == "B1GQ"  # wildcard group reaches FRA too
+    assert fra_attrib["SERIES_NAME"] == "Gross Domestic Product"
+    assert "BASE_YEAR" not in fra_attrib  # COUNTRY+INDICATOR group is USA-specific
+
+
+def test_reader_parses_observation_level_attributes() -> None:
+    """Observation-level attributes resolve per observation; null slots are skipped."""
+    series = _series_by_country(_parse_fixture().data[0])
+
+    usa_obs = _obs_by_time(series["USA"][1])
+    assert usa_obs["2020"].value == "100"
+    # both attributes resolve via coded index 0
+    assert _attr_display(usa_obs["2020"].attached_attribute) == {"OBS_STATUS": "A", "OBS_CONF": "F"}
+    # OBS_STATUS resolves via coded index 1 (not 0); OBS_CONF omitted (null slot)
+    assert _attr_display(usa_obs["2021"].attached_attribute) == {"OBS_STATUS": "H"}
+
+    # an observation with no attribute array carries no observation-level attributes
+    fra_obs = _obs_by_time(series["FRA"][1])
+    assert fra_obs["2020"].attached_attribute == {}


### PR DESCRIPTION
## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #419

## Description of changes

<!-- Please explain the changes you made right below this line. -->
Data queries against the StatGPT SDMX Proxy (SDMX 3.0) did not request the `attributes` parameter, so attribute values were missing from results. The shared query builder also injected the SDMX 2.1-only `detail` parameter, which had to be stripped downstream as a workaround.

This makes `SdmxDataSetQuery` the single source of truth for version-specific REST params:

- `get_params_v21()` → `detail=full` + `startPeriod`/`endPeriod`
- `get_params_v30()` → `attributes=all` + `c[TIME_PERIOD]=ge:..+le:..` (SDMX 3.0 time syntax)

Each dataset dispatches to the correct version, so the proxy now always sends `attributes=all`, never sends `detail`, and the SDMX 3.0 time conversion (previously in the client) lives alongside the rest of the param construction. The now-redundant client-side allowlist filtering and time conversion are removed.

## Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
