### PR TITLE
feat: add new GPT-5 models to LLM enum

### DIFF
--- a/statgpt/common/config/llm_models.py
+++ b/statgpt/common/config/llm_models.py
@@ -57,6 +57,9 @@ class LLMModelsEnum(StrEnum):
     GPT_5_MINI_2025_08_07 = "gpt-5-mini-2025-08-07"
     GPT_5_1_2025_11_13 = "gpt-5.1-2025-11-13"
     GPT_5_2_2025_12_11 = "gpt-5.2-2025-12-11"
+    GPT_5_4_2026_03_05 = "gpt-5.4-2026-03-05"
+    GPT_5_4_MINI_2026_03_17 = "gpt-5.4-mini-2026-03-17"
+    GPT_5_5_2026_04_24 = "gpt-5.5-2026-04-24"
 
     @property
     def deployment_id(self) -> str:
@@ -79,4 +82,7 @@ class LLMModelsEnum(StrEnum):
             LLMModelsEnum.GPT_5_MINI_2025_08_07,
             LLMModelsEnum.GPT_5_1_2025_11_13,
             LLMModelsEnum.GPT_5_2_2025_12_11,
+            LLMModelsEnum.GPT_5_4_2026_03_05,
+            LLMModelsEnum.GPT_5_4_MINI_2026_03_17,
+            LLMModelsEnum.GPT_5_5_2026_04_24,
         }


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes N/A

### Description of changes

Add gpt-5.4, gpt-5.4-mini, and gpt-5.5 to LLMModelsEnum and register them in the is_gpt_5_family property.


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.