### PR TITLE
fix: handle empty visual dataframes in data query artifact display and SDMX response #422

### DIFF
--- a/statgpt/app/chains/data_query/data_query_artifacts_displayer.py
+++ b/statgpt/app/chains/data_query/data_query_artifacts_displayer.py
@@ -98,7 +98,7 @@ class DataQueryArtifactDisplayer:
             return None
 
         df = response.visual_dataframe.copy()
-        cells_number = df.shape[0] * df.shape[1] if df is not None else 0
+        cells_number = df.shape[0] * df.shape[1]
 
         if cells_number == 0:
             return self._get_no_data_message(response)

--- a/statgpt/app/chains/data_query/data_query_artifacts_displayer.py
+++ b/statgpt/app/chains/data_query/data_query_artifacts_displayer.py
@@ -199,14 +199,15 @@ class DataQueryArtifactDisplayer:
         return responses
 
     async def _display_data_responses(self, responses: dict[str, DataResponse]) -> None:
+        non_empty_responses = {k: v for k, v in responses.items() if not v.visual_dataframe.empty}
         tasks = []
         async with attachments_storage_factory(self._auth_context.api_key) as attachments_storage:
-            for dataset_id, response in responses.items():
+            for dataset_id, response in non_empty_responses.items():
                 tasks.append(self._attach_data_response(attachments_storage, response))
             await asyncio.gather(*tasks)
 
         if self._chat_config.merge_python_code:
-            merged_python = await self._create_merged_python_code_attachment(responses)
+            merged_python = await self._create_merged_python_code_attachment(non_empty_responses)
             if merged_python is not None:
                 self._choice.add_attachment(**merged_python)
 
@@ -254,7 +255,7 @@ class DataQueryArtifactDisplayer:
     async def _attach_csv(
         self, attachments_storage: AttachmentsStorage, data_response: DataResponse
     ) -> dict[str, str] | None:
-        if not self._config.csv_file.enabled or data_response.visual_dataframe is None:
+        if not self._config.csv_file.enabled or data_response.visual_dataframe.empty:
             return None
 
         assert self._config.csv_file.name is not None, "csv_file.name must be set when enabled"

--- a/statgpt/common/data/sdmx/v21/dataset.py
+++ b/statgpt/common/data/sdmx/v21/dataset.py
@@ -212,13 +212,13 @@ class Sdmx21DataResponse(DataResponse):
 
     @property
     def custom_table_dict(self) -> dict | None:
+        if self.df.empty:
+            return None
+
         data_json = json.loads(self.dataframe.to_json(orient='table'))
 
-        if self.visual_dataframe is not None:
-            series_count = self.visual_dataframe.shape[0]
-            height = min(400, 75 + 27 * series_count)
-        else:
-            height = 400
+        series_count = self.visual_dataframe.shape[0]
+        height = min(400, 75 + 27 * series_count)
 
         time_dimension = self.dataset.get_time_dimension()
 
@@ -234,7 +234,7 @@ class Sdmx21DataResponse(DataResponse):
 
     @property
     def plotly_grid(self) -> go.Figure | None:
-        if self.visual_dataframe is None:
+        if self.visual_dataframe.empty:
             return None
         figure = df_2_plotly_grid(self.visual_dataframe, round_digits=2)
         return figure


### PR DESCRIPTION

### Applicable issues

#422 

### Description of changes

Fixes empty data-query results producing data attachments.
When a data query executes successfully but returns zero observations, the response is represented as an empty `DataFrame`, not `None`. The attachment generation flow now treats empty dataframes as no-data results and skips user-facing data attachments such as custom table, Plotly grid, CSV, JSON query, and Python code.
The SDMX data response helpers were also tightened so empty responses no longer build table or Plotly grid payloads internally.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
