### PR TITLE
feat: configurable MCP tool name prefix and per-tool MCP name/description overrides #431 #432

### DIFF
--- a/statgpt/app/README.md
+++ b/statgpt/app/README.md
@@ -32,6 +32,24 @@ StatGPT can expose its tools via the [Model Context Protocol (MCP)](https://mode
 
 The MCP server is mounted at `/api/v1/{deployment_id}/mcp`. The `{deployment_id}` placeholder is resolved per request from the URL path and is used to look up the channel configuration.
 
+### Tool Names and Descriptions
+
+By default, tools are exposed via MCP under the same names and descriptions the internal agent uses. The channel configuration can customize the MCP-facing values without affecting the chat flow:
+
+- `mcp.tool_name_prefix` — a prefix prepended to all tool names exposed via MCP (empty by default, i.e. no prefixing).
+- Per tool, `mcp_name` / `mcp_description` — overrides for the name/description exposed via MCP. If unset, the tool's regular `name` / `description` is used.
+
+```yaml
+details:
+  mcp:
+    tool_name_prefix: "statgpt__"
+  data_query:
+    name: "query_data"
+    mcp_name: "data_query"            # exposed via MCP as "statgpt__data_query"
+    mcp_description: "Query official statistics data using natural language."
+    # ...
+```
+
 ### DIAL Core Configuration
 
 To expose an existing StatGPT application's tools over MCP, add an `mcp` section to its entry in DIAL Core's `applications` config. The rest of the application fields (`endpoint`, `features`, etc.) are expected to already exist.

--- a/statgpt/app/mcp/provider.py
+++ b/statgpt/app/mcp/provider.py
@@ -110,8 +110,8 @@ class ChannelToolProvider(Provider):
         return _McpToolAdapter(
             langchain_tool=langchain_tool,
             inputs=inputs,
-            name=tool_config.name,
-            description=tool_config.description,
+            name=channel_config.mcp.tool_name_prefix + tool_config.effective_mcp_name,
+            description=tool_config.effective_mcp_description,
             parameters=langchain_tool.get_public_args_schema(),
             annotations=langchain_tool.get_mcp_annotations(),
         )
@@ -156,9 +156,14 @@ class ChannelToolProvider(Provider):
             return None
 
         channel_config = channel_service.channel_config
+        prefix = channel_config.mcp.tool_name_prefix
+        if prefix:
+            if not name.startswith(prefix):
+                return None
+            name = name.removeprefix(prefix)
         inputs = _build_mcp_inputs(auth_context, channel_service)
         for tool_config in channel_config.tools:
-            if tool_config.name == name:
+            if tool_config.effective_mcp_name == name:
                 return self._create_mcp_tool(tool_config, channel_config, inputs)
         return None
 

--- a/statgpt/common/schemas/channel.py
+++ b/statgpt/common/schemas/channel.py
@@ -109,6 +109,17 @@ class OutOfScopeConfig(BaseYamlModel):
     )
 
 
+class McpConfig(BaseYamlModel):
+    tool_name_prefix: str = Field(
+        default="",
+        pattern=r'^[a-zA-Z0-9_\.-]*$',
+        description=(
+            "Prefix prepended to tool names exposed via MCP (e.g. 'statgpt__'). "
+            "Internal agent tool names are unaffected. Empty string disables prefixing."
+        ),
+    )
+
+
 class TokenUsageConfig(BaseYamlModel):
     debug_only: bool = Field(
         default=True,
@@ -173,6 +184,7 @@ class ChannelConfig(BaseYamlModel):
         None, description="The out of scope configuration"
     )
     token_usage: TokenUsageConfig = Field(default_factory=TokenUsageConfig)
+    mcp: McpConfig = Field(default_factory=McpConfig, description="MCP server configuration")
     bearer_token_required: bool = Field(
         default=False,
         description=(

--- a/statgpt/common/schemas/tools.py
+++ b/statgpt/common/schemas/tools.py
@@ -29,6 +29,20 @@ class BaseToolConfig(BaseYamlModel):
     description: str = Field(description="The description of the tool.", max_length=4096)
     enabled: bool = Field(default=True, description="Whether the tool is enabled or not.")
 
+    mcp_name: str | None = Field(
+        default=None,
+        pattern=r'^[a-zA-Z0-9_\.-]+$',
+        description="Override for the tool name exposed via MCP. Defaults to `name` if not set.",
+    )
+    mcp_description: str | None = Field(
+        default=None,
+        max_length=4096,
+        description=(
+            "Override for the tool description exposed via MCP."
+            " Defaults to `description` if not set."
+        ),
+    )
+
     details: BaseToolDetails = Field(
         default_factory=BaseToolDetails, description="Details as a JSON object"
     )
@@ -36,6 +50,14 @@ class BaseToolConfig(BaseYamlModel):
     @property
     def out_of_scope_description(self) -> str:
         return self.description
+
+    @property
+    def effective_mcp_name(self) -> str:
+        return self.mcp_name if self.mcp_name is not None else self.name
+
+    @property
+    def effective_mcp_description(self) -> str:
+        return self.mcp_description if self.mcp_description is not None else self.description
 
 
 class AvailableDatasetsTool(BaseToolConfig):

--- a/tests/unit/app/mcp/test_provider.py
+++ b/tests/unit/app/mcp/test_provider.py
@@ -7,8 +7,9 @@ import pytest
 from fastmcp.exceptions import ToolError
 from mcp.types import EmbeddedResource, TextContent
 
-from statgpt.app.mcp.provider import _McpToolAdapter
+from statgpt.app.mcp.provider import ChannelToolProvider, _McpToolAdapter
 from statgpt.app.schemas.tool_artifact import DataQueryArtifact
+from statgpt.common.schemas.tools import AvailableDatasetsTool
 
 
 def _build_adapter(result) -> _McpToolAdapter:
@@ -75,3 +76,109 @@ async def test_tool_failure_raises_tool_error():
 
     with pytest.raises(ToolError):
         await adapter.run({})
+
+
+def _tool_config(**kwargs) -> AvailableDatasetsTool:
+    return AvailableDatasetsTool(name="query_data", description="Query data tool.", **kwargs)
+
+
+def _channel_config(tool_config, prefix: str) -> SimpleNamespace:
+    return SimpleNamespace(mcp=SimpleNamespace(tool_name_prefix=prefix), tools=[tool_config])
+
+
+@pytest.fixture
+def fake_statgpt_tool(monkeypatch) -> SimpleNamespace:
+    langchain_tool = SimpleNamespace(
+        name="query_data",
+        get_public_args_schema=lambda: {},
+        get_mcp_annotations=lambda: None,
+    )
+    monkeypatch.setattr(
+        "statgpt.app.mcp.provider.StatGptTool",
+        SimpleNamespace(from_config=lambda tool_config, channel_config: langchain_tool),
+    )
+    return langchain_tool
+
+
+def _build_provider(channel_config, monkeypatch) -> ChannelToolProvider:
+    provider = ChannelToolProvider()
+    channel_service = SimpleNamespace(channel_config=channel_config)
+    monkeypatch.setattr("statgpt.app.mcp.provider.get_http_request", lambda: None)
+    monkeypatch.setattr(
+        provider,
+        "_resolve_context",
+        AsyncMock(return_value=(SimpleNamespace(), channel_service)),
+    )
+    return provider
+
+
+def test_create_mcp_tool_applies_prefix(fake_statgpt_tool):
+    tool_config = _tool_config()
+    channel_config = _channel_config(tool_config, prefix="statgpt__")
+
+    mcp_tool = ChannelToolProvider()._create_mcp_tool(tool_config, channel_config, inputs={})
+
+    assert mcp_tool.name == "statgpt__query_data"
+    assert mcp_tool.description == "Query data tool."
+
+
+def test_create_mcp_tool_empty_prefix_keeps_name(fake_statgpt_tool):
+    tool_config = _tool_config()
+    channel_config = _channel_config(tool_config, prefix="")
+
+    mcp_tool = ChannelToolProvider()._create_mcp_tool(tool_config, channel_config, inputs={})
+
+    assert mcp_tool.name == "query_data"
+
+
+def test_create_mcp_tool_uses_mcp_overrides(fake_statgpt_tool):
+    tool_config = _tool_config(mcp_name="data", mcp_description="MCP description.")
+    channel_config = _channel_config(tool_config, prefix="statgpt__")
+
+    mcp_tool = ChannelToolProvider()._create_mcp_tool(tool_config, channel_config, inputs={})
+
+    assert mcp_tool.name == "statgpt__data"
+    assert mcp_tool.description == "MCP description."
+
+
+async def test_get_tool_resolves_prefixed_name(fake_statgpt_tool, monkeypatch):
+    channel_config = _channel_config(_tool_config(), prefix="statgpt__")
+    provider = _build_provider(channel_config, monkeypatch)
+
+    mcp_tool = await provider._get_tool("statgpt__query_data")
+
+    assert mcp_tool is not None
+    assert mcp_tool.name == "statgpt__query_data"
+
+
+async def test_get_tool_rejects_unprefixed_name_when_prefix_set(fake_statgpt_tool, monkeypatch):
+    channel_config = _channel_config(_tool_config(), prefix="statgpt__")
+    provider = _build_provider(channel_config, monkeypatch)
+
+    assert await provider._get_tool("query_data") is None
+
+
+async def test_get_tool_without_prefix_resolves_plain_name(fake_statgpt_tool, monkeypatch):
+    channel_config = _channel_config(_tool_config(), prefix="")
+    provider = _build_provider(channel_config, monkeypatch)
+
+    mcp_tool = await provider._get_tool("query_data")
+
+    assert mcp_tool is not None
+    assert mcp_tool.name == "query_data"
+
+
+async def test_get_tool_matches_mcp_name_override(fake_statgpt_tool, monkeypatch):
+    tool_config = _tool_config(mcp_name="data")
+    channel_config = _channel_config(tool_config, prefix="statgpt__")
+    provider = _build_provider(channel_config, monkeypatch)
+
+    assert await provider._get_tool("statgpt__data") is not None
+    assert await provider._get_tool("statgpt__query_data") is None
+
+
+def test_effective_mcp_fields_fall_back_to_base_fields():
+    tool_config = _tool_config()
+
+    assert tool_config.effective_mcp_name == "query_data"
+    assert tool_config.effective_mcp_description == "Query data tool."


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- closes #431
- closes #432

### Description of changes

Allows customizing how channel tools are presented to external MCP clients without affecting the internal agent:

- New `mcp.tool_name_prefix` channel config option — a prefix prepended to all tool names exposed via MCP (e.g. `query_data` → `statgpt__query_data`). Empty by default (no prefixing), so existing deployments are unaffected.
- New optional `mcp_name` / `mcp_description` fields on tool configs — MCP-facing overrides that fall back to the regular `name` / `description` when unset.
- The MCP provider lists tools under `prefix + (mcp_name or name)` and resolves incoming tool calls accordingly. Internal tool execution and the SupremeAgent keep using the original names and descriptions.
- Documented in the MCP Server section of `statgpt/app/README.md`; covered by new unit tests for the MCP provider.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
