### PR TITLE
feat: support `disabled` flag on dataset queries #400

### DIFF
--- a/statgpt/app/chains/data_query/data_query_artifacts_displayer.py
+++ b/statgpt/app/chains/data_query/data_query_artifacts_displayer.py
@@ -6,6 +6,7 @@ import pandas as pd
 import plotly.graph_objects as go
 
 from statgpt.app.schemas.dial_app_configuration import StatGPTConfiguration
+from statgpt.app.schemas.query import AppJsonQueryWithMetadata
 from statgpt.app.schemas.tool_artifact import DataQueryArtifact
 from statgpt.app.services.python_code_generator import PYTHON_SDMX1_HEADER
 from statgpt.app.utils import get_python_code_markdown
@@ -270,12 +271,12 @@ class DataQueryArtifactDisplayer:
         if not self._config.json_query.enabled:
             return None
 
-        data = data_response.json_query
-        if data is None:
+        query = data_response.json_query
+        if query is None:
             return None
 
         assert self._config.json_query.name is not None, "json_query.name must be set when enabled"
-        content = json.dumps(data, ensure_ascii=False)
+        content = AppJsonQueryWithMetadata.from_common(query).model_dump_json(by_alias=True)
         title = data_response.enrich_attachment_name(self._config.json_query.name)
         return dict(type=MediaTypes.JSON, title=title, data=content)
 

--- a/statgpt/app/schemas/__init__.py
+++ b/statgpt/app/schemas/__init__.py
@@ -1,4 +1,5 @@
 from .file_rags import DialRagState
+from .query import AppJsonQuery, AppJsonQueryWithMetadata
 from .selection_candidates import (
     BatchedSelectionOutputBase,
     CandidatesRelevancyMapping,

--- a/statgpt/app/schemas/query.py
+++ b/statgpt/app/schemas/query.py
@@ -1,0 +1,23 @@
+from pydantic import Field
+
+from statgpt.common.schemas.query import JsonQuery, JsonQueryWithMetadata
+
+
+class AppJsonQuery(JsonQuery):
+    disabled: bool = Field(
+        default=False,
+        description="If true, this dataset query is excluded from processing.",
+    )
+
+
+class AppJsonQueryWithMetadata(JsonQueryWithMetadata):
+    disabled: bool = Field(
+        default=False,
+        description="If true, this dataset query is excluded from processing.",
+    )
+
+    @classmethod
+    def from_common(
+        cls, query: JsonQueryWithMetadata, disabled: bool = False
+    ) -> "AppJsonQueryWithMetadata":
+        return cls(**query.model_dump(), disabled=disabled)

--- a/statgpt/app/schemas/service.py
+++ b/statgpt/app/schemas/service.py
@@ -1,7 +1,7 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from statgpt.app.schemas.query import AppJsonQueryWithMetadata
 from statgpt.common.schemas.channel_dataset import ChannelDatasetExpanded
-from statgpt.common.schemas.query import JsonQueryWithMetadata
 from statgpt.common.schemas.tools import BaseToolConfig
 
 
@@ -28,11 +28,20 @@ class ChannelDatasetsMetadataResponse(BaseModel):
 
 
 class GeneratePythonCodeRequest(BaseModel):
-    queries: list[JsonQueryWithMetadata] = Field(
+    queries: list[AppJsonQueryWithMetadata] = Field(
         min_length=1,
         max_length=64,
         description="List of JSON queries with metadata to generate Python code for",
     )
+
+    @field_validator("queries")
+    @classmethod
+    def _validate_at_least_one_enabled_query(
+        cls, value: list[AppJsonQueryWithMetadata]
+    ) -> list[AppJsonQueryWithMetadata]:
+        if all(query.disabled for query in value):
+            raise ValueError("All queries are disabled; at least one enabled query is required")
+        return value
 
 
 class GeneratePythonCodeResponse(BaseModel):

--- a/statgpt/app/services/onboarding_response_appenders.py
+++ b/statgpt/app/services/onboarding_response_appenders.py
@@ -6,9 +6,10 @@ from typing import Generic, TypeVar, overload
 from aidial_sdk.chat_completion import Choice
 
 from statgpt.app.chains.utils import time_period_utils
+from statgpt.app.schemas.query import AppJsonQueryWithMetadata
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.schemas.onboarding import PredefinedDataQueryResponse, PredefinedTextResponse
-from statgpt.common.schemas.query import JsonQuery, JsonQueryMetadata, JsonQueryWithMetadata
+from statgpt.common.schemas.query import JsonQuery, JsonQueryMetadata
 from statgpt.common.utils import MediaTypes
 
 from .chat_facade import ChannelServiceFacade
@@ -74,7 +75,7 @@ class PredefinedDataQueryResponseAppender(BaseResponseAppender[PredefinedDataQue
             dataset_url=dataset.dataset_url,
             key_dimension_ids_in_dsd_order=dataset.sdmx_key_dimension_ids_in_dsd_order,
         )
-        json_query = JsonQueryWithMetadata.from_query(
+        json_query = AppJsonQueryWithMetadata.from_query(
             query=self._get_relative_time_period_aware_query(
                 self._response.query, dataset.config.time_period_dimension_id
             ),

--- a/statgpt/app/services/python_code_generator.py
+++ b/statgpt/app/services/python_code_generator.py
@@ -1,11 +1,8 @@
 from typing import Never
 
+from statgpt.app.schemas.query import AppJsonQueryWithMetadata
 from statgpt.common.data.sdmx.python_code import generate_python_query_body
-from statgpt.common.schemas.query import (
-    JsonComponentQuery,
-    JsonQueryOperator,
-    JsonQueryWithMetadata,
-)
+from statgpt.common.schemas.query import JsonComponentQuery, JsonQueryOperator
 
 PYTHON_SDMX1_HEADER = """\
 # Uses the [sdmx1 library](https://pypi.org/project/sdmx1/)
@@ -117,10 +114,7 @@ def _build_params_from_filters(filters: list[JsonComponentQuery]) -> dict[str, s
     return params
 
 
-def generate_python_code_from_query(
-    query: JsonQueryWithMetadata,
-    suffix: str = "",
-) -> str:
+def generate_python_code_from_query(query: AppJsonQueryWithMetadata, suffix: str = "") -> str:
     flow_ref = _build_flow_ref(query.agency_id, query.resource_id, query.version)
 
     provider = query.sdmx1_source or query.agency_id
@@ -144,9 +138,11 @@ def generate_python_code_from_query(
     )
 
 
-def generate_merged_python_code(queries: list[JsonQueryWithMetadata]) -> str:
+def generate_merged_python_code(queries: list[AppJsonQueryWithMetadata]) -> str:
     queries = [
-        q for q in queries if not any(f.operator == JsonQueryOperator.EXCLUDED for f in q.filters)
+        q
+        for q in queries
+        if not q.disabled and not any(f.operator == JsonQueryOperator.EXCLUDED for f in q.filters)
     ]
     if not queries:
         return PYTHON_SDMX1_HEADER

--- a/statgpt/app/utils/message_interceptors/system_msg_interceptor.py
+++ b/statgpt/app/utils/message_interceptors/system_msg_interceptor.py
@@ -6,8 +6,8 @@ from aidial_sdk.chat_completion import Role
 from aidial_sdk.exceptions import InvalidRequestError
 from pydantic import ValidationError
 
+from statgpt.app.schemas.query import AppJsonQuery
 from statgpt.app.services.chat_facade import ChannelServiceFacade
-from statgpt.common.schemas.query import JsonQuery
 from statgpt.common.utils.media_types import MediaTypes
 
 from .base import BaseMessageInterceptor
@@ -43,10 +43,10 @@ class SystemMessageInterceptor(BaseMessageInterceptor):
                     if not attachment.data:
                         raise InvalidRequestError("System message attachment must have data field")
                     try:
-                        JsonQuery.model_validate_json(attachment.data)
+                        AppJsonQuery.model_validate_json(attachment.data)
                     except ValidationError as e:
                         raise InvalidRequestError(
-                            "Failed to parse system message attachment data as JsonQuery"
+                            "Failed to parse system message attachment data as a JSON query"
                         ) from e
                 elif attachment.type == MediaTypes.MARKDOWN:
                     continue

--- a/statgpt/common/data/base/dataset.py
+++ b/statgpt/common/data/base/dataset.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.schemas.dataset import Status
 from statgpt.common.schemas.enums import DataParsingStatus, DataRequestStatus
+from statgpt.common.schemas.query import JsonQueryWithMetadata
 
 from .attribute import Attribute
 from .base import BaseEntity, EntityType
@@ -157,8 +158,8 @@ class DataResponse(ABC):
 
     @property
     @abstractmethod
-    def json_query(self) -> dict | None:
-        """Return the query in JSON format."""
+    def json_query(self) -> JsonQueryWithMetadata | None:
+        """Return the query as a JSON query model."""
 
     @abstractmethod
     def get_python_code_body(self, suffix: str = "") -> str | None:

--- a/statgpt/common/data/sdmx/v21/dataset.py
+++ b/statgpt/common/data/sdmx/v21/dataset.py
@@ -253,7 +253,7 @@ class Sdmx21DataResponse(DataResponse):
         return self._url
 
     @property
-    def json_query(self) -> dict:
+    def json_query(self) -> JsonQueryWithMetadata:
         return JsonQueryWithMetadata(
             urn=self.dataset.short_urn,
             filters=self._to_component_filters(self.sdmx_query),
@@ -265,7 +265,7 @@ class Sdmx21DataResponse(DataResponse):
                 key_dimension_ids_in_dsd_order=self.dataset.sdmx_key_dimension_ids_in_dsd_order,
             ),
             sdmx1_source=self.dataset.get_resolved_sdmx1_source(),
-        ).model_dump(by_alias=True)
+        )
 
     def get_python_code_body(self, suffix: str = "") -> str | None:
         return self.dataset.get_python_code_body(self.sdmx_query, suffix=suffix)

--- a/tests/unit/test_python_code_generator.py
+++ b/tests/unit/test_python_code_generator.py
@@ -1,5 +1,8 @@
 import pytest
+from pydantic import ValidationError
 
+from statgpt.app.schemas.query import AppJsonQuery, AppJsonQueryWithMetadata
+from statgpt.app.schemas.service import GeneratePythonCodeRequest
 from statgpt.app.services.python_code_generator import (
     PYTHON_SDMX1_HEADER,
     _build_key_from_filters,
@@ -93,7 +96,7 @@ def test_build_key_from_filters_legacy_filter_order_when_no_hint() -> None:
 
 
 def test_generate_python_code_uses_key_dimension_ids_in_dsd_order() -> None:
-    query = JsonQueryWithMetadata(
+    query = AppJsonQueryWithMetadata(
         urn=_VALID_URN,
         filters=[
             JsonComponentQuery(component_code="B", operator=JsonQueryOperator.IN, values=["b1"]),
@@ -168,8 +171,8 @@ def test_build_params_in_multiple_values_rejected() -> None:
         )
 
 
-def _make_query(urn: str) -> JsonQueryWithMetadata:
-    return JsonQueryWithMetadata(
+def _make_query(urn: str, disabled: bool = False) -> AppJsonQueryWithMetadata:
+    return AppJsonQueryWithMetadata(
         urn=urn,
         filters=[
             JsonComponentQuery(component_code="A", operator=JsonQueryOperator.IN, values=["a1"]),
@@ -179,6 +182,7 @@ def _make_query(urn: str) -> JsonQueryWithMetadata:
             indicator_dimensions=["B"],
             time_period_dimension="TIME_PERIOD",
         ),
+        disabled=disabled,
     )
 
 
@@ -203,7 +207,7 @@ def test_generate_merged_python_code_multi_query_separates_sections() -> None:
 
 
 def test_generate_merged_python_code_drops_dataset_with_any_excluded_filter() -> None:
-    excluded_query = JsonQueryWithMetadata(
+    excluded_query = AppJsonQueryWithMetadata(
         urn="IMF:DF_X(1.0)",
         filters=[
             JsonComponentQuery(component_code="A", operator=JsonQueryOperator.IN, values=["a1"]),
@@ -233,7 +237,7 @@ def test_generate_merged_python_code_drops_dataset_with_any_excluded_filter() ->
 
 
 def test_generate_merged_python_code_returns_header_only_when_all_excluded() -> None:
-    excluded_query = JsonQueryWithMetadata(
+    excluded_query = AppJsonQueryWithMetadata(
         urn="IMF:DF_X(1.0)",
         filters=[
             JsonComponentQuery(
@@ -250,3 +254,82 @@ def test_generate_merged_python_code_returns_header_only_when_all_excluded() -> 
     )
     code = generate_merged_python_code([excluded_query])
     assert code == PYTHON_SDMX1_HEADER
+
+
+def test_generate_merged_python_code_drops_disabled_query() -> None:
+    disabled_urn = "IMF:DF_DISABLED(1.0)"
+    code = generate_merged_python_code(
+        [_make_query(_VALID_URN), _make_query(disabled_urn, disabled=True)]
+    )
+    assert "DF_DISABLED" not in code
+    # Only one query survives, so the single-query branch is taken (no `# Dataset:` headers).
+    assert "# Dataset:" not in code
+    assert '"IMF,WEO,1.0"' in code
+
+
+def test_generate_merged_python_code_returns_header_only_when_all_disabled() -> None:
+    code = generate_merged_python_code([_make_query(_VALID_URN, disabled=True)])
+    assert code == PYTHON_SDMX1_HEADER
+
+
+def test_generate_python_code_request_rejects_all_disabled_queries() -> None:
+    with pytest.raises(ValidationError, match="All queries are disabled"):
+        GeneratePythonCodeRequest(queries=[_make_query(_VALID_URN, disabled=True)])
+
+
+def test_generate_python_code_request_accepts_partially_disabled_queries() -> None:
+    request = GeneratePythonCodeRequest(
+        queries=[_make_query(_VALID_URN), _make_query("IMF:DF_DISABLED(1.0)", disabled=True)]
+    )
+    assert len(request.queries) == 2
+
+
+def test_app_json_query_disabled_defaults_to_false_and_is_serialized() -> None:
+    query = _make_query(_VALID_URN)
+    assert query.disabled is False
+    assert query.model_dump(by_alias=True)["disabled"] is False
+
+
+def test_app_json_query_with_metadata_from_query_serializes_disabled() -> None:
+    common_query = JsonQueryWithMetadata(
+        urn=_VALID_URN,
+        filters=[],
+        metadata=JsonQueryMetadata(
+            country_dimension="A",
+            indicator_dimensions=["B"],
+            time_period_dimension="TIME_PERIOD",
+        ),
+    )
+    app_query = AppJsonQueryWithMetadata.from_query(
+        query=common_query, metadata=common_query.metadata
+    )
+    assert app_query.model_dump(by_alias=True)["disabled"] is False
+
+
+def test_app_json_query_with_metadata_from_common_round_trips() -> None:
+    common_query = JsonQueryWithMetadata(
+        urn=_VALID_URN,
+        filters=[
+            JsonComponentQuery(component_code="A", operator=JsonQueryOperator.IN, values=["a1"]),
+        ],
+        metadata=JsonQueryMetadata(
+            country_dimension="A",
+            indicator_dimensions=["B"],
+            time_period_dimension="TIME_PERIOD",
+            key_dimension_ids_in_dsd_order=["A", "B"],
+        ),
+        sdmx1_source="IMF_DATA",
+    )
+    app_query = AppJsonQueryWithMetadata.from_common(common_query)
+    assert app_query.disabled is False
+    assert app_query.model_dump() == {**common_query.model_dump(), "disabled": False}
+
+    dump = app_query.model_dump(by_alias=True)
+    assert dump["disabled"] is False
+    assert dump["sdmx1Source"] == "IMF_DATA"
+    assert dump["metadata"]["keyDimensionIdsInDsdOrder"] == ["A", "B"]
+
+
+def test_app_json_query_rejects_non_bool_disabled() -> None:
+    with pytest.raises(ValidationError):
+        AppJsonQuery.model_validate({"urn": _VALID_URN, "filters": [], "disabled": "banana"})

--- a/tests/unit/test_system_msg_interceptor.py
+++ b/tests/unit/test_system_msg_interceptor.py
@@ -1,0 +1,62 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from aidial_sdk.chat_completion import Attachment, CustomContent
+from aidial_sdk.chat_completion import Message as DialMessage
+from aidial_sdk.chat_completion import Role
+from aidial_sdk.exceptions import InvalidRequestError
+
+from statgpt.app.utils.message_interceptors.system_msg_interceptor import SystemMessageInterceptor
+from statgpt.common.utils.media_types import MediaTypes
+
+
+def _system_message_with_json_attachment(data: dict) -> DialMessage:
+    return DialMessage(
+        role=Role.SYSTEM,
+        content="",
+        custom_content=CustomContent(
+            attachments=[Attachment(type=MediaTypes.JSON, data=json.dumps(data))]
+        ),
+    )
+
+
+def _json_query_body(disabled: bool | str | None = None) -> dict:
+    body: dict = {
+        "urn": "IMF:WEO(1.0)",
+        "filters": [
+            {"componentCode": "COUNTRY", "operator": "in", "values": ["USA"]},
+        ],
+    }
+    if disabled is not None:
+        body["disabled"] = disabled
+    return body
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("disabled", [None, True, False])
+async def test_system_message_json_query_attachment_passes(disabled: bool | None) -> None:
+    interceptor = SystemMessageInterceptor(data_service=MagicMock())
+    messages = [_system_message_with_json_attachment(_json_query_body(disabled))]
+
+    result = await interceptor.process_messages(messages=messages, state={})
+
+    assert result == []  # system messages are validated and dropped
+
+
+@pytest.mark.asyncio
+async def test_system_message_json_query_attachment_rejects_non_bool_disabled() -> None:
+    interceptor = SystemMessageInterceptor(data_service=MagicMock())
+    messages = [_system_message_with_json_attachment(_json_query_body(disabled="banana"))]
+
+    with pytest.raises(InvalidRequestError):
+        await interceptor.process_messages(messages=messages, state={})
+
+
+@pytest.mark.asyncio
+async def test_system_message_invalid_json_query_attachment_rejected() -> None:
+    interceptor = SystemMessageInterceptor(data_service=MagicMock())
+    messages = [_system_message_with_json_attachment({"urn": "not-a-valid-urn"})]
+
+    with pytest.raises(InvalidRequestError):
+        await interceptor.process_messages(messages=messages, state={})


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- closes #400

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Add support for a `disabled` boolean field on dataset query objects, so clients can mark individual datasets in multi-dataset conversations as inactive and have the backend exclude them from processing.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
