### PR TITLE
feat: move hybrid-search normalization instructions to system prompt #444

### DIFF
--- a/statgpt/app/default_prompts/assets/hybrid_search.yaml
+++ b/statgpt/app/default_prompts/assets/hybrid_search.yaml
@@ -30,6 +30,8 @@ normalizationPrompt:
        - Do NOT remove any of the listed terms from the query if they appear in it,
          even if step 1, 2, or 3 would otherwise remove them. These are known
          indicator terms that must be preserved.
+       - Do NOT add these terms if they are not present in the input. Only protect terms that are
+         already present in the input.
     5. Resolve all acronyms, keeping the original value in round brackets if it is not
        already resolved in the input.
     6. Append well-known terms with their well-known acronyms in round brackets if the

--- a/statgpt/app/default_prompts/assets/hybrid_search.yaml
+++ b/statgpt/app/default_prompts/assets/hybrid_search.yaml
@@ -1,37 +1,103 @@
 normalizationPrompt:
   systemMessage: |-
-    You are an expert in statistical indicators.
-    As an output provide cleaned input as JSON object {{"cleaned_input"}}.
-    Only JSON, no markdown
+    # Role
+    You are an expert in statistical indicators. You clean and normalize a user's
+    statistical-data query so it can be used to search for statistical indicators.
 
-  userMessage: |-
-    Instruction steps:
-    {removal_step}
-    - remove general question asking parts around words "data", "indicator(s)", "information" if they present.
-    {forbidden_step}
-    - resolve all acronyms, keeping original value in round squares if it is not already resolved in input
-    - append well-known terms with its well-known acronyms in round squares if it is not present in input
-    - normalize usage of percentage: %, percent, percentage - use "percent"
-    - output result as "cleaned input"
-    - you MUST provide output in the SAME LANGUAGE as input!
-    This applies to whole "cleaned_input" content!
+    # Task
+    Rewrite the raw query (given in the user message) into a single normalized search
+    string. Use the query context at the end of this message - named entities, time
+    period, and protected terms - to guide the rewrite.
+
+    # Instructions
+    Apply every step, in order:
+
+    1. Remove entities - only if a "Named Entities" section is present below:
+       - Remove from the query every entity listed there and marked (REMOVE).
+       - Keep every entity marked (DO NOT REMOVE).
+       - If the same entity (or part of it) appears more than once and at least one
+         occurrence is marked (DO NOT REMOVE), keep that entity.
+       - Do NOT remove country names, country groups, places, dates, or any other words
+         that are not listed in the "Named Entities" section. If there is no
+         "Named Entities" section, do not remove any entities.
+    2. Remove the time period - only if a "Time Period" section is present below:
+       - Remove all parts of the query that refer to that time period (e.g. years,
+         ranges, "last 15 years", "since Brexit"). If there is no "Time Period"
+         section, do not remove time-related wording.
+    3. Remove general question-asking parts around the words "data", "indicator(s)",
+       "information" if they are present.
+    4. Protect known terms - only if a "Forbidden to remove words" section is present below:
+       - Do NOT remove any of the listed terms from the query if they appear in it,
+         even if step 1, 2, or 3 would otherwise remove them. These are known
+         indicator terms that must be preserved.
+    5. Resolve all acronyms, keeping the original value in round brackets if it is not
+       already resolved in the input.
+    6. Append well-known terms with their well-known acronyms in round brackets if the
+       acronym is not already present in the input.
+    7. Normalize percentage wording: "%", "percent", "percentage" -> use "percent".
+    8. You MUST produce the output in the SAME LANGUAGE as the input. This applies to
+       the entire "cleaned_input" value.
+
+    # Output format
+    Return only a JSON object, no markdown: {{"cleaned_input": "<normalized query>"}}
+
+    # Examples
+    Each example shows the raw input with its query context, then the expected output.
+
+    Example 1
+    Input: total unemployment data as a percentage of the labor force for Germany for the last 15 years
+    Named Entities:
+     - last 15 years (Time frequency) (REMOVE)
+     - Germany (Country/Reference area) (REMOVE)
+    Time Period: from 2009-08-08 to 2024-08-08
+    Output: {{"cleaned_input": "total unemployment data as a percent of the labor force"}}
+
+    Example 2
+    Input: Gross Domestic Product per capita growth rate for the United Kingdom since Brexit
+    Named Entities:
+     - United Kingdom (Country/Reference area) (REMOVE)
+    Time Period: from 2020-01-31
+    Output: {{"cleaned_input": "Gross Domestic Product per capita growth rate"}}
+
+    Example 3
+    Input: calculate the misery index for Austria
+    Named Entities:
+     - Austria (Country/Reference area) (REMOVE)
+    Output: {{"cleaned_input": "misery index"}}
+
+    Example 4
+    Input: unemployment rate and inflation rate to calculate the Misery Index
+    (no Named Entities, no Time Period)
+    Output: {{"cleaned_input": "unemployment rate and inflation rate to calculate the Misery Index"}}
+
+    Example 5
+    Input: net trade flow of manufacturing items between the United States and Eurozone (as a group)
+    Named Entities:
+     - United States (Country/Reference area) (REMOVE)
+     - Euro Area (Counterpart area) (REMOVE)
+    Output: {{"cleaned_input": "net trade flow of manufacturing items"}}
+
+    Example 6
+    Input: Number of stays of Poland citizens in hotels?
+    Named Entities:
+     - Poland (Country/Reference area) (REMOVE)
+     - Poland citizen (Citizenship of a certain country) (DO NOT REMOVE)
+    Output: {{"cleaned_input": "Number of stays of Poland citizens in hotels"}}
+
+    Example 7
+    Input: Economic growth for Group of Seven (G7) countries
+    Named Entities:
+     - Group of Seven (G7) (Country/Reference area) (REMOVE)
+    Output: {{"cleaned_input": "Economic growth"}}
+
+    # Query context
+    The data below was extracted from the current query. Any section may be empty.
 
     {entities}
-
     {period}
-
     {forbidden}
-
-    Input:
+  userMessage: |-
     {input}
-
-    Examples:
-    1. if case is described as JSON {{"Input": "Provide the total unemployment data as a percentage of the labor force for Germany for the last 15 years", "Named Entities": ["last 15 years (Time frequency) (REMOVE)", "Germany (Country/Reference area) (REMOVE)"], "Time Period": "from 2009-08-08 to 2024-08-08"] then expected cleaned input is "total unemployment data as a percent of the labor force"
-    2. if case is described as JSON {{"Input": "Get the Gross Domestic Product per capita growth rate for the United Kingdom since Brexit", "Named Entities": ["United Kingdom (Country/Reference area) (REMOVE)"], "Time Period": "from 2020-01-31 (REMOVE)"] then expected cleaned input is "Gross Domestic Product per capita growth rate"
-    3. if case is described as JSON {{"Input": "I need to calculate the misery index for Austria. What indicators would you recommend?", "Named Entities": ["Austria (Country/Reference area) (REMOVE)"]}} then expected cleaned input is "misery index"
-    4. if case is described as JSON {{"Input": "Query the unemployment rate and inflation rate to calculate the Misery Index"]}} then expected cleaned input is "unemployment rate and inflation rate to calculate the Misery Index"
-    5. if case is described as JSON {{"Input": "I would like to evaluate net trade flow of manufacturing items between the United States and Eurozone (as a group). What indicators would you suggest?", "Named Entities": ["United States (Country/Reference area) (REMOVE)", "Euro Area (Counterpart area) (REMOVE)""]}} then expected cleaned input is "net trade flow of manufacturing items"
-    6. if case is described as JSON {{"Input": "Number of stays of Poland citizens in hotels?", "Named Entities": ["Poland (Country/Reference area) (REMOVE)", "Poland citizen (Citizenship of a certain country (citizen of Finland/Uzbek/foreigner from Greece/etc.) (DO NOT REMOVE)"]] then expected cleaned input is "Number of stays of Poland citizens in hotels"
 
 separateSubjectsPrompt:
   systemMessage: |-

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -809,38 +809,13 @@ class HybridSearcher:
                 period_str = f"to {period.end}"
             period_str = "Time Period:\n" + period_str
 
-        removal_step = ""
-        if entities_str and period_str:
-            removal_step = (
-                "- from the input: "
-                "keep entities marked (DO NOT REMOVE), "
-                "remove entities marked (REMOVE) "
-                "and remove all parts related to Time Period. "
-                "If an entity or part of entity appears in multiple categories "
-                "and at least one instance is marked (DO NOT REMOVE), keep entity"
-            )
-        elif entities_str:
-            removal_step = (
-                "- from the input: "
-                "keep entities marked (DO NOT REMOVE), "
-                "remove entities marked (REMOVE). "
-                "If an entity or part of entity appears in multiple categories "
-                "and at least one instance is marked (DO NOT REMOVE), keep entity"
-            )
-        elif period_str:
-            removal_step = "- from the input remove all parts related to Time Period. Only period"
-
         forbidden_to_remove_str = ""
-        forbidden_step = ""
         if forbidden:
             forbidden_to_remove_str = ", ".join(forbidden)
             forbidden_to_remove_str = f"Forbidden to remove words:\n{forbidden_to_remove_str}\n"
-            forbidden_step = "- do not remove forbidden to remove words from the input if they are present in input"
 
         output = await self._normalization_chain.ainvoke(
             {
-                "removal_step": removal_step,
-                "forbidden_step": forbidden_step,
                 "input": query,
                 "entities": entities_str,
                 "period": period_str,

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -897,6 +897,11 @@ class HybridSearcher:
             query, "name_normalized", version_ids, self.config.max_lexical_pre_match_candidates
         )
         timings.lexical_pre_match = time.perf_counter() - t_lexical_pre_match
+        # Drop pre-match phrases that are not actually contiguous in the query so the
+        # normalization / separate-subjects prompts don't protect spurious terms
+        # (e.g. "country groups" surfaced for "... Group of Seven (G7) countries").
+        good_candidates = await self._filter_candidates_present_in_query(query, good_candidates)
+        candidates = await self._filter_candidates_present_in_query(query, candidates)
         forbidden = good_candidates | candidates
         logger.info(
             f"[search], {len(good_candidates)} good candidates, {len(candidates)} candidates "
@@ -1060,6 +1065,35 @@ class HybridSearcher:
                 values = dimension_query.values
                 availability_dict[dataset_id][dimension_id] = set(values)
         return availability_dict
+
+    @staticmethod
+    def _is_contiguous_sublist(needle: list[str], haystack: list[str]) -> bool:
+        n = len(needle)
+        if n == 0 or n > len(haystack):
+            return False
+        return any(haystack[i : i + n] == needle for i in range(len(haystack) - n + 1))
+
+    async def _filter_candidates_present_in_query(
+        self, query: str, candidates: set[str]
+    ) -> set[str]:
+        """Keep only candidates that occur as a contiguous (tokenized) phrase in the query.
+
+        Lexical pre-match highlights indicator-name tokens, so a candidate phrase can be
+        assembled from query words that are not actually adjacent - or are unrelated
+        concepts - in the user's query (e.g. an indicator named "... country groups"
+        matching the query "... Group of Seven (G7) countries"). Such phrases are not
+        really present in the query and must not be added to the protected
+        ("forbidden to remove") terms.
+        """
+        if not candidates:
+            return candidates
+        query_tokens = (await self._tokenize(query)).split()
+        result: set[str] = set()
+        for candidate in candidates:
+            candidate_tokens = (await self._tokenize(candidate)).split()
+            if self._is_contiguous_sublist(candidate_tokens, query_tokens):
+                result.add(candidate)
+        return result
 
     async def lexical_pre_match(
         self, query: str, highlight_field: str, version_ids: set[int], max_candidates: int

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -989,6 +989,7 @@ class HybridSearcher:
         if self.config.disable_separate_subjects:
             queries = [normalized]
         else:
+            # TODO: likely need to pass `candidates` (filtered) instead of `good_candidates`
             queries = await self._separate_subjects(normalized, good_candidates)
         timings.separate_subjects = time.perf_counter() - t_separate_subjects
         logger.info(f"[search], {queries=}, (elapsed {time.perf_counter() - t_total:0.3f} sec)")

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -22,7 +22,7 @@ from statgpt.common.config.logging import logger
 from statgpt.common.data.base import DimensionQuery, QueryOperator
 from statgpt.common.hybrid_indexer.schemas import IndicatorIndex, MatchingIndex
 from statgpt.common.schemas import HybridSearchConfig
-from statgpt.common.utils import async_utils
+from statgpt.common.utils import AsyncLoadingCache, async_utils
 from statgpt.common.utils.elastic import ElasticIndex, SearchResult
 from statgpt.common.utils.models import get_chat_model
 from statgpt.common.vectorstore import ScoredVectorStoreDocument, VectorStore
@@ -762,6 +762,13 @@ class HybridSearcher:
         self._indicators_index = indicators_index
         self._vectorstore = vectorstore
 
+        # Memoize tokenization for this search: the same query/candidate strings are tokenized
+        # several times across the pipeline (assess -> dedup -> cleanup -> contiguity filter).
+        # Instance-level on purpose - each HybridSearcher binds a specific `_matching_index`
+        # (per-channel analyzer), so the cache must not be shared across instances. No TTL: it
+        # is discarded with this per-search instance.
+        self._tokenize_cache: AsyncLoadingCache[str] = AsyncLoadingCache()
+
         self._normalization_chain = (
             hybrid_search_default_prompts.normalization_prompt.get_template()
             | self._llm.with_structured_output(method="json_mode")
@@ -848,8 +855,12 @@ class HybridSearcher:
 
     async def _tokenize(self, value: str) -> str:
         value = value.lower()
-        tokens = await self._matching_index.analyze(text=value)
-        return " ".join(t.token for t in tokens)
+
+        async def _load() -> str:
+            tokens = await self._matching_index.analyze(text=value)
+            return " ".join(token.token for token in tokens)
+
+        return await self._tokenize_cache.get(value, _load)
 
     async def _search_by_query(
         self,
@@ -1069,13 +1080,6 @@ class HybridSearcher:
                 availability_dict[dataset_id][dimension_id] = set(values)
         return availability_dict
 
-    @staticmethod
-    def _is_contiguous_sublist(needle: list[str], haystack: list[str]) -> bool:
-        n = len(needle)
-        if n == 0 or n > len(haystack):
-            return False
-        return any(haystack[i : i + n] == needle for i in range(len(haystack) - n + 1))
-
     async def _filter_candidates_present_in_query(
         self, query: str, candidates: set[str]
     ) -> set[str]:
@@ -1090,11 +1094,12 @@ class HybridSearcher:
         """
         if not candidates:
             return candidates
-        query_tokens = (await self._tokenize(query)).split()
+        padded_query = f" {await self._tokenize(query)} "
         result: set[str] = set()
         for candidate in candidates:
-            candidate_tokens = (await self._tokenize(candidate)).split()
-            if self._is_contiguous_sublist(candidate_tokens, query_tokens):
+            candidate_tokens = await self._tokenize(candidate)
+            # Guard empty: all-stopword phrases tokenize to "" and would match any query.
+            if candidate_tokens and f" {candidate_tokens} " in padded_query:
                 result.add(candidate)
         return result
 

--- a/tests/unit/app/services/test_hybrid_search_forbidden_filter.py
+++ b/tests/unit/app/services/test_hybrid_search_forbidden_filter.py
@@ -1,21 +1,7 @@
-import pytest
+from types import SimpleNamespace
 
 from statgpt.app.services.hybrid_searcher import HybridSearcher
-
-
-@pytest.mark.parametrize(
-    "needle, haystack, expected",
-    [
-        (["a", "b"], ["x", "a", "b", "y"], True),
-        (["a", "b"], ["a", "x", "b"], False),  # present but not adjacent
-        (["b", "a"], ["a", "b"], False),  # wrong order
-        ([], ["a"], False),
-        (["a", "b", "c"], ["a", "b"], False),  # longer than haystack
-        (["a"], ["a"], True),
-    ],
-)
-def test_is_contiguous_sublist(needle, haystack, expected):
-    assert HybridSearcher._is_contiguous_sublist(needle, haystack) is expected
+from statgpt.common.utils import AsyncLoadingCache
 
 
 def _searcher_with_fake_tokenizer() -> HybridSearcher:
@@ -49,6 +35,58 @@ async def test_filter_keeps_real_indicator_phrases():
     assert kept == {"net trade flow", "manufacturing items"}
 
 
+async def test_filter_drops_partial_token_matches():
+    # The match must land on whole token boundaries: "grow" inside "growth" and "nomic"
+    # inside "economic" must NOT count as present.
+    searcher = _searcher_with_fake_tokenizer()
+    kept = await searcher._filter_candidates_present_in_query(
+        "economic growth", {"grow", "nomic grow"}
+    )
+    assert kept == set()
+
+
+async def test_filter_drops_phrase_spanning_token_boundary():
+    # "c d" is a substring of "abc def" but spans the abc/def token boundary - drop it.
+    searcher = _searcher_with_fake_tokenizer()
+    kept = await searcher._filter_candidates_present_in_query("abc def", {"c d"})
+    assert kept == set()
+
+
+async def test_filter_drops_empty_tokenization():
+    # A candidate made only of stop-words tokenizes to "". The empty guard matters precisely
+    # when the query ALSO reduces to "": without it both operands render as padded blanks
+    # (" {} " -> "  ") and the candidate would spuriously match. It must be dropped.
+    searcher = object.__new__(HybridSearcher)
+
+    async def fake_tokenize(value: str) -> str:
+        # emulate ES stop-word removal: pure stop-word phrases reduce to nothing
+        return "" if value in {"of the", "the"} else value.lower()
+
+    searcher._tokenize = fake_tokenize  # type: ignore[method-assign]
+    kept = await searcher._filter_candidates_present_in_query("the", {"of the"})
+    assert kept == set()
+
+
 async def test_filter_empty_returns_empty():
     searcher = _searcher_with_fake_tokenizer()
     assert await searcher._filter_candidates_present_in_query("anything", set()) == set()
+
+
+async def test_tokenize_memoizes_and_is_case_insensitive():
+    # The same string (regardless of case) is analyzed by Elasticsearch at most once.
+    searcher = object.__new__(HybridSearcher)
+    searcher._tokenize_cache = AsyncLoadingCache()
+    analyze_calls: list[str] = []
+
+    class _FakeIndex:
+        async def analyze(self, *, text: str) -> list[SimpleNamespace]:
+            analyze_calls.append(text)
+            return [SimpleNamespace(token=tok) for tok in text.split()]
+
+    searcher._matching_index = _FakeIndex()  # type: ignore[assignment]
+
+    first = await searcher._tokenize("Gross Domestic Product")
+    second = await searcher._tokenize("gross domestic product")  # differs only by case
+
+    assert first == second == "gross domestic product"
+    assert analyze_calls == ["gross domestic product"]  # exactly one ES round-trip

--- a/tests/unit/app/services/test_hybrid_search_forbidden_filter.py
+++ b/tests/unit/app/services/test_hybrid_search_forbidden_filter.py
@@ -1,0 +1,54 @@
+import pytest
+
+from statgpt.app.services.hybrid_searcher import HybridSearcher
+
+
+@pytest.mark.parametrize(
+    "needle, haystack, expected",
+    [
+        (["a", "b"], ["x", "a", "b", "y"], True),
+        (["a", "b"], ["a", "x", "b"], False),  # present but not adjacent
+        (["b", "a"], ["a", "b"], False),  # wrong order
+        ([], ["a"], False),
+        (["a", "b", "c"], ["a", "b"], False),  # longer than haystack
+        (["a"], ["a"], True),
+    ],
+)
+def test_is_contiguous_sublist(needle, haystack, expected):
+    assert HybridSearcher._is_contiguous_sublist(needle, haystack) is expected
+
+
+def _searcher_with_fake_tokenizer() -> HybridSearcher:
+    """A HybridSearcher whose _tokenize just lowercases (no ES / stemming needed)."""
+    searcher = object.__new__(HybridSearcher)
+
+    async def fake_tokenize(value: str) -> str:
+        return value.lower()
+
+    searcher._tokenize = fake_tokenize  # type: ignore[method-assign]
+    return searcher
+
+
+async def test_filter_drops_phrases_not_contiguous_in_query():
+    # Reproduces the reported case: an indicator named "... country groups" surfaces
+    # "country groups" for a query about Group of Seven (G7) - it must be dropped.
+    searcher = _searcher_with_fake_tokenizer()
+    query = "Economic growth for Group of Seven (G7) countries"
+    kept = await searcher._filter_candidates_present_in_query(
+        query, {"country groups", "economic growth"}
+    )
+    assert kept == {"economic growth"}
+
+
+async def test_filter_keeps_real_indicator_phrases():
+    searcher = _searcher_with_fake_tokenizer()
+    query = "net trade flow of manufacturing items"
+    kept = await searcher._filter_candidates_present_in_query(
+        query, {"net trade flow", "manufacturing items"}
+    )
+    assert kept == {"net trade flow", "manufacturing items"}
+
+
+async def test_filter_empty_returns_empty():
+    searcher = _searcher_with_fake_tokenizer()
+    assert await searcher._filter_candidates_present_in_query("anything", set()) == set()

--- a/tests/unit/app/services/test_hybrid_search_normalization_prompt.py
+++ b/tests/unit/app/services/test_hybrid_search_normalization_prompt.py
@@ -1,0 +1,60 @@
+import pytest
+
+from statgpt.app.default_prompts import hybrid_search_default_prompts
+
+EXPECTED_VARS = {"entities", "period", "forbidden", "input"}
+
+
+def test_normalization_prompt_input_variables():
+    """The YAML placeholders must stay in sync with the keys passed by _normalize_input."""
+    template = hybrid_search_default_prompts.normalization_prompt.get_template()
+    assert set(template.input_variables) == EXPECTED_VARS
+
+
+def test_normalization_prompt_split_system_holds_instructions_user_holds_only_input():
+    template = hybrid_search_default_prompts.normalization_prompt.get_template()
+    messages = template.format_messages(
+        entities="Named Entities:\n - Germany (Country/Reference area) (REMOVE)\n",
+        period="Time Period:\nfrom 2010-01-01 to 2020-12-31",
+        forbidden="Forbidden to remove words:\nbalance of payments\n",
+        input="gdp for germany",
+    )
+    assert len(messages) == 2
+    system_msg, human_msg = messages[0].content, messages[1].content
+    assert isinstance(system_msg, str) and isinstance(human_msg, str)
+
+    # Instructions + JSON output contract live in the system message.
+    assert "Instructions" in system_msg
+    assert "cleaned_input" in system_msg
+    assert "JSON" in system_msg
+    # The runtime query context is rendered into the system message, not the user message.
+    assert "Germany" in system_msg
+    assert "balance of payments" in system_msg
+    # The user message carries ONLY the raw query.
+    assert human_msg.strip() == "gdp for germany"
+    assert "Instructions" not in human_msg
+
+
+@pytest.mark.parametrize(
+    "entities, period, forbidden",
+    [
+        (
+            "Named Entities:\n - Germany (Country/Reference area) (REMOVE)\n",
+            "Time Period:\nfrom 2010-01-01 to 2020-12-31",
+            "Forbidden to remove words:\nGDP\n",
+        ),
+        ("Named Entities:\n - Germany (Country/Reference area) (REMOVE)\n", "", ""),
+        ("", "Time Period:\nfrom 2010-01-01 to 2020-12-31", ""),
+        ("", "", ""),
+    ],
+)
+def test_normalization_prompt_renders_all_conditional_cases(entities, period, forbidden):
+    """Every combination of present/absent context sections renders without error."""
+    template = hybrid_search_default_prompts.normalization_prompt.get_template()
+    messages = template.format_messages(
+        entities=entities, period=period, forbidden=forbidden, input="some query"
+    )
+    assert len(messages) == 2
+    human_msg = messages[1].content
+    assert isinstance(human_msg, str)
+    assert human_msg.strip() == "some query"


### PR DESCRIPTION
### Applicable issues

- fixes #444

### Description of changes

Restructures the hybrid-search **normalization prompt** (`normalizationPrompt`):

- Moves the instructions and few-shot examples out of the user message and into the **system message**, organized with sectioned markdown for better gpt-4.1 adherence. The user message now contains **only the raw query**; the extracted query context (named entities, time period, protected terms) is part of the system message.
- The two conditional instruction fragments previously assembled in Python (`removal_step`, `forbidden_step`) become always-present, explicitly-scoped system-prompt instructions, so `_normalize_input` passes only the dynamic data.

Behavior is preserved across all entity/period combinations and was verified against `gpt-4.1` on ~30 cases (country groups, language preservation, over-removal and forbidden-override guards). Adds unit tests for the prompt's input-variable contract and the system/user split.

Also fixes a related pre-existing issue surfaced while verifying: lexical pre-match could add phrases assembled from **non-adjacent** query tokens to the protected "forbidden to remove" set (e.g. an indicator named `… country groups` highlighted for the query `… Group of Seven (G7) countries`). Pre-match candidates are now filtered to phrases that appear as a contiguous phrase in the query before forming the protected set; the search planner's separate pre-match call is unchanged.

Scope: only `normalizationPrompt` and the protected-terms set feeding it — the separate-subjects and relevancy prompts are unchanged.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.