### PR TITLE
feat: surface lexical-only indicators to the hybrid-search relevance judge #446

### DIFF
--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -418,9 +418,48 @@ class HybridSearcher:
             candidates = self.make_sure_top_n_is_included(
                 candidates, hybrid_sorted, max_output=search_params.max_candidates
             )
+            candidates = self._include_lexical_only_candidates(
+                candidates,
+                lex_filtered,
+                max_lexical_only=self._outer.config.max_lexical_only_candidates,
+            )
 
             timings.hybrid_candidates_total = time.perf_counter() - t_total
             return lex_filtered, sem_filtered, candidates
+
+        def _include_lexical_only_candidates(
+            self,
+            candidates: list[dict],
+            lex_filtered: HarmonizedItemsScoredDict,
+            max_lexical_only: int,
+        ) -> list[dict]:
+            """Force the top lexical-only candidates into the LLM relevance set.
+
+            Fusion (`_hybrid_combination`) is anchored on the semantic results: it iterates the
+            semantic candidates and drops any id missing from them. A strong keyword match that
+            falls outside the semantic top-k therefore never enters the candidate set, never
+            reaches the LLM relevance judge, and can never be selected — a pure recall loss on
+            rare/coded indicators with weak embeddings. This rescues up to ``max_lexical_only`` such
+            candidates (already availability-filtered, ranked by lexical score) that are not already
+            present, appending them on top of the diversified hybrid candidates so the judge can
+            still score them.
+            """
+            if max_lexical_only <= 0:
+                return candidates
+
+            existing_ids = {c['id'] for c in candidates}
+            lexical_sorted = sorted(lex_filtered.items(), key=lambda x: x[1].score, reverse=True)
+
+            added = 0
+            for _id, data in lexical_sorted:
+                if added >= max_lexical_only:
+                    break
+                if _id in existing_ids:
+                    continue
+                candidates.append({"id": _id, "metadata": data.metadata.model_dump()})
+                existing_ids.add(_id)
+                added += 1
+            return candidates
 
         def make_sure_top_n_is_included(
             self,

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -447,6 +447,13 @@ class HybridSearcher:
             if max_lexical_only <= 0:
                 return candidates
 
+            # can be simplified to:
+            # 1. sort lexical candidates by reversed score
+            # 2. filter out ids present in existing candidates
+            # 3. take slice of lexical candidates
+            # 4. extending the candidates with this slice
+            # this avoids looping and state management inside the loop
+
             existing_ids = {c['id'] for c in candidates}
             lexical_sorted = sorted(lex_filtered.items(), key=lambda x: x[1].score, reverse=True)
 

--- a/statgpt/common/schemas/data_query_tool.py
+++ b/statgpt/common/schemas/data_query_tool.py
@@ -1,6 +1,13 @@
 from typing import Any
 
-from pydantic import Field, PositiveInt, TypeAdapter, field_validator, model_validator
+from pydantic import (
+    Field,
+    NonNegativeInt,
+    PositiveInt,
+    TypeAdapter,
+    field_validator,
+    model_validator,
+)
 from pydantic_core.core_schema import FieldValidationInfo
 
 from statgpt.common.config import LLMModelsEnum
@@ -207,6 +214,18 @@ class HybridSearchConfig(BaseYamlModel):
     max_semantic_candidates: PositiveInt = Field(
         default=2 * DEFAULT_MAX_CANDIDATES,
         description="The number of candidates to be searched by semantic search.",
+    )
+    max_lexical_only_candidates: NonNegativeInt = Field(
+        default=8,
+        description=(
+            "Number of top lexical-only candidates to force into the LLM relevance set. "
+            "Fusion is anchored on semantic results, so a strong keyword match that falls "
+            "outside the semantic top-k (`max_semantic_candidates`) is otherwise dropped before "
+            "the LLM judge and can never be selected — a pure recall loss on rare/coded indicators "
+            "with weak embeddings. These candidates are availability-filtered and ranked by lexical "
+            "score, and are added on top of the diversified hybrid candidates. "
+            "Set to 0 to restore the previous semantic-anchored behavior."
+        ),
     )
 
     default_alpha: float = Field(default=0.9)

--- a/tests/unit/app/services/test_hybrid_searcher.py
+++ b/tests/unit/app/services/test_hybrid_searcher.py
@@ -1,0 +1,97 @@
+"""Unit tests for HybridSearcher.HybridMatch candidate assembly."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from statgpt.app.services.hybrid_searcher import HarmonizedItemScored, HybridSearcher
+from statgpt.common.hybrid_indexer.schemas import IndicatorIndex
+
+
+def _indicator(id_: str, dataset_id: str = "ds1") -> IndicatorIndex:
+    return IndicatorIndex(
+        id=id_,
+        dataset_id=dataset_id,
+        dataset_name="Dataset One",
+        version_id=1,
+        series="[]",
+        name=f"name {id_}",
+        name_normalized=f"name {id_}",
+        where=[],
+        primary=f"primary {id_}",
+        primary_normalized=f"primary {id_}",
+    )
+
+
+def _candidate(id_: str, dataset_id: str = "ds1") -> dict:
+    """A candidate dict in the shape produced by hybrid diversification."""
+    return {"id": id_, "metadata": _indicator(id_, dataset_id).model_dump()}
+
+
+def _lex(id_: str, score: float, dataset_id: str = "ds1") -> HarmonizedItemScored:
+    return HarmonizedItemScored(score=score, metadata=_indicator(id_, dataset_id))
+
+
+@pytest.fixture
+def match() -> HybridSearcher.HybridMatch:
+    return HybridSearcher.HybridMatch(outer=Mock())
+
+
+def test_disabled_returns_candidates_unchanged(match):
+    candidates = [_candidate("a"), _candidate("b")]
+    lex_filtered = {"c": _lex("c", 0.9)}
+
+    result = match._include_lexical_only_candidates(candidates, lex_filtered, max_lexical_only=0)
+
+    assert [c["id"] for c in result] == ["a", "b"]
+
+
+def test_appends_top_lexical_only_sorted_by_score(match):
+    candidates = [_candidate("a")]
+    lex_filtered = {
+        "x": _lex("x", 0.2),
+        "y": _lex("y", 0.9),
+        "z": _lex("z", 0.5),
+    }
+
+    result = match._include_lexical_only_candidates(candidates, lex_filtered, max_lexical_only=2)
+
+    # existing candidate kept; top-2 lexical-only added in descending score order
+    assert [c["id"] for c in result] == ["a", "y", "z"]
+
+
+def test_skips_ids_already_present(match):
+    candidates = [_candidate("a"), _candidate("b")]
+    lex_filtered = {
+        "a": _lex("a", 0.99),  # already a candidate -> must not be duplicated
+        "c": _lex("c", 0.7),
+    }
+
+    result = match._include_lexical_only_candidates(candidates, lex_filtered, max_lexical_only=5)
+
+    assert [c["id"] for c in result] == ["a", "b", "c"]
+    assert [c["id"] for c in result].count("a") == 1
+
+
+def test_cap_limits_number_added(match):
+    candidates: list[dict] = []
+    lex_filtered = {str(i): _lex(str(i), float(i)) for i in range(10)}
+
+    result = match._include_lexical_only_candidates(candidates, lex_filtered, max_lexical_only=3)
+
+    # highest scores first: 9, 8, 7
+    assert [c["id"] for c in result] == ["9", "8", "7"]
+
+
+def test_appended_candidate_has_consumable_shape(match):
+    """Appended entries must match the {id, metadata-dict} shape _prepare_for_relevance expects."""
+    candidates: list[dict] = []
+    lex_filtered = {"c": _lex("c", 0.7)}
+
+    result = match._include_lexical_only_candidates(candidates, lex_filtered, max_lexical_only=1)
+
+    appended = result[0]
+    assert appended["id"] == "c"
+    metadata = appended["metadata"]
+    for key in ("dataset_id", "primary_normalized", "name_normalized", "where", "series"):
+        assert key in metadata


### PR DESCRIPTION
### Applicable issues

- fixes #446

### Description of changes

Hybrid indicator search fuses lexical + semantic results by iterating the **semantic** candidates only (`HybridMatch._hybrid_combination`): it walks the semantic hits and skips any id not present among them. A strong keyword match that falls outside the semantic top-k (`max_semantic_candidates`) therefore never enters fusion, never reaches the LLM relevance judge, and can never be selected — a pure recall loss on rare / coded indicators with weak embeddings (e.g. several BIS series). The availability-filtered lexical results are already computed but only used for the debug report, not for selection.

- After diversification, force the top `max_lexical_only_candidates` availability-filtered, lexical-score-ranked candidates that are not already present into the LLM relevance set, so the judge can still score them.
- Add `max_lexical_only_candidates` to `HybridSearchConfig` (default **8**); set it to `0` to restore the previous semantic-anchored behavior.
- Fusion scoring and ordering are unchanged — the only behavioral change is that previously-dropped lexical hits now reach the judge.
- Scope: runtime searcher only. The build-time `indexer.py` twin (harmonization) is intentionally unchanged.
- Adds unit tests for the injection (disabled passthrough, top-K ordering, dedup vs existing candidates, cap, consumable shape).

**Verification:** run the `gtdc.data-query` eval and compare indicator recall (especially BIS `WS_LBS_D_PUB` / `WS_NA_SEC_DSS`) against baseline; watch that `precision_soft` and latency do not regress. To A/B within the branch, set `maxLexicalOnlyCandidates: 0` in the gtdc channel `tools.yaml`.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.