### PR TITLE
chore: update sample config

### DIFF
--- a/configurations/clients/sample/datasets/imf.yaml
+++ b/configurations/clients/sample/datasets/imf.yaml
@@ -5,6 +5,18 @@ _anchors:
       - "statgpt-sample"
   _shared_details: &shared_details
     useTitleFromSrc: false
+    dataExplorerUrlConfig:
+      includeDataflowUrnParam: true
+      datasetUrnParam: datasetUrn
+      filterFormat: sdmx_key_string
+      includeSeriesKeyFilter: true
+      seriesKeyFilterParam: timeseriesName
+      timeEncoding: start_end_sdmx21
+    includeAttributes:
+      - "SCALE"
+      - "UNIT"
+      - "PUBLISHER"
+      - "SOURCE"
   _common_dimensions: &common_dimensions
     COUNTRY:
       dimensionType: "NON_INDICATOR"
@@ -44,11 +56,6 @@ dataSets:
               operator: "between"
         UNIT:
           dimensionType: "NON_INDICATOR"
-      includeAttributes:
-        - "SCALE"
-        - "UNIT"
-        - "PUBLISHER"
-        - "SOURCE"
       citation:
         provider: "IMF.STA"
         url: "https://data.imf.org/en/datasets/IMF.STA:BOP"
@@ -84,11 +91,6 @@ dataSets:
           defaultQueries:
             - values: [ "-5y", "+2y" ]
               operator: "between"
-      includeAttributes:
-        - "SCALE"
-        - "UNIT"
-        - "PUBLISHER"
-        - "SOURCE"
       citation:
         provider: "IMF.RES"
         url: "https://data.imf.org/en/datasets/IMF.RES:WEO"


### PR DESCRIPTION
### Applicable issues

N/A

### Description of changes

Updates the IMF sample dataset configuration:
- Adds `dataExplorerUrlConfig` to the `_shared_details` anchor, configuring data explorer URL generation for all IMF datasets (SDMX key string filter format, series key filter, start/end time encoding).
- Moves `includeAttributes` into the `_shared_details` anchor, removing per-dataset repetition.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
