### PR TITLE
fix: store real exceptions in reason_for_failure instead of generic TaskGroup message

### DIFF
--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -44,7 +44,7 @@ from statgpt.common.settings.document import (
     IndicatorDocumentMetadataFields,
     SpecialDimensionValueDocumentMetadataFields,
 )
-from statgpt.common.utils import async_utils, crc32_hash_incremental_async
+from statgpt.common.utils import async_utils, crc32_hash_incremental_async, format_exception_reason
 from statgpt.common.utils.elastic import ElasticIndex, ElasticSearchFactory, SearchResult
 from statgpt.common.vectorstore import EmbeddinglessVectorStore, VectorStore, VectorStoreFactory
 
@@ -1886,7 +1886,9 @@ class AdminPortalDataSetService(DataSetService):
                     channel_dataset_version_id
                 )
                 await self._update_channel_dataset_version_status(
-                    version, new_status=StatusEnum.FAILED, reason_for_failure=str(e)
+                    version,
+                    new_status=StatusEnum.FAILED,
+                    reason_for_failure=format_exception_reason(e),
                 )
 
     async def clear_channel_dataset_data_in_background(self, channel_dataset_id: int) -> None:
@@ -2574,7 +2576,7 @@ class AdminPortalDataSetService(DataSetService):
                 job = await self._session.get(models.AutoUpdateJob, auto_update_job_id)
                 if job is not None:
                     job.status = StatusEnum.FAILED
-                    job.reason_for_failure = str(e)
+                    job.reason_for_failure = format_exception_reason(e)
                     await self._session.commit()
 
 

--- a/statgpt/admin/services/import_export_jobs.py
+++ b/statgpt/admin/services/import_export_jobs.py
@@ -22,7 +22,12 @@ from statgpt.admin.settings.exim import JobsConfig
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.schemas import AuditActionType, AuditEntityType
 from statgpt.common.settings.dial import dial_settings
-from statgpt.common.utils import AttachmentResponse, AttachmentsStorage, attachments_storage_factory
+from statgpt.common.utils import (
+    AttachmentResponse,
+    AttachmentsStorage,
+    attachments_storage_factory,
+    format_exception_reason,
+)
 
 from .channel import AdminPortalChannelService as ChannelService
 from .dataset import AdminPortalDataSetService as DataSetService
@@ -216,7 +221,7 @@ class JobsService:
             job.status = schemas.PreprocessingStatusEnum.QUEUED
         except Exception as e:
             _log.exception(e)
-            job.reason_for_failure = str(e)
+            job.reason_for_failure = format_exception_reason(e)
             job.status = schemas.PreprocessingStatusEnum.FAILED
 
         job.updated_at = func.now()
@@ -298,7 +303,7 @@ class JobsService:
                     file_url = resp.url
         except Exception as e:
             _log.exception(e)
-            job.reason_for_failure = str(e)
+            job.reason_for_failure = format_exception_reason(e)
             await self._update_job_status(job, schemas.PreprocessingStatusEnum.FAILED)
             return schemas.Job.model_validate(job, from_attributes=True)
 
@@ -461,7 +466,7 @@ class JobsService:
                     )
         except Exception as e:
             _log.exception(e)
-            job.reason_for_failure = str(e)
+            job.reason_for_failure = format_exception_reason(e)
             await self._update_job_status(job, schemas.PreprocessingStatusEnum.FAILED)
             return schemas.Job.model_validate(job, from_attributes=True)
 

--- a/statgpt/common/utils/__init__.py
+++ b/statgpt/common/utils/__init__.py
@@ -7,7 +7,7 @@ from .dial import (
     attachments_storage_factory,
     dial_core_factory,
 )
-from .exceptions import InvalidLLMStreamResponse
+from .exceptions import InvalidLLMStreamResponse, format_exception_reason
 from .files import (
     change_file_extension,
     clean_filename,

--- a/statgpt/common/utils/exceptions.py
+++ b/statgpt/common/utils/exceptions.py
@@ -1,2 +1,16 @@
 class InvalidLLMStreamResponse(Exception):
     """The exception raised when LLM streams an invalid response."""
+
+
+def format_exception_reason(exc: BaseException) -> str:
+    """Render an exception as a concise human-readable reason string.
+
+    ``asyncio.TaskGroup()`` raises a ``BaseExceptionGroup`` whose ``str()`` is the
+    generic "unhandled errors in task group (N sub-exceptions)" message, hiding the
+    real cause. This unwraps groups recursively and joins the leaf exceptions as
+    "<ClassName>: <message>".
+    """
+    if isinstance(exc, BaseExceptionGroup):
+        return "; ".join(format_exception_reason(sub) for sub in exc.exceptions)
+    message = str(exc)
+    return f"{type(exc).__name__}: {message}" if message else type(exc).__name__

--- a/tests/unit/common/utils/test_exceptions.py
+++ b/tests/unit/common/utils/test_exceptions.py
@@ -1,0 +1,30 @@
+"""Unit tests for the exception utilities."""
+
+from statgpt.common.utils.exceptions import format_exception_reason
+
+
+class TestFormatExceptionReason:
+    """Tests for ``format_exception_reason``."""
+
+    def test_plain_exception(self) -> None:
+        assert format_exception_reason(ValueError("bad value")) == "ValueError: bad value"
+
+    def test_empty_message_falls_back_to_class_name(self) -> None:
+        assert format_exception_reason(KeyError()) == "KeyError"
+
+    def test_single_child_group_unwraps_to_leaf(self) -> None:
+        # The original bug: str() of this group yields the generic
+        # "unhandled errors in task group (1 sub-exception)" message.
+        group = ExceptionGroup("group", [ValueError("dataset 'X' not found")])
+        assert format_exception_reason(group) == "ValueError: dataset 'X' not found"
+
+    def test_multi_child_group_joins_leaves(self) -> None:
+        group = ExceptionGroup("group", [ValueError("first"), ConnectionError("timeout")])
+        assert format_exception_reason(group) == "ValueError: first; ConnectionError: timeout"
+
+    def test_nested_group_is_flattened(self) -> None:
+        group = ExceptionGroup(
+            "outer",
+            [ValueError("first"), ExceptionGroup("inner", [RuntimeError("second")])],
+        )
+        assert format_exception_reason(group) == "ValueError: first; RuntimeError: second"


### PR DESCRIPTION
### Applicable issues

- fixes #453

### Description of changes

Since adopting `asyncio.TaskGroup()`, failed background jobs persisted a useless `reason_for_failure` like `unhandled errors in task group (1 sub-exception)`. A `TaskGroup` raises a `BaseExceptionGroup` whose `str()` is that generic wrapper — the real cause lives in `exc.exceptions` and was being discarded by `reason_for_failure = str(e)`.

- Add `format_exception_reason()` in `statgpt/common/utils/exceptions.py`, which recursively unwraps `BaseExceptionGroup` into its leaf exceptions, rendered as `"<ClassName>: <message>"` joined by `"; "` (falls back to the bare class name when the message is empty).
- Use it at the job-failure sink sites in place of `str(e)`:
  - `admin/services/dataset.py` — reindex and auto-update handlers
  - `admin/services/import_export_jobs.py` — import-create, export, and import-background handlers
- Add unit tests covering plain exceptions, empty messages, and single/multi/nested exception groups.

No DB schema change — `reason_for_failure` stays `str | None`.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.