### PR TITLE
fix: send X-Source-Artefact-Urn header on all SDMX proxy structure requests #456

### DIFF
--- a/statgpt/common/data/sdmx/v21/datasource.py
+++ b/statgpt/common/data/sdmx/v21/datasource.py
@@ -402,6 +402,13 @@ class Sdmx21DataSourceHandler(
 
         return problems
 
+    def _create_dataflow_loader(self, sdmx_client: AsyncSdmxClient) -> DataflowLoader:
+        """Create a DataflowLoader for this data source.
+
+        Override to wire in source-specific behavior such as structure request headers.
+        """
+        return DataflowLoader(sdmx_client)
+
     async def _load_dataset_structure_message(
         self, urn_ref: UrnReference, auth_context: AuthContext
     ) -> tuple[Urn, StructureMessage21]:
@@ -410,7 +417,7 @@ class Sdmx21DataSourceHandler(
             agency_id=urn_ref.agency_id, resource_id=urn_ref.resource_id, version=urn_ref.version
         )
         sdmx_client = await self.create_sdmx_client(auth_context)
-        dataflow_loader = DataflowLoader(sdmx_client)
+        dataflow_loader = self._create_dataflow_loader(sdmx_client)
         urn, structure_message = await dataflow_loader.load_structure_message(urn, mode="full")
         return urn, structure_message
 
@@ -524,7 +531,7 @@ class Sdmx21DataSourceHandler(
 
         sdmx_client = await self.create_sdmx_client(auth_context)
 
-        dataflow_loader = DataflowLoader(sdmx_client)
+        dataflow_loader = self._create_dataflow_loader(sdmx_client)
         urn, structure_message = await dataflow_loader.load_structure_message(urn, mode="shallow")
 
         meta_json = {

--- a/statgpt/common/data/statgpt_sdmx_proxy/v30/datasource.py
+++ b/statgpt/common/data/statgpt_sdmx_proxy/v30/datasource.py
@@ -61,6 +61,9 @@ class StatGptSdmxProxyDataSourceHandler(Sdmx21DataSourceHandler):
         )
         return SdmxClient.from_config(self._config, auth_context, rate_limiter)
 
+    def _create_dataflow_loader(self, sdmx_client: SdmxClient) -> DataflowLoader:  # type: ignore[override]
+        return DataflowLoader(sdmx_client, structure_extra_headers=proxy_structure_extra_headers)
+
     @staticmethod
     def _to_proxy_annotation(annotation: BaseAnnotation) -> Sdmx30AnnotationModel:
         text = str(annotation.text) if annotation.text else None
@@ -95,9 +98,7 @@ class StatGptSdmxProxyDataSourceHandler(Sdmx21DataSourceHandler):
                 resource_id=dataset_config.urn.resource_id,
                 version=dataset_config.urn.version,
             )
-            dataflow_loader = DataflowLoader(
-                sdmx_client, structure_extra_headers=proxy_structure_extra_headers
-            )
+            dataflow_loader = self._create_dataflow_loader(sdmx_client)
             urn, structure_message = await dataflow_loader.load_structure_message(urn, mode="full")
             dataflow = structure_message.dataflow[urn]
         except Exception:


### PR DESCRIPTION

### Applicable issues

- fixes #456

### Description of changes

The `X-Source-Artefact-Urn` header (which disambiguates artefacts that share an identity) was only wired into the proxy handler's `_get_dataset`. Other structure-loading paths in the base `Sdmx21DataSourceHandler` — `_load_dataset_structure_message` (used by `reresolve_config`/auto-update) and `get_structure_hash_and_metadata` — created a bare `DataflowLoader`, so the header was dropped and the proxy responded with `400 Bad Request`, failing the auto-update job.

- Introduced an overridable `_create_dataflow_loader` hook in the base handler, used by all structure-loading paths.
- Overrode it in the proxy handler to inject the header callback.
- Routed the proxy's `_get_dataset` through the same hook, giving a single source of truth for loader creation.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.