### PR TITLE
fix: close Elasticsearch client on shutdown to avoid unclosed session warnings #458

### DIFF
--- a/statgpt/admin/app.py
+++ b/statgpt/admin/app.py
@@ -27,13 +27,14 @@ from statgpt.admin.settings.app import APP_SETTINGS
 from statgpt.common.config import multiline_logger as logger
 from statgpt.common.models import DatabaseHealthChecker, optional_msi_token_manager_context
 from statgpt.common.services.data_preloader import preload_data
+from statgpt.common.utils.elastic import elasticsearch_client_context
 
 Lifespan = Callable[[FastAPI], AsyncContextManager[None]]
 
 
 @asynccontextmanager
 async def app_lifespan(app_: FastAPI):
-    async with optional_msi_token_manager_context():
+    async with optional_msi_token_manager_context(), elasticsearch_client_context():
         # Check resources' availability:
         await DatabaseHealthChecker().check()
 

--- a/statgpt/admin/auto_update.py
+++ b/statgpt/admin/auto_update.py
@@ -14,6 +14,7 @@ from statgpt.admin.services.channel import (
 from statgpt.admin.services.dataset import AdminPortalDataSetService, auto_update_in_background_task
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.models import get_session_context_manager, optional_msi_token_manager_context
+from statgpt.common.utils.elastic import elasticsearch_client_context
 
 _log = logging.getLogger(__name__)
 _SEPARATOR = "-" * 50
@@ -134,7 +135,7 @@ async def run_auto_update() -> bool:
 async def main() -> None:
     try:
         _log.info("Starting batch auto-update script...")
-        async with optional_msi_token_manager_context():
+        async with optional_msi_token_manager_context(), elasticsearch_client_context():
             success = await run_auto_update()
 
         _log.info(_SEPARATOR)

--- a/statgpt/app/application/application.py
+++ b/statgpt/app/application/application.py
@@ -12,11 +12,12 @@ from fastapi import params as fastapi_params
 
 from statgpt.common.models import DatabaseHealthChecker, optional_msi_token_manager_context
 from statgpt.common.services.data_preloader import preload_data
+from statgpt.common.utils.elastic import elasticsearch_client_context
 
 
 @asynccontextmanager
 async def lifespan(app: "StatGPTApp"):
-    async with optional_msi_token_manager_context():
+    async with optional_msi_token_manager_context(), elasticsearch_client_context():
         # Check resources' availability:
         await DatabaseHealthChecker().check()
 

--- a/statgpt/common/utils/elastic.py
+++ b/statgpt/common/utils/elastic.py
@@ -1,4 +1,5 @@
-from collections.abc import Iterable
+from collections.abc import AsyncIterator, Iterable
+from contextlib import asynccontextmanager
 from typing import Any
 
 from elasticsearch import AsyncElasticsearch, helpers
@@ -208,3 +209,20 @@ class ElasticSearchFactory:
             cls._indexes[name] = index
 
         return cls._indexes[name]
+
+    @classmethod
+    async def close(cls) -> None:
+        """Close the singleton client and reset cached state. No-op if never opened."""
+        if cls._client is not None:
+            await cls._client.close()
+            cls._client = None
+            cls._indexes.clear()
+
+
+@asynccontextmanager
+async def elasticsearch_client_context() -> AsyncIterator[None]:
+    """Ensure the lazily-created Elasticsearch singleton is closed on exit."""
+    try:
+        yield
+    finally:
+        await ElasticSearchFactory.close()


### PR DESCRIPTION

### Applicable issues

- fixes #458

### Description of changes

The `AsyncElasticsearch` singleton held by `ElasticSearchFactory` was created lazily on first use and never closed. At interpreter teardown the GC finalized the still-open `aiohttp.ClientSession`, emitting `Unclosed client session` / `Unclosed connector` warnings — and occasionally a logging error (`sys.meta_path is None`) when routing that warning through uvicorn's formatter during shutdown.

This adds explicit cleanup while the event loop is still alive:

- `ElasticSearchFactory.close()` — closes the client, resets `_client`, and clears `_indexes`. No-op when no client was ever opened, so lazy initialization is preserved.
- `elasticsearch_client_context()` — an async context manager that closes the singleton on exit, mirroring the existing `optional_msi_token_manager_context()` pattern.
- Nested into both app lifespans (chat + admin) and the standalone `auto_update.py` script, which can lazily open the client.

Verified locally: a process that opens the Elasticsearch client previously printed the unclosed-session warnings at exit, and now exits cleanly with none.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.