### PR TITLE
fix: mark auto-update job FAILED on background task timeout #485

### DIFF
--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -2498,7 +2498,7 @@ class AdminPortalDataSetService(DataSetService):
     async def _mark_auto_update_job_failed(self, auto_update_job_id: int, reason: str) -> None:
         async with self._scoped_session():
             job = await self._session.get(models.AutoUpdateJob, auto_update_job_id)
-            if job is not None:
+            if job is not None and job.status not in StatusEnum.final_statuses():
                 job.status = StatusEnum.FAILED
                 job.reason_for_failure = reason
                 await self._session.commit()
@@ -2646,8 +2646,8 @@ class AdminPortalDataSetService(DataSetService):
             # coroutine, surfacing here as CancelledError (a BaseException that the
             # `except Exception` branch below does NOT catch). Without this branch the
             # job would be left stuck in IN_PROGRESS. Mark it FAILED — shielded so the
-            # write survives the cancellation — then re-raise so the decorator's
-            # timeout machinery still runs.
+            # write survives a subsequent cancel (e.g. shutdown) — then re-raise so
+            # the decorator's timeout machinery still runs.
             _log.error(f"Auto-update job {auto_update_job_id} was cancelled (likely timed out)")
             await asyncio.shield(
                 self._mark_auto_update_job_failed(

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os.path
@@ -2494,6 +2495,16 @@ class AdminPortalDataSetService(DataSetService):
                 job, StatusEnum.COMPLETED, result=schemas.AutoUpdateResult.REINDEX_TRIGGERED
             )
 
+    async def _mark_auto_update_job_failed(
+        self, auto_update_job_id: int, reason: str
+    ) -> None:
+        async with self._scoped_session():
+            job = await self._session.get(models.AutoUpdateJob, auto_update_job_id)
+            if job is not None:
+                job.status = StatusEnum.FAILED
+                job.reason_for_failure = reason
+                await self._session.commit()
+
     async def process_auto_update_job(
         self,
         auto_update_job_id: int,
@@ -2632,14 +2643,25 @@ class AdminPortalDataSetService(DataSetService):
                     auth_context=auth_context,
                 )
 
+        except asyncio.CancelledError:
+            # A per-task timeout in the @background_task decorator cancels this
+            # coroutine, surfacing here as CancelledError (a BaseException that the
+            # `except Exception` branch below does NOT catch). Without this branch the
+            # job would be left stuck in IN_PROGRESS. Mark it FAILED — shielded so the
+            # write survives the cancellation — then re-raise so the decorator's
+            # timeout machinery still runs.
+            _log.error(f"Auto-update job {auto_update_job_id} was cancelled (likely timed out)")
+            await asyncio.shield(
+                self._mark_auto_update_job_failed(
+                    auto_update_job_id, "Job cancelled (likely timed out)"
+                )
+            )
+            raise
         except Exception as e:
             _log.exception(f"Failed to process auto-update job {auto_update_job_id}")
-            async with self._scoped_session():
-                job = await self._session.get(models.AutoUpdateJob, auto_update_job_id)
-                if job is not None:
-                    job.status = StatusEnum.FAILED
-                    job.reason_for_failure = format_exception_reason(e)
-                    await self._session.commit()
+            await self._mark_auto_update_job_failed(
+                auto_update_job_id, format_exception_reason(e)
+            )
 
 
 @background_task

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -2495,9 +2495,7 @@ class AdminPortalDataSetService(DataSetService):
                 job, StatusEnum.COMPLETED, result=schemas.AutoUpdateResult.REINDEX_TRIGGERED
             )
 
-    async def _mark_auto_update_job_failed(
-        self, auto_update_job_id: int, reason: str
-    ) -> None:
+    async def _mark_auto_update_job_failed(self, auto_update_job_id: int, reason: str) -> None:
         async with self._scoped_session():
             job = await self._session.get(models.AutoUpdateJob, auto_update_job_id)
             if job is not None:
@@ -2659,9 +2657,7 @@ class AdminPortalDataSetService(DataSetService):
             raise
         except Exception as e:
             _log.exception(f"Failed to process auto-update job {auto_update_job_id}")
-            await self._mark_auto_update_job_failed(
-                auto_update_job_id, format_exception_reason(e)
-            )
+            await self._mark_auto_update_job_failed(auto_update_job_id, format_exception_reason(e))
 
 
 @background_task

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -1942,17 +1942,20 @@ class AdminPortalDataSetService(DataSetService):
                     f'Finished processing version_id={channel_dataset_version_id}'
                     f' of channel_dataset_id={channel_dataset_id}'
                 )
+        except asyncio.CancelledError:
+            # background_task timeout raises CancelledError, which `except Exception` misses.
+            _log.error(f"Reindex of version_id={channel_dataset_version_id} was cancelled")
+            await asyncio.shield(
+                self._mark_channel_dataset_version_failed(
+                    channel_dataset_version_id, "Reindex cancelled (likely timed out)"
+                )
+            )
+            raise
         except Exception as e:
             _log.exception(f"Failed to reindex version_id={channel_dataset_version_id}")
-            async with self._scoped_session():
-                version = await self._get_channel_dataset_version_or_raise(
-                    channel_dataset_version_id
-                )
-                await self._update_channel_dataset_version_status(
-                    version,
-                    new_status=StatusEnum.FAILED,
-                    reason_for_failure=format_exception_reason(e),
-                )
+            await self._mark_channel_dataset_version_failed(
+                channel_dataset_version_id, format_exception_reason(e)
+            )
 
     async def clear_channel_dataset_data_in_background(self, channel_dataset_id: int) -> None:
         _log.info(f"Clear data after reindexing channel_dataset_id={channel_dataset_id}")
@@ -2503,6 +2506,20 @@ class AdminPortalDataSetService(DataSetService):
                 job.reason_for_failure = reason
                 await self._session.commit()
 
+    async def _mark_channel_dataset_version_failed(
+        self, channel_dataset_version_id: int, reason: str
+    ) -> None:
+        async with self._scoped_session():
+            version = await self._session.get(
+                models.ChannelDatasetVersion, channel_dataset_version_id
+            )
+            if version is not None and (
+                version.preprocessing_status not in StatusEnum.final_statuses()
+            ):
+                await self._update_channel_dataset_version_status(
+                    version, new_status=StatusEnum.FAILED, reason_for_failure=reason
+                )
+
     async def process_auto_update_job(
         self,
         auto_update_job_id: int,
@@ -2642,12 +2659,7 @@ class AdminPortalDataSetService(DataSetService):
                 )
 
         except asyncio.CancelledError:
-            # A per-task timeout in the @background_task decorator cancels this
-            # coroutine, surfacing here as CancelledError (a BaseException that the
-            # `except Exception` branch below does NOT catch). Without this branch the
-            # job would be left stuck in IN_PROGRESS. Mark it FAILED — shielded so the
-            # write survives a subsequent cancel (e.g. shutdown) — then re-raise so
-            # the decorator's timeout machinery still runs.
+            # background_task timeout raises CancelledError, which `except Exception` misses.
             _log.error(f"Auto-update job {auto_update_job_id} was cancelled (likely timed out)")
             await asyncio.shield(
                 self._mark_auto_update_job_failed(

--- a/tests/unit/admin/services/test_auto_update_job.py
+++ b/tests/unit/admin/services/test_auto_update_job.py
@@ -37,3 +37,26 @@ class TestProcessAutoUpdateJobCancellation:
         assert job.status == StatusEnum.FAILED
         assert job.reason_for_failure
         mock_session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_does_not_clobber_completed_job(self) -> None:
+        """A late cancellation must not overwrite an already-terminal COMPLETED
+        job (e.g. one that finished with REINDEX_TRIGGERED)."""
+        job = MagicMock()
+        job.status = StatusEnum.COMPLETED
+
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=job)
+
+        service = AdminPortalDataSetService()
+        # Inject a session so _scoped_session() yields it directly (no real DB).
+        service._DbServiceBase__session = mock_session  # type: ignore[attr-defined]
+        service._set_auto_update_job_status = AsyncMock(  # type: ignore[method-assign]
+            side_effect=asyncio.CancelledError()
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await service.process_auto_update_job(auto_update_job_id=1, auth_context=MagicMock())
+
+        assert job.status == StatusEnum.COMPLETED
+        mock_session.commit.assert_not_awaited()

--- a/tests/unit/admin/services/test_auto_update_job.py
+++ b/tests/unit/admin/services/test_auto_update_job.py
@@ -32,9 +32,7 @@ class TestProcessAutoUpdateJobCancellation:
         )
 
         with pytest.raises(asyncio.CancelledError):
-            await service.process_auto_update_job(
-                auto_update_job_id=1, auth_context=MagicMock()
-            )
+            await service.process_auto_update_job(auto_update_job_id=1, auth_context=MagicMock())
 
         assert job.status == StatusEnum.FAILED
         assert job.reason_for_failure

--- a/tests/unit/admin/services/test_auto_update_job.py
+++ b/tests/unit/admin/services/test_auto_update_job.py
@@ -1,0 +1,41 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from statgpt.admin.services.dataset import AdminPortalDataSetService
+from statgpt.common.schemas import PreprocessingStatusEnum as StatusEnum
+
+
+class TestProcessAutoUpdateJobCancellation:
+    """Regression guard: a ``@background_task`` timeout cancels the coroutine,
+    surfacing inside ``process_auto_update_job`` as ``CancelledError`` (which the
+    ``except Exception`` branch does NOT catch). The job must still be marked
+    FAILED instead of being left stuck in IN_PROGRESS, and the cancellation must
+    re-raise so the decorator's timeout machinery keeps working.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancellation_marks_job_failed_and_reraises(self) -> None:
+        job = MagicMock()
+        job.status = StatusEnum.IN_PROGRESS
+
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=job)
+
+        service = AdminPortalDataSetService()
+        # Inject a session so _scoped_session() yields it directly (no real DB).
+        service._DbServiceBase__session = mock_session  # type: ignore[attr-defined]
+        # Cancel the task right after the initial IN_PROGRESS status write.
+        service._set_auto_update_job_status = AsyncMock(  # type: ignore[method-assign]
+            side_effect=asyncio.CancelledError()
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await service.process_auto_update_job(
+                auto_update_job_id=1, auth_context=MagicMock()
+            )
+
+        assert job.status == StatusEnum.FAILED
+        assert job.reason_for_failure
+        mock_session.commit.assert_awaited()


### PR DESCRIPTION
### Applicable issues

- fixes #485

### Description of changes

Auto-update jobs were left stuck in a non-final (`IN_PROGRESS`) status when a background task hit its `task_timeout`.

The `@background_task` decorator enforces the timeout with `asyncio.timeout`, which **cancels** the running coroutine on expiry. Inside `process_auto_update_job` this surfaces as `CancelledError` — a `BaseException` that the existing `except Exception` handler does not catch — so the FAILED-status write was skipped, and the decorator then swallowed the resulting `TimeoutError` (intentionally, to keep sibling batch tasks alive).

Changes (`statgpt/admin/services/dataset.py`):
- Added an `except asyncio.CancelledError` branch in `process_auto_update_job` that marks the job `FAILED` and re-raises, so the decorator's batch-resilience behavior is preserved.
- The FAILED-status write is wrapped in `asyncio.shield` so it survives the cancellation.
- Extracted a `_mark_auto_update_job_failed()` helper, reused by both the cancellation and the existing exception branch.

Added a regression test (`tests/unit/admin/services/test_auto_update_job.py`) asserting a cancellation mid-processing marks the job `FAILED` and re-raises.

> Note: this treats any cancellation (including genuine shutdown) as a job failure, which is more correct than leaving it stuck; the stuck-job recovery remains as a backstop.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
