### PR TITLE
fix: stop dropping camelCase tool config fields during channel init

### DIFF
--- a/statgpt/cli/commands/content.py
+++ b/statgpt/cli/commands/content.py
@@ -473,18 +473,7 @@ def _add_tools_to_channel(ch_cfg: dict[str, Any], tools_cfg: dict[str, Any]) -> 
 
         tool_type = tool["type"]
         ch_cfg["details"][tool_type] = {
-            k: v
-            for k, v in tool.items()
-            if k
-            in (
-                "name",
-                "description",
-                "details",
-                "mcp_only",
-                "mcp_visibility",
-                "mcp_name",
-                "mcp_description",
-            )
+            k: v for k, v in tool.items() if k not in ["channels", "type"]
         }
 
 

--- a/statgpt/common/schemas/base.py
+++ b/statgpt/common/schemas/base.py
@@ -29,7 +29,7 @@ class ListResponse(BaseModel, Generic[ItemT]):
 
 class BaseYamlModel(BaseModel):
     model_config = ConfigDict(
-        alias_generator=alias_generators.to_camel, populate_by_name=True, extra="allow"
+        alias_generator=alias_generators.to_camel, populate_by_name=True, extra="ignore"
     )
 
 


### PR DESCRIPTION

### Applicable issues

- fixes #493

### Description of changes

CLI `content init` silently dropped tool-level config fields (e.g. `mcpAppResourceUri`) when building the channel config, so they never reached the DB (`mcp_meta` returned `None`) and change detection falsely reported `Channel unchanged`.

- `_add_tools_to_channel` now copies all tool keys except the CLI-only routing keys (`channels`, `type`), instead of a hardcoded snake_case whitelist that both omitted `mcp_app_resource_uri` and missed camelCase keys.
- `BaseYamlModel` switched to `extra="ignore"` so unknown/misplaced keys are dropped at validation instead of round-tripping into the persisted config.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.