### PR TITLE
feat: return query JSON as structured content for the data query MCP tool

### DIFF
--- a/statgpt/app/mcp/attachments.py
+++ b/statgpt/app/mcp/attachments.py
@@ -1,8 +1,10 @@
+from typing import Any
 from urllib.parse import quote
 
 from mcp.types import EmbeddedResource, TextResourceContents
 from pydantic import AnyUrl
 
+from statgpt.app.schemas.query import AppJsonQueryWithMetadata
 from statgpt.app.schemas.tool_artifact import DataQueryArtifact
 
 
@@ -36,3 +38,21 @@ def data_query_artifact_to_resources(
             )
         )
     return resources
+
+
+def data_query_artifact_to_structured_content(
+    artifact: DataQueryArtifact,
+) -> dict[str, Any] | None:
+    """Serialize each DataResponse's json_query as the tool's MCP structured content.
+
+    Returns a ``{"queries": [...]}`` object where each entry is an AppJsonQueryWithMetadata
+    dumped with camelCase aliases, matching the DIAL "Query (JSON)" attachment shape.
+    Returns None when no response carries a query so the provider omits structuredContent.
+    """
+    queries: list[dict[str, Any]] = []
+    for response in artifact.data_responses.values():
+        query = response.json_query
+        if query is None:
+            continue
+        queries.append(AppJsonQueryWithMetadata.from_common(query).model_dump(by_alias=True))
+    return {"queries": queries} if queries else None

--- a/statgpt/app/mcp/provider.py
+++ b/statgpt/app/mcp/provider.py
@@ -18,7 +18,10 @@ from starlette.requests import Request
 
 from statgpt.app.chains.tools import StatGptTool, ToolInputError, ToolUpstreamError
 from statgpt.app.config import ChainParametersConfig
-from statgpt.app.mcp.attachments import data_query_artifact_to_resources
+from statgpt.app.mcp.attachments import (
+    data_query_artifact_to_resources,
+    data_query_artifact_to_structured_content,
+)
 from statgpt.app.mcp.decorators import guard_channel_resolution
 from statgpt.app.mcp.exceptions import MissingDeploymentIdError
 from statgpt.app.mcp.guardrails import enforce_input_guardrail
@@ -111,6 +114,7 @@ class _McpToolAdapter(Tool):
             # to_csv is CPU-bound and can block on large dataframes; offload to a worker thread.
             resources = await asyncio.to_thread(data_query_artifact_to_resources, result.artifact)
             content.extend(resources)
+            structured_content = data_query_artifact_to_structured_content(result.artifact)
         elif isinstance(result.artifact, SdmxQueryAppArtifact):
             # Surface the upstream HTTP metadata so the MCP-App can distinguish success from
             # error responses and know the body's media type. The raw body stays in the text

--- a/tests/unit/app/mcp/test_attachments.py
+++ b/tests/unit/app/mcp/test_attachments.py
@@ -4,8 +4,17 @@ from types import SimpleNamespace
 
 import pandas as pd
 
-from statgpt.app.mcp.attachments import data_query_artifact_to_resources
+from statgpt.app.mcp.attachments import (
+    data_query_artifact_to_resources,
+    data_query_artifact_to_structured_content,
+)
 from statgpt.app.schemas.tool_artifact import DataQueryArtifact
+from statgpt.common.schemas.query import (
+    JsonComponentQuery,
+    JsonQueryMetadata,
+    JsonQueryOperator,
+    JsonQueryWithMetadata,
+)
 
 _FIXED_TS = datetime(2026, 4, 20, 15, 30, 0, tzinfo=timezone.utc)
 _FIXED_TS_STR = _FIXED_TS.strftime("%Y%m%dT%H%M%SZ")
@@ -16,16 +25,36 @@ def _make_artifact(data_responses: dict) -> DataQueryArtifact:
     return DataQueryArtifact.model_construct(data_responses=data_responses)
 
 
+def _json_query(urn: str) -> JsonQueryWithMetadata:
+    return JsonQueryWithMetadata(
+        urn=urn,
+        filters=[
+            JsonComponentQuery(
+                component_code="REF_AREA", operator=JsonQueryOperator.IN, values=["FR", "DE"]
+            ),
+        ],
+        metadata=JsonQueryMetadata(
+            country_dimension="REF_AREA",
+            indicator_dimensions=["INDICATOR"],
+            time_period_dimension="TIME_PERIOD",
+            key_dimension_ids_in_dsd_order=["REF_AREA", "INDICATOR"],
+        ),
+        sdmx1_source="IMF_DATA",
+    )
+
+
 def _response(
     resource_path: str,
     df: pd.DataFrame,
     created_at: datetime = _FIXED_TS,
+    json_query: JsonQueryWithMetadata | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         resource_path=resource_path,
         visual_dataframe=df,
         csv_dataframe=df,
         created_at=created_at,
+        json_query=json_query,
     )
 
 
@@ -101,3 +130,61 @@ def test_no_responses_returns_empty_list():
     artifact = _make_artifact({})
 
     assert data_query_artifact_to_resources(artifact) == []
+
+
+def test_structured_content_serializes_single_query():
+    df = pd.DataFrame({"x": [1]})
+    artifact = _make_artifact(
+        {"ds1": _response("IMF:CPI(1.0.0)", df, json_query=_json_query("IMF:CPI(1.0.0)"))}
+    )
+
+    structured = data_query_artifact_to_structured_content(artifact)
+
+    assert structured is not None
+    assert list(structured) == ["queries"]
+    assert len(structured["queries"]) == 1
+    query = structured["queries"][0]
+    assert query["urn"] == "IMF:CPI(1.0.0)"
+    assert query["disabled"] is False
+    assert query["sdmx1Source"] == "IMF_DATA"
+    assert query["filters"][0]["componentCode"] == "REF_AREA"
+    assert query["metadata"]["keyDimensionIdsInDsdOrder"] == ["REF_AREA", "INDICATOR"]
+
+
+def test_structured_content_preserves_insertion_order():
+    df = pd.DataFrame({"x": [1]})
+    artifact = _make_artifact(
+        {
+            "ds1": _response("IMF:CPI(1.0.0)", df, json_query=_json_query("IMF:CPI(1.0.0)")),
+            "ds2": _response("BIS:IR(2.1.0)", df, json_query=_json_query("BIS:IR(2.1.0)")),
+        }
+    )
+
+    structured = data_query_artifact_to_structured_content(artifact)
+
+    assert structured is not None
+    assert [q["urn"] for q in structured["queries"]] == ["IMF:CPI(1.0.0)", "BIS:IR(2.1.0)"]
+
+
+def test_structured_content_skips_responses_without_query():
+    df = pd.DataFrame({"x": [1]})
+    artifact = _make_artifact(
+        {
+            "no_query": _response("IMF:NOQ(1.0.0)", df, json_query=None),
+            "ok": _response("IMF:OK(1.0.0)", df, json_query=_json_query("IMF:OK(1.0.0)")),
+        }
+    )
+
+    structured = data_query_artifact_to_structured_content(artifact)
+
+    assert structured is not None
+    assert [q["urn"] for q in structured["queries"]] == ["IMF:OK(1.0.0)"]
+
+
+def test_structured_content_returns_none_when_no_queries():
+    df = pd.DataFrame({"x": [1]})
+    artifact = _make_artifact({"no_query": _response("IMF:NOQ(1.0.0)", df, json_query=None)})
+
+    assert data_query_artifact_to_structured_content(artifact) is None
+
+    assert data_query_artifact_to_structured_content(_make_artifact({})) is None

--- a/tests/unit/app/mcp/test_provider.py
+++ b/tests/unit/app/mcp/test_provider.py
@@ -12,6 +12,7 @@ from mcp.types import EmbeddedResource, TextContent
 from statgpt.app.chains.out_of_scope_checker import OutOfScopeCheckerResponse
 from statgpt.app.mcp.provider import ChannelToolProvider, _McpToolAdapter
 from statgpt.app.schemas.tool_artifact import DataQueryArtifact
+from statgpt.common.schemas.query import JsonQueryMetadata, JsonQueryWithMetadata
 from statgpt.common.schemas.tool_details import SdmxQueryAppDetails
 from statgpt.common.schemas.tools import AvailableDatasetsTool, SdmxQueryAppTool
 
@@ -29,6 +30,18 @@ def _build_adapter(result) -> _McpToolAdapter:
     )
 
 
+def _json_query(urn: str) -> JsonQueryWithMetadata:
+    return JsonQueryWithMetadata(
+        urn=urn,
+        filters=[],
+        metadata=JsonQueryMetadata(
+            country_dimension="REF_AREA",
+            indicator_dimensions=["INDICATOR"],
+            time_period_dimension="TIME_PERIOD",
+        ),
+    )
+
+
 async def test_data_query_artifact_adds_csv_resources():
     df = pd.DataFrame({"x": [1, 2]})
     response = SimpleNamespace(
@@ -36,6 +49,7 @@ async def test_data_query_artifact_adds_csv_resources():
         visual_dataframe=df,
         csv_dataframe=df,
         created_at=datetime(2026, 4, 20, 15, 30, 0, tzinfo=timezone.utc),
+        json_query=_json_query("IMF:CPI(1.0.0)"),
     )
     artifact = DataQueryArtifact.model_construct(data_responses={"ds1": response})
     result = SimpleNamespace(content="answer", artifact=artifact)
@@ -48,6 +62,25 @@ async def test_data_query_artifact_adds_csv_resources():
     resources = [c for c in tool_result.content if isinstance(c, EmbeddedResource)]
     assert len(resources) == 1
     assert resources[0].resource.mimeType == "text/csv"
+    assert tool_result.structured_content is not None
+    assert [q["urn"] for q in tool_result.structured_content["queries"]] == ["IMF:CPI(1.0.0)"]
+
+
+async def test_data_query_artifact_without_query_has_no_structured_content():
+    df = pd.DataFrame({"x": [1]})
+    response = SimpleNamespace(
+        resource_path="IMF:CPI(1.0.0)",
+        visual_dataframe=df,
+        csv_dataframe=df,
+        created_at=datetime(2026, 4, 20, 15, 30, 0, tzinfo=timezone.utc),
+        json_query=None,
+    )
+    artifact = DataQueryArtifact.model_construct(data_responses={"ds1": response})
+    adapter = _build_adapter(SimpleNamespace(content="answer", artifact=artifact))
+
+    tool_result = await adapter.run({})
+
+    assert tool_result.structured_content is None
 
 
 async def test_non_data_query_result_returns_text_only():


### PR DESCRIPTION

### Applicable issues

- fixes #495

### Description of changes

The Data Query tool is an interactive MCP-App tool, but it returned only a text block plus inline `text/csv` embedded resources and left `structured_content` empty (populated only for the `sdmx_query_app` passthrough tool). Per the MCP Apps protocol, an interactive tool must return structured content for the bound widget to render.

Populate `structured_content` for `DataQueryArtifact` with the SDMX Query JSON as a `{"queries": [...]}` payload so the bound widget can render it.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.