### PR TITLE
fix: offload SDMX response parsing from the event loop

### DIFF
--- a/statgpt/common/data/sdmx/v21/sdmx_client.py
+++ b/statgpt/common/data/sdmx/v21/sdmx_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import os
+import threading
 from typing import IO, Any
 
 import httpx
@@ -25,6 +26,12 @@ from statgpt.common.utils import AsyncLoadingCache
 
 def init_sdmx(config: SdmxDataSourceConfig):
     sdmx.add_source(config.sdmx_config.to_sdmx1_dict(), override=True)
+
+
+# The sdmx1 reader mutates a structure passed via `structure=` (e.g. `make_key(..., extend=True)`
+# adds missing components to the shared DSD), so dsd-bearing parses running on worker threads
+# must be serialized.
+_PARSE_DSD_LOCK = threading.Lock()
 
 
 class AsyncSdmxClient:
@@ -342,7 +349,9 @@ class AsyncSdmxClient:
     async def _fetch(self, req: PreparedRequest, tofile: os.PathLike | IO | None = None) -> Message:
         httpx_response = await self._perform_request(req)
         response = self._convert_response(httpx_response, req)
-        return self._parse_response(response, tofile=tofile)
+        # XML parsing is CPU-bound and can take seconds for large data messages;
+        # run it off the event loop so concurrent requests are not stalled.
+        return await asyncio.to_thread(self._parse_response, response, tofile)
 
     async def _perform_request(self, req: PreparedRequest, max_retries=3, delay=3) -> Response:
         attempts = 0
@@ -418,7 +427,11 @@ class AsyncSdmxClient:
         # Instantiate reader from class
         reader = reader_class()
 
-        msg = reader.convert(response_content, structure=dsd)
+        if dsd is not None:
+            with _PARSE_DSD_LOCK:
+                msg = reader.convert(response_content, structure=dsd)
+        else:
+            msg = reader.convert(response_content, structure=dsd)
         msg.response = response
         return msg
 

--- a/statgpt/common/data/sdmx/v21/sdmx_client.py
+++ b/statgpt/common/data/sdmx/v21/sdmx_client.py
@@ -29,13 +29,19 @@ def init_sdmx(config: SdmxDataSourceConfig):
     sdmx.add_source(config.sdmx_config.to_sdmx1_dict(), override=True)
 
 
-# sdmx1 readers mutate a structure passed via `structure=` (the XML reader extends the DSD via
-# `make_key(..., extend=True)`; the v30 proxy JSON reader attaches it as `msg.dataflow.structure`
-# and adds components via `getdefault`), so dsd-bearing parses running on worker threads must be
-# serialized. No caller of `_parse_response` currently passes a dsd — threaded XML parses run
-# with `structure=None` and build private structures, staying fully parallel; the lock is used
-# by the v30 proxy data path (`AsyncStatGptSdmxProxyClient._proxy_data`).
 _PARSE_DSD_LOCK = threading.Lock()
+
+
+def _dsd_parse_lock(dsd: object | None) -> contextlib.AbstractContextManager[Any]:
+    """Serialize dsd-bearing sdmx1 parses that run on worker threads.
+
+    sdmx1 readers mutate a structure passed via ``structure=`` (the XML reader extends the DSD
+    via ``make_key(..., extend=True)``; the v30 proxy JSON reader attaches it as
+    ``msg.dataflow.structure`` and adds components via ``getdefault``), so concurrent dsd-bearing
+    parses must be serialized. Parses with ``dsd is None`` build private structures and stay
+    fully parallel.
+    """
+    return _PARSE_DSD_LOCK if dsd is not None else contextlib.nullcontext()
 
 
 class AsyncSdmxClient:
@@ -431,8 +437,7 @@ class AsyncSdmxClient:
         # Instantiate reader from class
         reader = reader_class()
 
-        ctx = _PARSE_DSD_LOCK if dsd is not None else contextlib.nullcontext()
-        with ctx:
+        with _dsd_parse_lock(dsd):
             msg = reader.convert(response_content, structure=dsd)
         msg.response = response
         return msg

--- a/statgpt/common/data/sdmx/v21/sdmx_client.py
+++ b/statgpt/common/data/sdmx/v21/sdmx_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import io
 import os
 import threading
@@ -28,9 +29,12 @@ def init_sdmx(config: SdmxDataSourceConfig):
     sdmx.add_source(config.sdmx_config.to_sdmx1_dict(), override=True)
 
 
-# The sdmx1 reader mutates a structure passed via `structure=` (e.g. `make_key(..., extend=True)`
-# adds missing components to the shared DSD), so dsd-bearing parses running on worker threads
-# must be serialized.
+# sdmx1 readers mutate a structure passed via `structure=` (the XML reader extends the DSD via
+# `make_key(..., extend=True)`; the v30 proxy JSON reader attaches it as `msg.dataflow.structure`
+# and adds components via `getdefault`), so dsd-bearing parses running on worker threads must be
+# serialized. No caller of `_parse_response` currently passes a dsd — threaded XML parses run
+# with `structure=None` and build private structures, staying fully parallel; the lock is used
+# by the v30 proxy data path (`AsyncStatGptSdmxProxyClient._proxy_data`).
 _PARSE_DSD_LOCK = threading.Lock()
 
 
@@ -427,10 +431,8 @@ class AsyncSdmxClient:
         # Instantiate reader from class
         reader = reader_class()
 
-        if dsd is not None:
-            with _PARSE_DSD_LOCK:
-                msg = reader.convert(response_content, structure=dsd)
-        else:
+        ctx = _PARSE_DSD_LOCK if dsd is not None else contextlib.nullcontext()
+        with ctx:
             msg = reader.convert(response_content, structure=dsd)
         msg.response = response
         return msg

--- a/statgpt/common/data/statgpt_sdmx_proxy/v30/sdmx_client.py
+++ b/statgpt/common/data/statgpt_sdmx_proxy/v30/sdmx_client.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import io
 from typing import cast
 from urllib.parse import urlencode
@@ -15,7 +14,7 @@ from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.config import multiline_logger as logger
 from statgpt.common.data.base.sdmx_schemas import SdmxPlusAvailabilityRequestBody
 from statgpt.common.data.sdmx.v21.ratelimiter import SdmxRateLimiter
-from statgpt.common.data.sdmx.v21.sdmx_client import _PARSE_DSD_LOCK, AsyncSdmxClient
+from statgpt.common.data.sdmx.v21.sdmx_client import AsyncSdmxClient, _dsd_parse_lock
 from statgpt.common.data.statgpt_sdmx_proxy.config import StatGptSdmxProxyDataSourceConfig
 from statgpt.common.data.statgpt_sdmx_proxy.sdmx_schemas.structure_message import (
     ProxyAgencySchemeResponseBody,
@@ -296,11 +295,7 @@ class AsyncStatGptSdmxProxyClient(AsyncSdmxClient):
     def _convert_proxy_data(
         response_content: io.IOBase, dsd: DataStructureDefinition | None
     ) -> DataMessage:
-        # The reader attaches `dsd` as `msg.dataflow.structure` and mutates it while parsing
-        # (`msg.structure...getdefault(...)`), so dsd-bearing parses running on worker threads
-        # must be serialized.
-        ctx = _PARSE_DSD_LOCK if dsd is not None else contextlib.nullcontext()
-        with ctx:
+        with _dsd_parse_lock(dsd):
             return StatGptSdmxProxyDataReader().convert(response_content, structure=dsd)
 
     def _build_key_segment(

--- a/statgpt/common/data/statgpt_sdmx_proxy/v30/sdmx_client.py
+++ b/statgpt/common/data/statgpt_sdmx_proxy/v30/sdmx_client.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 import io
 from typing import cast
 from urllib.parse import urlencode
@@ -13,7 +15,7 @@ from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.config import multiline_logger as logger
 from statgpt.common.data.base.sdmx_schemas import SdmxPlusAvailabilityRequestBody
 from statgpt.common.data.sdmx.v21.ratelimiter import SdmxRateLimiter
-from statgpt.common.data.sdmx.v21.sdmx_client import AsyncSdmxClient
+from statgpt.common.data.sdmx.v21.sdmx_client import _PARSE_DSD_LOCK, AsyncSdmxClient
 from statgpt.common.data.statgpt_sdmx_proxy.config import StatGptSdmxProxyDataSourceConfig
 from statgpt.common.data.statgpt_sdmx_proxy.sdmx_schemas.structure_message import (
     ProxyAgencySchemeResponseBody,
@@ -272,7 +274,9 @@ class AsyncStatGptSdmxProxyClient(AsyncSdmxClient):
         requests_response = self._convert_response(response, req)
         try:
             response_content: io.IOBase = ResponseIO(response)
-            msg = StatGptSdmxProxyDataReader().convert(response_content, structure=dsd)
+            # JSON data parsing is CPU-bound and can take seconds for large messages;
+            # run it off the event loop so concurrent requests are not stalled.
+            msg = await asyncio.to_thread(self._convert_proxy_data, response_content, dsd)
             msg.response = requests_response
         except Exception:
             logger.error(
@@ -287,6 +291,17 @@ class AsyncStatGptSdmxProxyClient(AsyncSdmxClient):
                 f"Unexpected response message type: {type(msg).__name__} for URL {req.url!r}"
             )
         return msg
+
+    @staticmethod
+    def _convert_proxy_data(
+        response_content: io.IOBase, dsd: DataStructureDefinition | None
+    ) -> DataMessage:
+        # The reader attaches `dsd` as `msg.dataflow.structure` and mutates it while parsing
+        # (`msg.structure...getdefault(...)`), so dsd-bearing parses running on worker threads
+        # must be serialized.
+        ctx = _PARSE_DSD_LOCK if dsd is not None else contextlib.nullcontext()
+        with ctx:
+            return StatGptSdmxProxyDataReader().convert(response_content, structure=dsd)
 
     def _build_key_segment(
         self,

--- a/tests/unit/common/data/sdmx/v21/test_sdmx_client.py
+++ b/tests/unit/common/data/sdmx/v21/test_sdmx_client.py
@@ -1,0 +1,56 @@
+"""Tests for the async SDMX client."""
+
+import asyncio
+import time
+from unittest import mock
+
+import httpx
+import requests
+from sdmx.message import Message
+
+from statgpt.common.data.sdmx.v21.sdmx_client import AsyncSdmxClient
+
+
+def _make_client() -> AsyncSdmxClient:
+    return AsyncSdmxClient(
+        sync_client=mock.Mock(),
+        httpx_client=mock.Mock(spec=httpx.AsyncClient),
+        authorizer=None,
+        rate_limiter=mock.Mock(),
+    )
+
+
+async def test_fetch_parses_off_the_event_loop() -> None:
+    """A slow (CPU-bound) parse must not block concurrent coroutines on the event loop."""
+    client = _make_client()
+    message = Message()
+    parse_seconds = 0.3
+
+    def _slow_parse(response, tofile=None, dsd=None) -> Message:
+        time.sleep(parse_seconds)  # simulates CPU-bound XML parsing in the worker thread
+        return message
+
+    ticks = 0
+
+    async def _ticker() -> None:
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    with (
+        mock.patch.object(client, "_perform_request", mock.AsyncMock(return_value=mock.Mock())),
+        mock.patch.object(
+            client, "_convert_response", mock.Mock(return_value=mock.Mock(spec=requests.Response))
+        ),
+        mock.patch.object(client, "_parse_response", _slow_parse),
+    ):
+        ticker_task = asyncio.create_task(_ticker())
+        try:
+            result = await client._fetch(mock.Mock())
+        finally:
+            ticker_task.cancel()
+
+    assert result is message
+    # With the parse on the event loop the ticker would not tick at all during the sleep.
+    assert ticks >= 5

--- a/tests/unit/common/data/statgpt_sdmx_proxy/v30/test_proxy_sdmx_client.py
+++ b/tests/unit/common/data/statgpt_sdmx_proxy/v30/test_proxy_sdmx_client.py
@@ -1,0 +1,68 @@
+"""Tests for the async StatGPT SDMX proxy client."""
+
+import asyncio
+import time
+from unittest import mock
+
+import httpx
+import requests
+from sdmx.message import DataMessage
+
+from statgpt.common.data.statgpt_sdmx_proxy.v30.sdmx_client import AsyncStatGptSdmxProxyClient
+
+
+def _make_client() -> AsyncStatGptSdmxProxyClient:
+    return AsyncStatGptSdmxProxyClient(
+        sync_client=mock.Mock(),
+        httpx_client=mock.Mock(spec=httpx.AsyncClient),
+        authorizer=None,
+        rate_limiter=mock.Mock(),
+    )
+
+
+async def test_proxy_data_parses_off_the_event_loop() -> None:
+    """A slow (CPU-bound) data parse must not block concurrent coroutines on the event loop."""
+    client = _make_client()
+    message = DataMessage()
+    parse_seconds = 0.3
+
+    def _slow_convert(response_content, dsd) -> DataMessage:
+        time.sleep(parse_seconds)  # simulates CPU-bound JSON parsing in the worker thread
+        return message
+
+    ticks = 0
+
+    async def _ticker() -> None:
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    # ResponseIO reads `.headers` and `.content` from the wrapped response.
+    http_response = mock.Mock(headers={}, content=b"{}")
+
+    with (
+        mock.patch.object(
+            client, "_perform_get", mock.AsyncMock(return_value=(http_response, mock.Mock()))
+        ),
+        mock.patch.object(
+            client, "_convert_response", mock.Mock(return_value=mock.Mock(spec=requests.Response))
+        ),
+        mock.patch.object(client, "_convert_proxy_data", _slow_convert),
+    ):
+        ticker_task = asyncio.create_task(_ticker())
+        try:
+            result = await client._proxy_data(
+                agency_id="IMF",
+                resource_id="DF",
+                version="1.0",
+                key=None,
+                params=None,
+                dsd=None,
+            )
+        finally:
+            ticker_task.cancel()
+
+    assert result is message
+    # With the parse on the event loop the ticker would not tick at all during the sleep.
+    assert ticks >= 5


### PR DESCRIPTION
### Applicable issues

- fixes #500

### Description of changes

SDMX responses were parsed synchronously on the event loop; large data messages take seconds of CPU-bound parsing and stall every concurrent request. Both parse paths now run in a worker thread via `asyncio.to_thread`, mirroring the existing `_data_msg_to_dataframe` offload in `dataset.py`. Threaded XML parses in `AsyncSdmxClient` all run with `structure=None` and build private structures, so they stay fully parallel; the proxy v30 data parse carries a shared `DataStructureDefinition` that the reader attaches to the message and mutates while parsing (`msg.structure...getdefault(...)`), so dsd-bearing parses are serialized with a module-level `threading.Lock`.

- Run `_parse_response` via `asyncio.to_thread` in `AsyncSdmxClient._fetch`
- Run the `StatGptSdmxProxyDataReader` convert via `asyncio.to_thread` in `AsyncStatGptSdmxProxyClient._proxy_data`
- Add `_PARSE_DSD_LOCK` guarding `reader.convert` when a `dsd` is passed (no `_parse_response` caller currently does; the proxy data path does)
- Add unit tests asserting a slow in-thread parse does not block a concurrent coroutine (XML client and proxy client)

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
