### PR TITLE
feat: parallelize data query search preparation LLM calls

### DIFF
--- a/statgpt/app/chains/data_query/query_builder/misc/search_preparation.py
+++ b/statgpt/app/chains/data_query/query_builder/misc/search_preparation.py
@@ -148,17 +148,28 @@ class SearchPreparationChainFactory:
         )
 
         chain = (
-            RunnablePassthrough.assign(
-                versioned_datasets_dict=dataset_utils.get_available_datasets,
-            )
             # # unpack country groups in the user prompt
-            # | RunnablePassthrough.assign(
+            # # NOTE: if re-enabled, it must precede the merged assign below,
+            # # since its output feeds the normalization chain
+            # RunnablePassthrough.assign(
             #     query_with_expanded_groups=self._group_expander_chain.create_chain,
             # )
-            # normalize (summarize) conversation
-            | RunnablePassthrough.assign(
+            # load available datasets, normalize (summarize) conversation and extract time range
+            # in parallel: each consumes only the raw tool input
+            RunnablePassthrough.assign(
+                versioned_datasets_dict=dataset_utils.get_available_datasets,
                 normalized_query=self._normalization_chain.create_chain,
-            ).with_config(config=RunnableConfig(callbacks=[normalizing_query_stage_callback]))
+                date_time_query_response=self._datetime_chain.create_chain,
+            ).with_config(
+                config=RunnableConfig(
+                    callbacks=[
+                        normalizing_query_stage_callback,
+                        StageCallback(
+                            "Extracting Time Range", self._populate_datetime, debug_only=True
+                        ),
+                    ]
+                )
+            )
             # save 'normalized_query' to separate variable, since it will be overwritten later
             | RunnablePassthrough.assign(normalized_query_raw=lambda d: d["normalized_query"])
             | (
@@ -180,20 +191,10 @@ class SearchPreparationChainFactory:
                     ]
                 )
             )
-            # extract named entities and time range
+            # extract named entities from the rewritten normalized query
             | RunnablePassthrough.assign(
                 named_entities_response=self._named_entities_chain.create_chain,
-                date_time_query_response=self._datetime_chain.create_chain,
-            ).with_config(
-                config=RunnableConfig(
-                    callbacks=[
-                        named_entities_stage_callback,
-                        StageCallback(
-                            "Extracting Time Range", self._populate_datetime, debug_only=True
-                        ),
-                    ]
-                )
-            )
+            ).with_config(config=RunnableConfig(callbacks=[named_entities_stage_callback]))
             | RunnablePassthrough.assign(
                 country_named_entities=self._get_country_named_entities,
             )

--- a/statgpt/app/chains/data_query/query_builder/misc/search_preparation.py
+++ b/statgpt/app/chains/data_query/query_builder/misc/search_preparation.py
@@ -155,7 +155,12 @@ class SearchPreparationChainFactory:
             #     query_with_expanded_groups=self._group_expander_chain.create_chain,
             # )
             # load available datasets, normalize (summarize) conversation and extract time range
-            # in parallel: each consumes only the raw tool input
+            # in parallel: each consumes only the raw tool input.
+            # NOTE: both StageCallbacks below are bound to this single merged run, so each
+            # stage's displayed duration spans the whole parallel step, and a failure in any
+            # branch closes both stages as FAILED. Sibling branches are not cancelled on
+            # failure (RunnableParallel gathers without cancellation) — accepted trade-offs
+            # of merging the head; see the performance plan for details.
             RunnablePassthrough.assign(
                 versioned_datasets_dict=dataset_utils.get_available_datasets,
                 normalized_query=self._normalization_chain.create_chain,

--- a/tests/unit/app/chains/test_search_preparation.py
+++ b/tests/unit/app/chains/test_search_preparation.py
@@ -113,7 +113,7 @@ def _make_inputs() -> dict:
 
 
 async def test_search_preparation_chain_produces_all_stage1_keys():
-    factory, stubs = _make_factory()
+    factory, _ = _make_factory()
     inputs = _make_inputs()
 
     result = await factory.create().ainvoke(inputs)
@@ -143,7 +143,7 @@ async def test_search_preparation_chain_produces_all_stage1_keys():
 
 
 async def test_normalized_query_after_selection_equals_rewritten_query():
-    factory, stubs = _make_factory()
+    factory, _ = _make_factory()
     inputs = _make_inputs()
 
     result = await factory.create().ainvoke(inputs)

--- a/tests/unit/app/chains/test_search_preparation.py
+++ b/tests/unit/app/chains/test_search_preparation.py
@@ -1,0 +1,167 @@
+"""Unit tests for the Stage-1 (search preparation) chain composition."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+from langchain_core.runnables import Runnable, RunnableLambda
+
+from statgpt.app.chains.data_query.query_builder.misc.search_preparation import (
+    SearchPreparationChainFactory,
+)
+from statgpt.app.schemas.query_builder import (
+    DataSetsSelectionChainResponse,
+    DateTimeQueryResponse,
+    NamedEntitiesResponse,
+    NamedEntity,
+)
+from statgpt.app.services.chat_facade import ChannelServiceFacade, VersionedDataSet
+from statgpt.common.auth.auth_context import AuthContext
+from statgpt.common.data.base import DataSet
+from statgpt.common.schemas.data_query_tool import DataQueryStageNames
+from statgpt.common.schemas.tool_details import StagesConfig
+
+NORMALIZED_QUERY = 'normalized query'
+REWRITTEN_QUERY = 'rewritten query'
+
+
+class FakeChoice:
+    """Minimal ChoiceI implementation for ChainState validation."""
+
+    def create_stage(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError('no stage expected in this test')
+
+    def append_content(self, content: str) -> Any:
+        pass
+
+    def add_attachment(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+    def set_state(self, state: dict) -> Any:
+        pass
+
+
+class StubChain:
+    """LLM sub-chain stub: records the inputs it was created with, returns a fixed output."""
+
+    def __init__(self, output: Any):
+        self._output = output
+        self.captured_inputs: dict | None = None
+
+    def create_chain(self, inputs: dict) -> Runnable:
+        self.captured_inputs = dict(inputs)
+        return RunnableLambda(lambda _: self._output)
+
+
+def _make_versioned_dataset(entity_id: str) -> VersionedDataSet:
+    data = Mock(spec=DataSet)
+    data.entity_id = entity_id
+    return VersionedDataSet(version=Mock(), data=data)
+
+
+def _make_factory() -> tuple[SearchPreparationChainFactory, dict[str, StubChain]]:
+    factory = SearchPreparationChainFactory.__new__(SearchPreparationChainFactory)
+    factory._config = SimpleNamespace(  # type: ignore[assignment]
+        pipeline_stage_names=DataQueryStageNames(),
+        stages_config=StagesConfig(),
+    )
+
+    stubs = {
+        'normalization': StubChain(NORMALIZED_QUERY),
+        'datetime': StubChain(
+            DateTimeQueryResponse(start='2020-01-01', end='2020-12-31', time_period_specified=True)
+        ),
+        'named_entities': StubChain(
+            NamedEntitiesResponse(entities=[NamedEntity(entity='France', entity_type='country')])
+        ),
+        'datasets_selection': StubChain(
+            DataSetsSelectionChainResponse(dataset_ids=['ds2'], rewritten_query=REWRITTEN_QUERY)
+        ),
+    }
+    factory._normalization_chain = stubs['normalization']  # type: ignore[assignment]
+    factory._datetime_chain = stubs['datetime']  # type: ignore[assignment]
+    factory._named_entities_chain = stubs['named_entities']  # type: ignore[assignment]
+    factory._datasets_selection_chain = stubs['datasets_selection']  # type: ignore[assignment]
+    return factory, stubs
+
+
+def _make_inputs() -> dict:
+    data_service = Mock(spec=ChannelServiceFacade)
+    data_service.list_available_datasets.return_value = [
+        _make_versioned_dataset('ds1'),
+        _make_versioned_dataset('ds2'),
+    ]
+    data_service.get_country_named_entity_type.return_value = 'Country'
+
+    return {
+        'auth_context': Mock(spec=AuthContext),
+        'choice': FakeChoice(),
+        'target': None,
+        'state': {},
+        'data_service': data_service,
+        'query': 'GDP of France in 2020',
+    }
+
+
+async def test_search_preparation_chain_produces_all_stage1_keys():
+    factory, stubs = _make_factory()
+    inputs = _make_inputs()
+
+    result = await factory.create().ainvoke(inputs)
+
+    expected_keys = {
+        'versioned_datasets_dict',
+        'normalized_query',
+        'normalized_query_raw',
+        'date_time_query_response',
+        'datasets_selection_response',
+        'datasets_dict',
+        'named_entities_response',
+        'country_named_entities',
+    }
+    assert expected_keys <= result.keys()
+
+    assert set(result['versioned_datasets_dict']) == {'ds1', 'ds2'}
+    # datasets filter from the selection response is applied
+    assert set(result['datasets_dict']) == {'ds2'}
+    assert result['date_time_query_response'] == DateTimeQueryResponse(
+        start='2020-01-01', end='2020-12-31', time_period_specified=True
+    )
+    assert result['country_named_entities'] == [NamedEntity(entity='France', entity_type='country')]
+
+
+async def test_normalized_query_after_selection_equals_rewritten_query():
+    factory, stubs = _make_factory()
+    inputs = _make_inputs()
+
+    result = await factory.create().ainvoke(inputs)
+
+    assert result['normalized_query'] == REWRITTEN_QUERY
+    # raw normalization output is preserved before the rewrite
+    assert result['normalized_query_raw'] == NORMALIZED_QUERY
+
+
+async def test_stage1_step_inputs_preserve_data_dependencies():
+    factory, stubs = _make_factory()
+    inputs = _make_inputs()
+
+    await factory.create().ainvoke(inputs)
+
+    # the merged head runs on the raw tool inputs: neither normalization nor datetime
+    # may observe outputs of other head branches
+    for stub_name in ('normalization', 'datetime'):
+        captured = stubs[stub_name].captured_inputs
+        assert captured is not None
+        assert 'normalized_query' not in captured
+        assert 'versioned_datasets_dict' not in captured
+        assert 'date_time_query_response' not in captured
+
+    # dataset selection consumes the pre-rewrite normalized query
+    selection_inputs = stubs['datasets_selection'].captured_inputs
+    assert selection_inputs is not None
+    assert selection_inputs['normalized_query'] == NORMALIZED_QUERY
+
+    # NER consumes the post-rewrite normalized query
+    ner_inputs = stubs['named_entities'].captured_inputs
+    assert ner_inputs is not None
+    assert ner_inputs['normalized_query'] == REWRITTEN_QUERY

--- a/tests/unit/app/chains/test_search_preparation.py
+++ b/tests/unit/app/chains/test_search_preparation.py
@@ -26,10 +26,19 @@ REWRITTEN_QUERY = 'rewritten query'
 
 
 class FakeChoice:
-    """Minimal ChoiceI implementation for ChainState validation."""
+    """Minimal ChoiceI implementation for ChainState validation.
+
+    ``create_stage`` records invocations instead of raising: LangChain swallows
+    exceptions raised inside callbacks, so tests assert ``created_stages`` is
+    empty after the chain run.
+    """
+
+    def __init__(self) -> None:
+        self.created_stages: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
 
     def create_stage(self, *args: Any, **kwargs: Any) -> Any:
-        raise AssertionError('no stage expected in this test')
+        self.created_stages.append((args, kwargs))
+        return Mock()
 
     def append_content(self, content: str) -> Any:
         pass
@@ -109,6 +118,9 @@ async def test_search_preparation_chain_produces_all_stage1_keys():
 
     result = await factory.create().ainvoke(inputs)
 
+    # all Stage-1 stages are debug-only under the default config: none may open
+    assert inputs['choice'].created_stages == []
+
     expected_keys = {
         'versioned_datasets_dict',
         'normalized_query',
@@ -136,6 +148,7 @@ async def test_normalized_query_after_selection_equals_rewritten_query():
 
     result = await factory.create().ainvoke(inputs)
 
+    assert inputs['choice'].created_stages == []
     assert result['normalized_query'] == REWRITTEN_QUERY
     # raw normalization output is preserved before the rewrite
     assert result['normalized_query_raw'] == NORMALIZED_QUERY
@@ -146,6 +159,8 @@ async def test_stage1_step_inputs_preserve_data_dependencies():
     inputs = _make_inputs()
 
     await factory.create().ainvoke(inputs)
+
+    assert inputs['choice'].created_stages == []
 
     # the merged head runs on the raw tool inputs: neither normalization nor datetime
     # may observe outputs of other head branches


### PR DESCRIPTION
### Applicable issues

- fixes #498

### Description of changes

Stage 1 of the data-query pipeline ran its independent steps sequentially: dataset load, then normalization LLM, then dataset-selection LLM, then NER + datetime LLMs. The dataset load, normalization, and datetime extraction depend only on the raw tool input, so they now run in a single parallel `RunnablePassthrough.assign`. The Stage-1 critical path becomes `max(load, normalization, datetime) -> dataset selection -> NER`, with no change to prompt inputs or chain semantics.

- Merged dataset load, normalization, and time-range extraction into one parallel head assign
- Moved the "Normalizing Query" and "Extracting Time Range" stage callbacks onto the merged head
- NER now runs alone after dataset selection, still consuming the post-rewrite normalized query
- Added a unit test covering Stage-1 output keys, the query rewrite, and per-step data dependencies

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
