### PR TITLE
feat: parallelize hybrid search and direct tool call dispatch

### DIFF
--- a/statgpt/app/chains/main.py
+++ b/statgpt/app/chains/main.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from langchain_core.runnables import Runnable, RunnablePassthrough
 
 from statgpt.app.chains.out_of_scope_checker import OutOfScopeChecker
@@ -62,8 +64,15 @@ class MainChainFactory:
         state[StateVarsConfig.DIRECT_TOOL_CALLS] = tool_calls_parsed
 
         tool_executor = ToolCaller.from_config(self._channel_config)
-        for tool_call in tool_calls_parsed:
-            tool_msg = await tool_executor.call_tool(tool_call, inputs, show_stage=False)
+        # Dispatch concurrently (mirrors the agent path); gather preserves the
+        # original tool-call order for history.
+        tool_messages = await asyncio.gather(
+            *(
+                tool_executor.call_tool(tool_call, inputs, show_stage=False)
+                for tool_call in tool_calls_parsed
+            )
+        )
+        for tool_msg in tool_messages:
             history.add_tool_message(tool_msg)
 
         return inputs

--- a/statgpt/app/chains/main.py
+++ b/statgpt/app/chains/main.py
@@ -64,8 +64,10 @@ class MainChainFactory:
         state[StateVarsConfig.DIRECT_TOOL_CALLS] = tool_calls_parsed
 
         tool_executor = ToolCaller.from_config(self._channel_config)
-        # Dispatch concurrently (mirrors the agent path); gather preserves the
-        # original tool-call order for history.
+        # Dispatch concurrently with bare gather to mirror the agent path
+        # (supreme_agent); gather preserves the original tool-call order for
+        # history. Accepted trade-off: on first failure sibling tool calls keep
+        # running detached instead of being cancelled - same as the agent path.
         tool_messages = await asyncio.gather(
             *(
                 tool_executor.call_tool(tool_call, inputs, show_stage=False)

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -412,7 +412,13 @@ class HybridSearcher:
                 return res
 
             # ES and pgvector queries are independent - run them concurrently.
-            lex, sem_raw = await asyncio.gather(_timed_lexical(), _timed_semantic_raw())
+            # TaskGroup (unlike bare gather) cancels the sibling query on first
+            # failure instead of leaving it running past the request's failure.
+            async with asyncio.TaskGroup() as tg:
+                lex_task = tg.create_task(_timed_lexical())
+                sem_task = tg.create_task(_timed_semantic_raw())
+            lex = lex_task.result()
+            sem_raw = sem_task.result()
 
             lex_filtered: HarmonizedItemsScoredDict = self._filer_candidates_by_availability(
                 lex, availability

--- a/statgpt/app/services/hybrid_searcher.py
+++ b/statgpt/app/services/hybrid_searcher.py
@@ -1,3 +1,4 @@
+import asyncio
 import collections
 import json
 import re
@@ -277,15 +278,22 @@ class HybridSearcher:
 
             return items_dict
 
-        async def _es_get_by_id(self, _id: str) -> IndicatorIndex | None:
-            query = {"term": {"id.keyword": _id}}
-            result: SearchResult = await self._outer._indicators_index.search(query=query, size=1)
-            if len(result.hits.hits) == 0:
-                logger.warning(f"HybridMatch: cannot find by id {_id}")
-                return None
-            res_raw = result.hits.hits[0].source
-            res = IndicatorIndex.model_validate(res_raw)
-            return res
+        async def _es_get_by_ids(self, ids: list[str]) -> dict[str, IndicatorIndex]:
+            """Fetch all documents for `ids` in a single terms query (avoids N+1 ES lookups)."""
+            if not ids:
+                return {}
+            query = {"terms": {"id.keyword": ids}}
+            result: SearchResult = await self._outer._indicators_index.search(
+                query=query, size=len(ids)
+            )
+            found: dict[str, IndicatorIndex] = {}
+            for hit in result.hits.hits:
+                item = IndicatorIndex.model_validate(hit.source)
+                found[item.id] = item
+            for _id in ids:
+                if _id not in found:
+                    logger.warning(f"HybridMatch: cannot find by id {_id}")
+            return found
 
         async def _semantic_raw(
             self, user_query: str, version_ids: set[int], max_query: int
@@ -313,6 +321,15 @@ class HybridSearcher:
             semantic: PlainItemsScoredDict,
             alpha: float,
         ) -> HarmonizedItemsScoredDict:
+            missing_ids = list(
+                dict.fromkeys(
+                    _id
+                    for document in sem_raw
+                    if (_id := document.metadata['id']) in semantic and _id not in lexical
+                )
+            )
+            fetched = await self._es_get_by_ids(missing_ids)
+
             hybrid = {}
 
             for document in sem_raw:
@@ -328,7 +345,7 @@ class HybridSearcher:
                 if _id in lexical:
                     metadata = lexical[_id].metadata
                 else:
-                    metadata = await self._es_get_by_id(_id)
+                    metadata = fetched.get(_id)
 
                 if metadata is None:
                     continue
@@ -378,20 +395,28 @@ class HybridSearcher:
 
             t_total = time.perf_counter()
 
-            t_lexical = time.perf_counter()
-            lex = await self._lexical(
-                query, version_ids, max_query=search_params.max_lexical_candidates
-            )
-            timings.lexical = time.perf_counter() - t_lexical
+            async def _timed_lexical() -> HarmonizedItemsScoredDict:
+                t_lexical = time.perf_counter()
+                res = await self._lexical(
+                    query, version_ids, max_query=search_params.max_lexical_candidates
+                )
+                timings.lexical = time.perf_counter() - t_lexical
+                return res
+
+            async def _timed_semantic_raw() -> list[ScoredVectorStoreDocument]:
+                t_semantic_raw = time.perf_counter()
+                res = await self._semantic_raw(
+                    query, version_ids, max_query=search_params.max_semantic_candidates
+                )
+                timings.semantic_raw = time.perf_counter() - t_semantic_raw
+                return res
+
+            # ES and pgvector queries are independent - run them concurrently.
+            lex, sem_raw = await asyncio.gather(_timed_lexical(), _timed_semantic_raw())
+
             lex_filtered: HarmonizedItemsScoredDict = self._filer_candidates_by_availability(
                 lex, availability
             )
-
-            t_semantic_raw = time.perf_counter()
-            sem_raw: list[ScoredVectorStoreDocument] = await self._semantic_raw(
-                query, version_ids, max_query=search_params.max_semantic_candidates
-            )
-            timings.semantic_raw = time.perf_counter() - t_semantic_raw
             sem_indexed = self._semantic_result(sem_raw)
             sem_filtered: PlainItemsScoredDict = self._filer_candidates_by_availability(
                 sem_indexed, availability

--- a/tests/unit/app/chains/test_main_direct_tool_calls.py
+++ b/tests/unit/app/chains/test_main_direct_tool_calls.py
@@ -1,0 +1,68 @@
+"""Unit tests for MainChainFactory._direct_tool_calls_chain dispatch."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from langchain_core.messages import ToolMessage
+
+from statgpt.app.chains.main import MainChainFactory
+from statgpt.app.config import StateVarsConfig
+from statgpt.app.config.chain_parameters import ChainParametersConfig
+from statgpt.app.settings.dial_app import dial_app_settings
+
+
+def _dial_tool_call(id_: str, name: str) -> SimpleNamespace:
+    return SimpleNamespace(id=id_, function=SimpleNamespace(name=name, arguments="{}"))
+
+
+def _inputs_with_tool_calls(tool_calls: list[SimpleNamespace]) -> tuple[dict, Mock]:
+    history = Mock()
+    history.get_last_non_tool_message.return_value = SimpleNamespace(tool_calls=tool_calls)
+    inputs = {ChainParametersConfig.STATE: {}, ChainParametersConfig.HISTORY: history}
+    return inputs, history
+
+
+async def test_no_tool_calls_skips_dispatch(monkeypatch):
+    monkeypatch.setattr(dial_app_settings, "enable_direct_tool_calls", True)
+    inputs, history = _inputs_with_tool_calls([])
+
+    factory = MainChainFactory(channel_config=Mock())
+    result = await factory._direct_tool_calls_chain(inputs)
+
+    assert result is inputs
+    assert inputs[ChainParametersConfig.STATE][StateVarsConfig.DIRECT_TOOL_CALLS] == []
+    history.add_tool_message.assert_not_called()
+
+
+async def test_dispatches_concurrently_and_preserves_order(monkeypatch):
+    monkeypatch.setattr(dial_app_settings, "enable_direct_tool_calls", True)
+
+    second_started = asyncio.Event()
+
+    async def call_tool(tool_call, inputs, show_stage=True, prefix=''):
+        if tool_call["id"] == "call-1":
+            # Resolves only after the second call has started: sequential
+            # dispatch would hang here (bounded by the wait_for timeouts).
+            await asyncio.wait_for(second_started.wait(), timeout=1)
+        else:
+            second_started.set()
+        return ToolMessage(content=f"result {tool_call['id']}", tool_call_id=tool_call["id"])
+
+    monkeypatch.setattr(
+        "statgpt.app.chains.main.ToolCaller",
+        SimpleNamespace(from_config=lambda config: SimpleNamespace(call_tool=call_tool)),
+    )
+    inputs, history = _inputs_with_tool_calls(
+        [_dial_tool_call("call-1", "tool_a"), _dial_tool_call("call-2", "tool_b")]
+    )
+
+    factory = MainChainFactory(channel_config=Mock())
+    result = await asyncio.wait_for(factory._direct_tool_calls_chain(inputs), timeout=1)
+
+    assert result is inputs
+    state = inputs[ChainParametersConfig.STATE]
+    assert [tc["id"] for tc in state[StateVarsConfig.DIRECT_TOOL_CALLS]] == ["call-1", "call-2"]
+    # results are appended to history in the original tool-call order
+    added_ids = [call.args[0].tool_call_id for call in history.add_tool_message.call_args_list]
+    assert added_ids == ["call-1", "call-2"]

--- a/tests/unit/app/services/test_hybrid_searcher.py
+++ b/tests/unit/app/services/test_hybrid_searcher.py
@@ -1,11 +1,21 @@
 """Unit tests for HybridSearcher.HybridMatch candidate assembly."""
 
-from unittest.mock import Mock
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from statgpt.app.services.hybrid_searcher import HarmonizedItemScored, HybridSearcher
-from statgpt.common.hybrid_indexer.schemas import IndicatorIndex
+from statgpt.app.schemas.query_builder import HybridMatchTimings
+from statgpt.app.services.hybrid_searcher import (
+    HarmonizedItemScored,
+    HybridSearcher,
+    PlainItemScored,
+    SearchParams,
+)
+from statgpt.common.hybrid_indexer.schemas import IndicatorIndex, MatchingIndex
+from statgpt.common.utils.elastic import SearchResult
+from statgpt.common.vectorstore import ScoredVectorStoreDocument
 
 
 def _indicator(id_: str, dataset_id: str = "ds1") -> IndicatorIndex:
@@ -30,6 +40,45 @@ def _candidate(id_: str, dataset_id: str = "ds1") -> dict:
 
 def _lex(id_: str, score: float, dataset_id: str = "ds1") -> HarmonizedItemScored:
     return HarmonizedItemScored(score=score, metadata=_indicator(id_, dataset_id))
+
+
+def _plain(id_: str, score: float, dataset_id: str = "ds1") -> PlainItemScored:
+    metadata = MatchingIndex.model_validate(_indicator(id_, dataset_id).model_dump())
+    return PlainItemScored(score=score, metadata=metadata)
+
+
+def _doc(id_: str, score: float, dataset_id: str = "ds1") -> ScoredVectorStoreDocument:
+    return ScoredVectorStoreDocument(
+        page_content=f"name {id_}",
+        metadata=_indicator(id_, dataset_id).model_dump(),
+        table_name="indicators",
+        document_id=1,
+        dataset_id=uuid.uuid4(),
+        version_id=1,
+        score=score,
+    )
+
+
+def _search_result(indicators: list[IndicatorIndex]) -> SearchResult:
+    return SearchResult.model_validate(
+        {
+            "took": 1,
+            "timed_out": False,
+            "hits": {
+                "total": {"value": len(indicators), "relation": "eq"},
+                "max_score": 1.0 if indicators else None,
+                "hits": [
+                    {
+                        "_index": "indicators",
+                        "_id": indicator.id,
+                        "_score": 1.0,
+                        "_source": indicator.model_dump(),
+                    }
+                    for indicator in indicators
+                ],
+            },
+        }
+    )
 
 
 @pytest.fixture
@@ -95,3 +144,92 @@ def test_appended_candidate_has_consumable_shape(match):
     metadata = appended["metadata"]
     for key in ("dataset_id", "primary_normalized", "name_normalized", "where", "series"):
         assert key in metadata
+
+
+async def test_es_get_by_ids_no_query_for_empty_ids(match):
+    match._outer._indicators_index.search = AsyncMock()
+
+    assert await match._es_get_by_ids([]) == {}
+    match._outer._indicators_index.search.assert_not_awaited()
+
+
+async def test_es_get_by_ids_warns_per_missing_id(match, monkeypatch):
+    logger_mock = Mock()
+    monkeypatch.setattr("statgpt.app.services.hybrid_searcher.logger", logger_mock)
+    match._outer._indicators_index.search = AsyncMock(
+        return_value=_search_result([_indicator("a")])
+    )
+
+    found = await match._es_get_by_ids(["a", "b", "c"])
+
+    assert set(found) == {"a"}
+    warned = [call.args[0] for call in logger_mock.warning.call_args_list]
+    assert any("b" in msg for msg in warned)
+    assert any("c" in msg for msg in warned)
+    assert len(warned) == 2
+
+
+async def test_hybrid_combination_fetches_missing_ids_in_one_query(match):
+    """Ids absent from the lexical results are fetched with a single terms query (no N+1)."""
+    sem_raw = [
+        _doc("a", 0.9),  # present in lexical -> no ES lookup
+        _doc("b", 0.8),  # missing from lexical -> fetched from ES
+        _doc("c", 0.7),  # missing from lexical and from ES -> dropped
+        _doc("d", 0.6),  # filtered out by availability -> not fetched
+        _doc("b", 0.5),  # duplicate id -> requested once
+    ]
+    lexical = {"a": _lex("a", 0.5)}
+    semantic = {"a": _plain("a", 0.9), "b": _plain("b", 0.8), "c": _plain("c", 0.7)}
+    search_mock = AsyncMock(return_value=_search_result([_indicator("b")]))
+    match._outer._indicators_index.search = search_mock
+
+    hybrid = await match._hybrid_combination(
+        sem_raw=sem_raw, lexical=lexical, semantic=semantic, alpha=0.5
+    )
+
+    search_mock.assert_awaited_once_with(query={"terms": {"id.keyword": ["b", "c"]}}, size=2)
+    assert set(hybrid) == {"a", "b"}
+    assert hybrid["a"].score == pytest.approx(0.5 * 0.9 + 0.5 * 0.5)
+    assert hybrid["b"].score == pytest.approx(0.5 * 0.8)
+
+
+async def test_hybrid_candidates_runs_lexical_and_semantic_concurrently(match):
+    match._outer.config.max_output_div = 2
+    match._outer.config.max_lexical_only_candidates = 0
+
+    semantic_started = asyncio.Event()
+
+    async def fake_lexical(query, version_ids, max_query):
+        # Resolves only after the semantic search has started: sequential
+        # execution would hang here (bounded by the wait_for timeouts).
+        await asyncio.wait_for(semantic_started.wait(), timeout=1)
+        return {"a": _lex("a", 0.5)}
+
+    async def fake_semantic_raw(query, version_ids, max_query):
+        semantic_started.set()
+        return [_doc("a", 0.9)]
+
+    match._lexical = fake_lexical
+    match._semantic_raw = fake_semantic_raw
+
+    timings = HybridMatchTimings()
+    search_params = SearchParams(
+        alpha=0.5, max_candidates=10, max_semantic_candidates=10, max_lexical_candidates=10
+    )
+    lex_filtered, sem_filtered, candidates = await asyncio.wait_for(
+        match._hybrid_candidates(
+            query="q",
+            version_ids={1},
+            availability={"ds1": {}},
+            search_params=search_params,
+            timings=timings,
+        ),
+        timeout=1,
+    )
+
+    assert set(lex_filtered) == {"a"}
+    assert set(sem_filtered) == {"a"}
+    assert [c["id"] for c in candidates] == ["a"]
+    # per-part timings are measured inside each coroutine
+    assert timings.lexical > 0
+    assert timings.semantic_raw > 0


### PR DESCRIPTION
### Applicable issues

- fixes #502

### Description of changes

The hybrid indicator search ran its independent ElasticSearch and pgvector queries sequentially and then issued one ES lookup per semantic candidate missing from the lexical results; direct tool calls were likewise executed one at a time. This PR removes that avoidable serialization while keeping outputs, timings semantics, and history ordering unchanged.

- Run `_lexical` and `_semantic_raw` concurrently in an `asyncio.TaskGroup` (first failure cancels the sibling query); per-part timings are measured inside each coroutine and availability filtering happens after the join
- Replace the per-id ES lookup in `_hybrid_combination` with a single `terms` query fetching all missing ids, keeping the per-missing-id warning
- Dispatch direct tool calls with `asyncio.gather` (mirroring the agent path), appending results to history in the original tool-call order
- Add unit tests for the batched ES fetch, hybrid combination, concurrent search execution, and direct tool call dispatch ordering

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
