### PR TITLE
feat: add python code and typed structured content for the data query MCP tool

### DIFF
--- a/statgpt/app/mcp/attachments.py
+++ b/statgpt/app/mcp/attachments.py
@@ -1,11 +1,16 @@
-from typing import Any
+import logging
 from urllib.parse import quote
 
 from mcp.types import EmbeddedResource, TextResourceContents
 from pydantic import AnyUrl
 
+from statgpt.app.schemas.mcp import DataQueryStructuredContent, DataQueryToolsInfo
 from statgpt.app.schemas.query import AppJsonQueryWithMetadata
 from statgpt.app.schemas.tool_artifact import DataQueryArtifact
+from statgpt.app.services.python_code_generator import generate_merged_python_code
+from statgpt.common.schemas import ChannelConfig
+
+_log = logging.getLogger(__name__)
 
 
 def data_query_artifact_to_resources(
@@ -41,18 +46,31 @@ def data_query_artifact_to_resources(
 
 
 def data_query_artifact_to_structured_content(
-    artifact: DataQueryArtifact,
-) -> dict[str, Any] | None:
-    """Serialize each DataResponse's json_query as the tool's MCP structured content.
+    artifact: DataQueryArtifact, channel_config: ChannelConfig
+) -> DataQueryStructuredContent | None:
+    """Build the data query tool's MCP structured content from the artifact.
 
-    Returns a ``{"queries": [...]}`` object where each entry is an AppJsonQueryWithMetadata
-    dumped with camelCase aliases, matching the DIAL "Query (JSON)" attachment shape.
-    Returns None when no response carries a query so the provider omits structuredContent.
+    Collects each DataResponse's json_query, generates a reproducible sdmx1 snippet for
+    them, and records the companion SDMX-proxy tool name. Returns None when no response
+    carries a query so the provider omits structuredContent.
     """
-    queries: list[dict[str, Any]] = []
+    queries: list[AppJsonQueryWithMetadata] = []
     for response in artifact.data_responses.values():
         query = response.json_query
         if query is None:
             continue
-        queries.append(AppJsonQueryWithMetadata.from_common(query).model_dump(by_alias=True))
-    return {"queries": queries} if queries else None
+        queries.append(AppJsonQueryWithMetadata.from_common(query))
+    if not queries:
+        return None
+
+    try:
+        python_code = generate_merged_python_code(queries)
+    except ValueError:
+        _log.exception("Failed to generate python code for MCP structured content")
+        python_code = ""
+
+    sdmx_query_app = channel_config.sdmx_query_app
+    tools = DataQueryToolsInfo(
+        sdmx_proxy=sdmx_query_app.name if sdmx_query_app is not None else None
+    )
+    return DataQueryStructuredContent(queries=queries, python_code=python_code, tools=tools)

--- a/statgpt/app/mcp/attachments.py
+++ b/statgpt/app/mcp/attachments.py
@@ -1,4 +1,3 @@
-import logging
 from urllib.parse import quote
 
 from mcp.types import EmbeddedResource, TextResourceContents
@@ -9,8 +8,6 @@ from statgpt.app.schemas.query import AppJsonQueryWithMetadata
 from statgpt.app.schemas.tool_artifact import DataQueryArtifact
 from statgpt.app.services.python_code_generator import generate_merged_python_code
 from statgpt.common.schemas import ChannelConfig
-
-_log = logging.getLogger(__name__)
 
 
 def data_query_artifact_to_resources(
@@ -63,12 +60,7 @@ def data_query_artifact_to_structured_content(
     if not queries:
         return None
 
-    try:
-        python_code = generate_merged_python_code(queries)
-    except ValueError:
-        _log.exception("Failed to generate python code for MCP structured content")
-        python_code = ""
-
+    python_code = generate_merged_python_code(queries)
     sdmx_query_app = channel_config.sdmx_query_app
     tools = DataQueryToolsInfo(
         sdmx_proxy=sdmx_query_app.name if sdmx_query_app is not None else None

--- a/statgpt/app/mcp/provider.py
+++ b/statgpt/app/mcp/provider.py
@@ -27,6 +27,7 @@ from statgpt.app.mcp.exceptions import MissingDeploymentIdError
 from statgpt.app.mcp.guardrails import enforce_input_guardrail
 from statgpt.app.mcp.widget_resource import WidgetResource
 from statgpt.app.schemas.dial_app_configuration import StatGPTConfiguration
+from statgpt.app.schemas.mcp import DataQueryStructuredContent, SdmxProxyStructuredContent
 from statgpt.app.schemas.tool_artifact import DataQueryArtifact, SdmxQueryAppArtifact
 from statgpt.app.security import DialAuthCredentials, create_auth_context
 from statgpt.app.services.chat_facade import ChannelServiceFacade
@@ -109,20 +110,22 @@ class _McpToolAdapter(Tool):
             raise ToolError(f"{self._langchain_tool.name} tool failed to execute")
         text = result.content if isinstance(result.content, str) else str(result.content)
         content: list[ContentBlock] = [TextContent(type="text", text=text)]
-        structured_content: dict[str, Any] | None = None
+        structured_content: DataQueryStructuredContent | SdmxProxyStructuredContent | None = None
         if isinstance(result.artifact, DataQueryArtifact):
             # to_csv is CPU-bound and can block on large dataframes; offload to a worker thread.
             resources = await asyncio.to_thread(data_query_artifact_to_resources, result.artifact)
             content.extend(resources)
-            structured_content = data_query_artifact_to_structured_content(result.artifact)
+            structured_content = data_query_artifact_to_structured_content(
+                result.artifact, self._channel_config
+            )
         elif isinstance(result.artifact, SdmxQueryAppArtifact):
             # Surface the upstream HTTP metadata so the MCP-App can distinguish success from
             # error responses and know the body's media type. The raw body stays in the text
             # content block above to keep the passthrough behavior.
-            structured_content = {
-                "status_code": result.artifact.status_code,
-                "content_type": result.artifact.content_type,
-            }
+            structured_content = SdmxProxyStructuredContent(
+                status_code=result.artifact.status_code,
+                content_type=result.artifact.content_type,
+            )
         return ToolResult(content=content, structured_content=structured_content)
 
 

--- a/statgpt/app/schemas/mcp.py
+++ b/statgpt/app/schemas/mcp.py
@@ -1,0 +1,48 @@
+from pydantic import ConfigDict, Field
+
+from statgpt.app.schemas.query import AppJsonQueryWithMetadata
+from statgpt.common.schemas.base import BaseYamlModel
+
+
+class DataQueryToolsInfo(BaseYamlModel):
+    """Names of companion MCP tools the caller can use to act on the queries."""
+
+    model_config = ConfigDict(serialize_by_alias=True)
+
+    sdmx_proxy: str | None = Field(
+        default=None,
+        description="Name of the SDMX-proxy MCP tool, if configured on the channel.",
+    )
+
+
+class DataQueryStructuredContent(BaseYamlModel):
+    """MCP structured content for the data query tool.
+
+    Serialized with camelCase aliases to match the DIAL attachment shape.
+    """
+
+    model_config = ConfigDict(serialize_by_alias=True)
+
+    queries: list[AppJsonQueryWithMetadata] = Field(
+        description="The queries used to fetch the data, one per dataset."
+    )
+    python_code: str = Field(
+        description="A self-contained sdmx1 snippet that reproduces the queries."
+    )
+    tools: DataQueryToolsInfo = Field(description="Companion MCP tools for these queries.")
+    version: int = Field(default=1, description="Schema version of this structured content.")
+
+
+class SdmxProxyStructuredContent(BaseYamlModel):
+    """MCP structured content for the SDMX-proxy passthrough tool.
+
+    Surfaces the upstream HTTP metadata so the MCP-App can distinguish success from
+    error responses and know the body's media type.
+    """
+
+    model_config = ConfigDict(serialize_by_alias=True)
+
+    status_code: int = Field(description="HTTP status code returned by the upstream request.")
+    content_type: str | None = Field(
+        default=None, description="Content type of the upstream response body, if known."
+    )

--- a/statgpt/app/services/python_code_generator.py
+++ b/statgpt/app/services/python_code_generator.py
@@ -1,8 +1,11 @@
+import logging
 from typing import Never
 
 from statgpt.app.schemas.query import AppJsonQueryWithMetadata
 from statgpt.common.data.sdmx.python_code import generate_python_query_body
 from statgpt.common.schemas.query import JsonComponentQuery, JsonQueryOperator
+
+_log = logging.getLogger(__name__)
 
 PYTHON_SDMX1_HEADER = """\
 # Uses the [sdmx1 library](https://pypi.org/project/sdmx1/)
@@ -138,6 +141,21 @@ def generate_python_code_from_query(query: AppJsonQueryWithMetadata, suffix: str
     )
 
 
+def _snippet_or_placeholder(query: AppJsonQueryWithMetadata, suffix: str = "") -> str:
+    """Return a query's sdmx1 snippet, or a commented placeholder if it can't be expressed.
+
+    Some queries have no faithful SDMX REST representation (e.g. exclusive ``gt`` / ``lt``
+    time bounds, or a multi-value ``in`` on the time dimension) and raise ValueError. We
+    keep the rest of the merged snippet usable by substituting an explanatory comment for
+    just the offending query instead of dropping the whole snippet.
+    """
+    try:
+        return generate_python_code_from_query(query, suffix=suffix)
+    except ValueError:
+        _log.exception("Failed to generate sdmx1 snippet for query %s", query.urn)
+        return f"# Unable to generate a reproducible sdmx1 snippet for {query.urn}."
+
+
 def generate_merged_python_code(queries: list[AppJsonQueryWithMetadata]) -> str:
     queries = [
         q
@@ -147,10 +165,10 @@ def generate_merged_python_code(queries: list[AppJsonQueryWithMetadata]) -> str:
     if not queries:
         return PYTHON_SDMX1_HEADER
     if len(queries) == 1:
-        body = generate_python_code_from_query(queries[0])
+        body = _snippet_or_placeholder(queries[0])
     else:
         sections = [
-            f"# Dataset: {query.urn}\n{generate_python_code_from_query(query, suffix=f'_{i}')}"
+            f"# Dataset: {query.urn}\n{_snippet_or_placeholder(query, suffix=f'_{i}')}"
             for i, query in enumerate(queries, start=1)
         ]
         body = "\n\n".join(sections)

--- a/tests/unit/app/mcp/test_attachments.py
+++ b/tests/unit/app/mcp/test_attachments.py
@@ -25,6 +25,12 @@ def _make_artifact(data_responses: dict) -> DataQueryArtifact:
     return DataQueryArtifact.model_construct(data_responses=data_responses)
 
 
+def _channel_config(sdmx_proxy_name: str | None = "sdmx_query_app") -> SimpleNamespace:
+    # The converter only reads channel_config.sdmx_query_app(.name).
+    sdmx_query_app = SimpleNamespace(name=sdmx_proxy_name) if sdmx_proxy_name is not None else None
+    return SimpleNamespace(sdmx_query_app=sdmx_query_app)
+
+
 def _json_query(urn: str) -> JsonQueryWithMetadata:
     return JsonQueryWithMetadata(
         urn=urn,
@@ -138,17 +144,35 @@ def test_structured_content_serializes_single_query():
         {"ds1": _response("IMF:CPI(1.0.0)", df, json_query=_json_query("IMF:CPI(1.0.0)"))}
     )
 
-    structured = data_query_artifact_to_structured_content(artifact)
+    structured = data_query_artifact_to_structured_content(artifact, _channel_config())
 
     assert structured is not None
-    assert list(structured) == ["queries"]
-    assert len(structured["queries"]) == 1
-    query = structured["queries"][0]
+    data = structured.model_dump(by_alias=True)
+    assert list(data) == ["queries", "pythonCode", "tools", "version"]
+    assert data["tools"] == {"sdmxProxy": "sdmx_query_app"}
+    assert data["version"] == 1
+    assert "import sdmx" in data["pythonCode"]
+    assert len(data["queries"]) == 1
+    query = data["queries"][0]
     assert query["urn"] == "IMF:CPI(1.0.0)"
     assert query["disabled"] is False
     assert query["sdmx1Source"] == "IMF_DATA"
     assert query["filters"][0]["componentCode"] == "REF_AREA"
     assert query["metadata"]["keyDimensionIdsInDsdOrder"] == ["REF_AREA", "INDICATOR"]
+
+
+def test_structured_content_omits_sdmx_proxy_when_unconfigured():
+    df = pd.DataFrame({"x": [1]})
+    artifact = _make_artifact(
+        {"ds1": _response("IMF:CPI(1.0.0)", df, json_query=_json_query("IMF:CPI(1.0.0)"))}
+    )
+
+    structured = data_query_artifact_to_structured_content(
+        artifact, _channel_config(sdmx_proxy_name=None)
+    )
+
+    assert structured is not None
+    assert structured.tools.sdmx_proxy is None
 
 
 def test_structured_content_preserves_insertion_order():
@@ -160,10 +184,10 @@ def test_structured_content_preserves_insertion_order():
         }
     )
 
-    structured = data_query_artifact_to_structured_content(artifact)
+    structured = data_query_artifact_to_structured_content(artifact, _channel_config())
 
     assert structured is not None
-    assert [q["urn"] for q in structured["queries"]] == ["IMF:CPI(1.0.0)", "BIS:IR(2.1.0)"]
+    assert [q.urn for q in structured.queries] == ["IMF:CPI(1.0.0)", "BIS:IR(2.1.0)"]
 
 
 def test_structured_content_skips_responses_without_query():
@@ -175,16 +199,16 @@ def test_structured_content_skips_responses_without_query():
         }
     )
 
-    structured = data_query_artifact_to_structured_content(artifact)
+    structured = data_query_artifact_to_structured_content(artifact, _channel_config())
 
     assert structured is not None
-    assert [q["urn"] for q in structured["queries"]] == ["IMF:OK(1.0.0)"]
+    assert [q.urn for q in structured.queries] == ["IMF:OK(1.0.0)"]
 
 
 def test_structured_content_returns_none_when_no_queries():
     df = pd.DataFrame({"x": [1]})
     artifact = _make_artifact({"no_query": _response("IMF:NOQ(1.0.0)", df, json_query=None)})
 
-    assert data_query_artifact_to_structured_content(artifact) is None
+    assert data_query_artifact_to_structured_content(artifact, _channel_config()) is None
 
-    assert data_query_artifact_to_structured_content(_make_artifact({})) is None
+    assert data_query_artifact_to_structured_content(_make_artifact({}), _channel_config()) is None

--- a/tests/unit/app/mcp/test_provider.py
+++ b/tests/unit/app/mcp/test_provider.py
@@ -11,19 +11,23 @@ from mcp.types import EmbeddedResource, TextContent
 
 from statgpt.app.chains.out_of_scope_checker import OutOfScopeCheckerResponse
 from statgpt.app.mcp.provider import ChannelToolProvider, _McpToolAdapter
-from statgpt.app.schemas.tool_artifact import DataQueryArtifact
+from statgpt.app.schemas.tool_artifact import DataQueryArtifact, SdmxQueryAppArtifact
 from statgpt.common.schemas.query import JsonQueryMetadata, JsonQueryWithMetadata
 from statgpt.common.schemas.tool_details import SdmxQueryAppDetails
 from statgpt.common.schemas.tools import AvailableDatasetsTool, SdmxQueryAppTool
 
 
-def _build_adapter(result) -> _McpToolAdapter:
+def _build_adapter(
+    result, sdmx_query_app=SimpleNamespace(name="sdmx_query_app")
+) -> _McpToolAdapter:
     tool = SimpleNamespace(name="fake_tool", ainvoke=AsyncMock(return_value=result))
     return _McpToolAdapter(
         langchain_tool=tool,  # type: ignore[arg-type]
         inputs={},
         # out_of_scope=None disables the guardrail, so run() proceeds straight to the tool.
-        channel_config=SimpleNamespace(out_of_scope=None),  # type: ignore[arg-type]
+        channel_config=SimpleNamespace(  # type: ignore[arg-type]
+            out_of_scope=None, sdmx_query_app=sdmx_query_app
+        ),
         auth_context=SimpleNamespace(),  # type: ignore[arg-type]
         name="fake_tool",
         parameters={},
@@ -62,8 +66,12 @@ async def test_data_query_artifact_adds_csv_resources():
     resources = [c for c in tool_result.content if isinstance(c, EmbeddedResource)]
     assert len(resources) == 1
     assert resources[0].resource.mimeType == "text/csv"
-    assert tool_result.structured_content is not None
-    assert [q["urn"] for q in tool_result.structured_content["queries"]] == ["IMF:CPI(1.0.0)"]
+    structured = tool_result.structured_content
+    assert structured is not None
+    assert [q["urn"] for q in structured["queries"]] == ["IMF:CPI(1.0.0)"]
+    assert structured["tools"] == {"sdmxProxy": "sdmx_query_app"}
+    assert structured["version"] == 1
+    assert "import sdmx" in structured["pythonCode"]
 
 
 async def test_data_query_artifact_without_query_has_no_structured_content():
@@ -81,6 +89,40 @@ async def test_data_query_artifact_without_query_has_no_structured_content():
     tool_result = await adapter.run({})
 
     assert tool_result.structured_content is None
+
+
+async def test_data_query_structured_content_omits_sdmx_proxy_when_unconfigured():
+    df = pd.DataFrame({"x": [1]})
+    response = SimpleNamespace(
+        resource_path="IMF:CPI(1.0.0)",
+        visual_dataframe=df,
+        csv_dataframe=df,
+        created_at=datetime(2026, 4, 20, 15, 30, 0, tzinfo=timezone.utc),
+        json_query=_json_query("IMF:CPI(1.0.0)"),
+    )
+    artifact = DataQueryArtifact.model_construct(data_responses={"ds1": response})
+    adapter = _build_adapter(
+        SimpleNamespace(content="answer", artifact=artifact), sdmx_query_app=None
+    )
+
+    tool_result = await adapter.run({})
+
+    assert tool_result.structured_content is not None
+    assert tool_result.structured_content["tools"] == {"sdmxProxy": None}
+
+
+async def test_sdmx_query_app_artifact_exposes_http_metadata():
+    artifact = SdmxQueryAppArtifact.model_construct(
+        status_code=200, content_type="application/json"
+    )
+    adapter = _build_adapter(SimpleNamespace(content="<xml/>", artifact=artifact))
+
+    tool_result = await adapter.run({})
+
+    assert tool_result.structured_content == {
+        "statusCode": 200,
+        "contentType": "application/json",
+    }
 
 
 async def test_non_data_query_result_returns_text_only():

--- a/tests/unit/test_python_code_generator.py
+++ b/tests/unit/test_python_code_generator.py
@@ -206,6 +206,49 @@ def test_generate_merged_python_code_multi_query_separates_sections() -> None:
     assert "provider_1" in code and "provider_2" in code
 
 
+def _make_query_with_unrepresentable_time(urn: str) -> AppJsonQueryWithMetadata:
+    """A query with an exclusive `gt` time bound, which has no SDMX REST representation."""
+    return AppJsonQueryWithMetadata(
+        urn=urn,
+        filters=[
+            JsonComponentQuery(component_code="A", operator=JsonQueryOperator.IN, values=["a1"]),
+            JsonComponentQuery(
+                component_code="TIME_PERIOD", operator=JsonQueryOperator.GT, values=["2020"]
+            ),
+        ],
+        metadata=JsonQueryMetadata(
+            country_dimension="A",
+            indicator_dimensions=["B"],
+            time_period_dimension="TIME_PERIOD",
+        ),
+    )
+
+
+def test_generate_merged_python_code_single_unrepresentable_query_yields_placeholder() -> None:
+    urn = "IMF:DF_BAD(1.0)"
+    code = generate_merged_python_code([_make_query_with_unrepresentable_time(urn)])
+
+    assert code.startswith(PYTHON_SDMX1_HEADER + "\n\n")
+    assert f"# Unable to generate a reproducible sdmx1 snippet for {urn}." in code
+    # The failure is isolated: no partial/broken request body is emitted.
+    assert "sdmx.Client" not in code
+
+
+def test_generate_merged_python_code_skips_only_the_unrepresentable_query() -> None:
+    good_urn = "IMF:DF_GOOD(1.0)"
+    bad_urn = "IMF:DF_BAD(1.0)"
+    code = generate_merged_python_code(
+        [_make_query(good_urn), _make_query_with_unrepresentable_time(bad_urn)]
+    )
+
+    # The good dataset still renders a complete snippet...
+    assert f"# Dataset: {good_urn}" in code
+    assert 'sdmx.Client("IMF")' in code
+    # ...while the bad one degrades to a placeholder instead of dropping the whole snippet.
+    assert f"# Dataset: {bad_urn}" in code
+    assert f"# Unable to generate a reproducible sdmx1 snippet for {bad_urn}." in code
+
+
 def test_generate_merged_python_code_drops_dataset_with_any_excluded_filter() -> None:
     excluded_query = AppJsonQueryWithMetadata(
         urn="IMF:DF_X(1.0)",


### PR DESCRIPTION
## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- closes #511
- related to PR #496

## Description of changes

Extends the data query MCP tool's `structuredContent` and makes it type-safe.

- Replaces the raw dict payload with typed Pydantic models (`DataQueryStructuredContent`, `DataQueryToolsInfo`, `SdmxProxyStructuredContent`) in a new `statgpt/app/schemas/mcp.py`. The models are passed directly to `ToolResult`, which serializes them (camelCase, matching the DIAL attachment shape).
- Populates the previously stubbed `pythonCode` field with a reproducible `sdmx1` snippet via the existing `generate_merged_python_code`, guarded against unsupported time filters.
- Surfaces the companion SDMX-proxy tool name under `tools.sdmxProxy` (omitted when no proxy tool is configured on the channel).
- Converts the SDMX-proxy passthrough branch to a typed model as well, for consistency.

## Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.