### PR TITLE
fix: make invalid sdmx_proxy MCP tool calls visible in logs

### DIFF
--- a/statgpt/app/chains/sdmx_query_app_tool.py
+++ b/statgpt/app/chains/sdmx_query_app_tool.py
@@ -1,15 +1,17 @@
+import logging
 from typing import Any, Literal
 
 import httpx
 from mcp.types import ToolAnnotations
-from pydantic import Field
+from pydantic import Field, field_validator, model_validator
 
-from statgpt.app.chains.tools import StatGptTool, ToolArgs, ToolInputError, ToolUpstreamError
+from statgpt.app.chains.tools import StatGptTool, ToolArgs, ToolUpstreamError
 from statgpt.app.schemas import SdmxQueryAppArtifact, ToolMessageState
-from statgpt.common.config import multiline_logger as logger
 from statgpt.common.schemas import SdmxQueryAppTool as SdmxQueryAppToolConfig
 from statgpt.common.schemas import ToolTypes
 from statgpt.common.utils import ManagedHttpClient
+
+_log = logging.getLogger(__name__)
 
 _HTTP_TIMEOUT = httpx.Timeout(90.0, connect=45.0)
 
@@ -43,6 +45,23 @@ class SdmxQueryAppArgs(ToolArgs):
         description="Value forwarded as the `Accept` header (e.g. an SDMX media type).",
     )
 
+    @field_validator("path")
+    @classmethod
+    def _path_stays_on_configured_host(cls, path: str) -> str:
+        if not path.startswith("/"):
+            raise ValueError("`path` must start with '/'.")
+        # Reject protocol-relative paths and absolute URLs to keep requests on the
+        # configured host (the base URL is prepended verbatim, no urljoin).
+        if path.startswith("//") or "://" in path:
+            raise ValueError("`path` must be domain-less (no scheme or host).")
+        return path
+
+    @model_validator(mode="after")
+    def _no_body_for_get(self) -> "SdmxQueryAppArgs":
+        if self.method == "GET" and self.body is not None:
+            raise ValueError("`body` is not supported for `GET` requests; use `method='POST'`.")
+        return self
+
 
 class SdmxQueryAppTool(StatGptTool[SdmxQueryAppToolConfig], tool_type=ToolTypes.SDMX_QUERY_APP):
     """MCP-only passthrough tool that forwards a frontend-built SDMX request to a configured
@@ -61,16 +80,6 @@ class SdmxQueryAppTool(StatGptTool[SdmxQueryAppToolConfig], tool_type=ToolTypes.
     def get_args_schema(cls, tool_config: SdmxQueryAppToolConfig) -> type[SdmxQueryAppArgs]:
         return SdmxQueryAppArgs
 
-    @staticmethod
-    def _build_url(base_url: str, path: str) -> str:
-        if not path.startswith("/"):
-            raise ToolInputError("`path` must start with '/'.")
-        # Reject protocol-relative paths and absolute URLs to keep requests on the
-        # configured host (the base URL is prepended verbatim, no urljoin).
-        if path.startswith("//") or "://" in path:
-            raise ToolInputError("`path` must be domain-less (no scheme or host).")
-        return f"{base_url}{path}"
-
     def _build_headers(self, method: str, accept: str | None) -> dict[str, str]:
         headers: dict[str, str] = {}
         if accept:
@@ -88,15 +97,10 @@ class SdmxQueryAppTool(StatGptTool[SdmxQueryAppToolConfig], tool_type=ToolTypes.
         accept: str | None = None,
         **kwargs,
     ) -> tuple[str, SdmxQueryAppArtifact]:
-        if method == "GET" and body is not None:
-            raise ToolInputError("`body` is not supported for `GET` requests; use `method='POST'`.")
-
-        base_url = self._tool_config.details.get_base_url()
-        url = self._build_url(base_url, path)
-
+        url = f"{self._tool_config.details.get_base_url()}{path}"
         headers = self._build_headers(method, accept)
 
-        logger.info(f"SDMX query app passthrough: {method} {url}")
+        _log.info("SDMX query app passthrough: %s %s", method, url)
         try:
             response = await sdmx_query_app_http_client.client.request(
                 method=method,

--- a/statgpt/app/chains/tools.py
+++ b/statgpt/app/chains/tools.py
@@ -47,20 +47,12 @@ class ToolRegistry(MutableMapping):
         return len(self._mapping)
 
 
-class ToolInputError(Exception):
-    """Raised by a tool for invalid caller-provided arguments.
-
-    The message is safe to surface to the caller (e.g. translated into an MCP
-    ToolError) instead of being masked as a generic execution failure.
-    """
-
-
 class ToolUpstreamError(Exception):
     """Raised by a tool when an upstream dependency (e.g. an HTTP backend) fails.
 
-    Like `ToolInputError`, the message is safe to surface to the caller so that
-    connection/timeout failures yield a clear message instead of being masked as
-    a generic execution failure.
+    The message is safe to surface to the caller (e.g. translated into an MCP
+    ToolError) so that connection/timeout failures yield a clear message instead
+    of being masked as a generic execution failure.
     """
 
 

--- a/statgpt/app/mcp/provider.py
+++ b/statgpt/app/mcp/provider.py
@@ -16,7 +16,7 @@ from mcp.types import ContentBlock, TextContent
 from pydantic import PrivateAttr, ValidationError
 from starlette.requests import Request
 
-from statgpt.app.chains.tools import StatGptTool, ToolInputError, ToolUpstreamError
+from statgpt.app.chains.tools import StatGptTool, ToolUpstreamError
 from statgpt.app.config import ChainParametersConfig
 from statgpt.app.mcp.attachments import (
     data_query_artifact_to_resources,
@@ -90,9 +90,6 @@ class _McpToolAdapter(Tool):
         }
         try:
             result = await self._langchain_tool.ainvoke(tool_call)
-        except ToolInputError as e:
-            # Invalid caller-provided arguments: surface the specific message.
-            raise ToolError(str(e)) from e
         except ValidationError as e:
             # Argument-schema validation failures (e.g. missing required field, bad enum
             # value). Surface a concise message instead of the generic failure.

--- a/tests/unit/app/chains/test_sdmx_query_app_tool.py
+++ b/tests/unit/app/chains/test_sdmx_query_app_tool.py
@@ -1,20 +1,22 @@
 import pytest
+from pydantic import ValidationError
 
-from statgpt.app.chains.sdmx_query_app_tool import SdmxQueryAppTool
-from statgpt.app.chains.tools import ToolInputError
+from statgpt.app.chains.sdmx_query_app_tool import SdmxQueryAppArgs
 from statgpt.common.schemas.tool_details import SdmxQueryAppDetails
 
-_BASE_URL = "https://sdmx.example.org/api"
+
+def _args(**kwargs) -> SdmxQueryAppArgs:
+    return SdmxQueryAppArgs(inputs={}, **kwargs)
 
 
-class TestBuildUrl:
-    """`_build_url` is the SSRF guard: it must keep every request on the trusted,
-    pre-configured host. The base URL is prepended verbatim (no urljoin), so the
-    only defense is rejecting any caller path that could escape the host."""
+class TestPathValidation:
+    """`SdmxQueryAppArgs.path` validation is the SSRF guard: the trusted base URL is
+    prepended verbatim (no urljoin), so the only defense is rejecting any caller path
+    that could escape the configured host."""
 
-    def test_simple_path_is_appended_verbatim(self):
-        url = SdmxQueryAppTool._build_url(_BASE_URL, "/structure/dataflow/IMF.RES/ED/1.0.0")
-        assert url == f"{_BASE_URL}/structure/dataflow/IMF.RES/ED/1.0.0"
+    def test_simple_path_is_accepted(self):
+        args = _args(path="/structure/dataflow/IMF.RES/ED/1.0.0")
+        assert args.path == "/structure/dataflow/IMF.RES/ED/1.0.0"
 
     @pytest.mark.parametrize(
         "path",
@@ -29,8 +31,8 @@ class TestBuildUrl:
         ],
     )
     def test_path_without_leading_slash_is_rejected(self, path: str):
-        with pytest.raises(ToolInputError, match="must start with '/'"):
-            SdmxQueryAppTool._build_url(_BASE_URL, path)
+        with pytest.raises(ValidationError, match="must start with '/'"):
+            _args(path=path)
 
     @pytest.mark.parametrize(
         "path",
@@ -43,8 +45,8 @@ class TestBuildUrl:
         ],
     )
     def test_protocol_relative_and_scheme_paths_are_rejected(self, path: str):
-        with pytest.raises(ToolInputError, match="domain-less"):
-            SdmxQueryAppTool._build_url(_BASE_URL, path)
+        with pytest.raises(ValidationError, match="domain-less"):
+            _args(path=path)
 
     @pytest.mark.parametrize(
         "path",
@@ -58,8 +60,21 @@ class TestBuildUrl:
         ],
     )
     def test_tricky_but_on_host_paths_are_allowed(self, path: str):
-        url = SdmxQueryAppTool._build_url(_BASE_URL, path)
-        assert url == f"{_BASE_URL}{path}"
+        args = _args(path=path)
+        assert args.path == path
+
+
+class TestBodyValidation:
+    """`body` is only meaningful for `POST`; supplying it with `GET` is rejected
+    instead of being silently ignored."""
+
+    def test_body_with_get_is_rejected(self):
+        with pytest.raises(ValidationError, match="not supported for `GET`"):
+            _args(path="/data", method="GET", body={"key": "value"})
+
+    def test_body_with_post_is_accepted(self):
+        args = _args(path="/availability", method="POST", body={"key": "value"})
+        assert args.body == {"key": "value"}
 
 
 class TestBaseUrlTrailingSlash:
@@ -77,8 +92,3 @@ class TestBaseUrlTrailingSlash:
     def test_trailing_slashes_are_trimmed(self, raw: str, expected: str):
         details = SdmxQueryAppDetails(base_url_raw=raw)
         assert details.get_base_url() == expected
-
-    def test_no_double_slash_when_joined_with_path(self):
-        details = SdmxQueryAppDetails(base_url_raw="https://sdmx.example.org/api/")
-        url = SdmxQueryAppTool._build_url(details.get_base_url(), "/structure")
-        assert url == "https://sdmx.example.org/api/structure"


### PR DESCRIPTION
## Applicable issues

- fixes #516

## Description of changes

Invalid `sdmx_proxy` tool calls (bad `path`, `body` supplied with `GET`) previously raised `ToolInputError` from inside `_arun`, a path that produced no log output at all — a failed call left no trace in the server logs while still returning HTTP 200 at the transport level.

- Moved the `path` SSRF guard and the `GET`+`body` check from imperative code in `SdmxQueryAppTool` into `SdmxQueryAppArgs` validators, so they fire during args validation and surface as `ValidationError` through the existing MCP handler, which logs them at INFO and returns a field-specific message to the client.
- Removed `ToolInputError` and its dedicated handler branch in the MCP provider — this tool was its only user.
- Switched the passthrough request log from `multiline_logger` (`statgpt-ml`) to the standard module logger, so it appears under `statgpt.app.chains.sdmx_query_app_tool` alongside the other MCP logs.
- Rewrote the unit tests to exercise the schema validators (same rejected/allowed path matrix) and added coverage for the `GET`+`body` rejection.

## Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
