### PR TITLE
fix: allow any Host header for MCP apps to fix 421 on deployed environments

### DIFF
--- a/statgpt/admin/app.py
+++ b/statgpt/admin/app.py
@@ -57,7 +57,9 @@ if APP_SETTINGS.beta_mcp_enabled:
         logger.warning(f"MCP is enabled, but optional beta-mcp dependencies are not installed: {e}")
         sys.exit(1)
 
-    mcp_app = mcp.http_app(path="/", transport="streamable-http", stateless_http=True)
+    mcp_app = mcp.http_app(
+        path="/", transport="streamable-http", stateless_http=True, allowed_hosts=["*"]
+    )
 
     @asynccontextmanager
     async def combined_lifespan(app_: FastAPI):

--- a/statgpt/app/application/app_factory.py
+++ b/statgpt/app/application/app_factory.py
@@ -48,7 +48,9 @@ class DialAppFactory:
     def create_app(self) -> DIALApp:
         _log.info("Creating DIAL app name=%s", dial_app_settings.dial_app_name)
 
-        mcp_app = mcp.http_app(path="/", transport="streamable-http", stateless_http=True)
+        mcp_app = mcp.http_app(
+            path="/", transport="streamable-http", stateless_http=True, allowed_hosts=["*"]
+        )
 
         @asynccontextmanager
         async def lifespan(app_: StatGPTApp):  # noqa: E306


### PR DESCRIPTION
## Applicable issues

N/A

## Description of changes

After the fastmcp 3.x upgrade (#521), MCP endpoints started rejecting all requests on deployed environments with `421 Misdirected Request` (surfaced to clients as 401), while working fine locally.

FastMCP 3.x enables Host/Origin header validation (DNS rebinding protection) by default, allowing only loopback hosts (`localhost`, `127.0.0.1`, `::1`). Locally the client connects via `localhost`, so requests pass; on deployed environments the `Host` header carries the public domain and every request is rejected.

This PR passes `allowed_hosts=["*"]` to `mcp.http_app(...)` in both the chat backend and the admin backend (beta MCP), disabling Host header filtering. DNS rebinding protection is designed to defend localhost-bound servers from malicious web pages and is not needed here: the services run behind a gateway with their own authentication.

## Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.