### PR TITLE
chore: bump sdmx1 to 2.26.0

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -176,7 +176,7 @@ resolutions:
       comment: "MIT License: https://github.com/langchain-ai/langgraph/blob/main/libs/sdk-py/LICENSE"
 
     # WARNINGS (dual-license packages)
-    - message: ".*PyPI::packaging:25\\..*"
+    - message: ".*PyPI::packaging:26\\..*"
       reason: "CANT_FIX_EXCEPTION"
       comment: "Dual (Apache 2.0 OR BSD 2-Clause): https://github.com/pypa/packaging/blob/main/LICENSE"
     - message: ".*PyPI::python-dateutil:2\\..*"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3768,14 +3768,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "25.0"
+version = "26.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
-    {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
+    {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
+    {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
 ]
 
 [[package]]
@@ -5507,18 +5507,19 @@ files = [
 
 [[package]]
 name = "sdmx1"
-version = "2.25.0"
+version = "2.26.0"
 description = "Statistical Data and Metadata eXchange (SDMX)"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "sdmx1-2.25.0-py3-none-any.whl", hash = "sha256:940f9fc67e92d8dbced1793b76d77b59256cc1b57a9203b76f77104c5ea4d1e2"},
-    {file = "sdmx1-2.25.0.tar.gz", hash = "sha256:573e7bc98ab0351d02eec805787b2c1e0af197d19f2f164e0b11ee8092ade63c"},
+    {file = "sdmx1-2.26.0-py3-none-any.whl", hash = "sha256:de7147381f40aad93bee45d7adc6567558f83f1f4a6c63ac5fbc22a0d0ed7f95"},
+    {file = "sdmx1-2.26.0.tar.gz", hash = "sha256:253e8cae85e3c752a6faaa3f7cfbad93f43a09dcb52f2e41f22aa1c71bc7b6e2"},
 ]
 
 [package.dependencies]
 lxml = ">=3.6"
+packaging = ">=26"
 pandas = ">=1.0"
 platformdirs = ">=4.1"
 python-dateutil = "*"
@@ -5527,7 +5528,7 @@ requests = ">=2.7"
 [package.extras]
 cache = ["requests-cache"]
 docs = ["furo", "ipython", "sphinx (>=8)"]
-tests = ["filelock", "gitpython", "jinja2", "pytest (>=5)", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "requests-cache", "responses"]
+tests = ["filelock", "gitpython", "jinja2", "pytest (>=9)", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "requests-cache", "responses"]
 
 [[package]]
 name = "secretstorage"
@@ -6825,4 +6826,4 @@ mcp = ["fastmcp"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "e918590865a9873217b2d7fb9f1f3f963aaf5f1d24c3c9fecd0018683071a9f5"
+content-hash = "f9c3120d1f376ecccee07eb4b3493c78a5085760d5128f31833957a3c9c2b6e9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     'pydantic-settings (>=2.14.2,<3.0.0)',       # Settings management
 
     # SDMX & Data processing
-    'sdmx1 (>=2.14.0,<3.0.0)',                   # SDMX data format support
+    'sdmx1 (>=2.26.0,<3.0.0)',                   # SDMX data format support
     'pandas (>=2.2.3,<3.0.0)',                   # Data manipulation
     'numpy (>=1.26.4,<2.0.0)',                   # Pinned to 1.x: CVE-2018-1999024 is a false positive (MathJax XSS); avoid breaking 2.x major
     'plotly (>=5.21.0,<6.0.0)',                  # Data visualization


### PR DESCRIPTION
### Applicable issues

N/A

### Description of changes

Bump `sdmx1` from 2.25.0 to 2.26.0 and raise the minimum constraint to `>=2.26.0,<3.0.0`. The only other lock change is `packaging` 25.0 → 26.2, a new minimum required by `sdmx1` since 2.25.1.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
