### PR TITLE
feat: merge an import into an existing channel without cleaning it up #527

### DIFF
--- a/statgpt/admin/routers/channel.py
+++ b/statgpt/admin/routers/channel.py
@@ -89,8 +89,11 @@ async def export_channel(
 
 
 IMPORT_CHANNEL_CLEAN_UP_DESCRIPTION = (
-    "If enabled and a channel with the same `deployment_id` exists, it will be deleted."
-    " If disabled and a channel with the same `deployment_id` exists, the import job will fail."
+    "If enabled and a channel with the same `deployment_id` exists, it will be deleted"
+    " and rebuilt from scratch."
+    " If disabled and a channel with the same `deployment_id` exists, the archive is merged"
+    " into it: configs and datasets are updated in place, new datasets and indexes are added,"
+    " and dimension indexes are deduplicated afterwards."
 )
 
 

--- a/statgpt/admin/services/channel.py
+++ b/statgpt/admin/services/channel.py
@@ -205,10 +205,9 @@ class AdminPortalChannelService(ChannelService):
         zip_file: zipfile.ZipFile,
         clean_up: bool,
         scope: schemas.ExportScope,
-        deployment_id: str | None,
+        deployment_id: str,
         auth_context: AuthContext,
-        existing_channel: models.Channel | None = None,
-    ) -> models.Channel:
+    ) -> tuple[bool, models.Channel]:
         if scope.includes_dial_files():
             await self._import_dial_files_from_zip(zip_file, auth_context)
 
@@ -217,12 +216,15 @@ class AdminPortalChannelService(ChannelService):
             if clean_up:
                 await self._cleanup_existing_channel(channel_data.deployment_id)
                 existing_channel = None
+            else:
+                existing_channel = await self.find_channel_by_deployment_id(deployment_id)
 
             if existing_channel is not None:
                 _log.info(
                     f"Merging import into existing channel id={existing_channel.id} "
                     f"(deployment_id={channel_data.deployment_id!r})"
                 )
+                is_merge = True
                 channel = await self.update(
                     existing_channel.id,
                     schemas.ChannelUpdate(
@@ -234,11 +236,12 @@ class AdminPortalChannelService(ChannelService):
                     ),
                 )
             else:
+                is_merge = False
                 channel = await self.create_channel(channel_data)
             await self._session.commit()
-            return await self.get_model_by_id(channel.id)
+            return is_merge, await self.get_model_by_id(channel.id)
 
-        return await self._get_existing_channel_by_deployment_id(deployment_id)
+        return True, await self.get_channel_by_deployment_id(deployment_id)
 
     async def _import_dial_files_from_zip(
         self, zip_file: zipfile.ZipFile, auth_context: AuthContext
@@ -289,16 +292,6 @@ class AdminPortalChannelService(ChannelService):
             pass  # No channel found, nothing to delete
         else:
             await self.delete(existing_channel.id)
-
-    async def _get_existing_channel_by_deployment_id(
-        self, deployment_id: str | None
-    ) -> models.Channel:
-        if deployment_id is None:
-            raise ValueError("deployment_id is required when importing indexes only.")
-        try:
-            return await self.get_channel_by_deployment_id(deployment_id)
-        except NoResultFound:
-            raise ValueError(f"Channel with deployment_id {deployment_id} not found during import.")
 
     @staticmethod
     async def _deduplicate_collection(collection_name: str, label: str) -> DedupCounts:

--- a/statgpt/admin/services/channel.py
+++ b/statgpt/admin/services/channel.py
@@ -215,9 +215,31 @@ class AdminPortalChannelService(ChannelService):
             channel_data = await self._load_channel_data_from_zip(zip_file)
             if clean_up:
                 await self._cleanup_existing_channel(channel_data.deployment_id)
-            created_channel = await self.create_channel(channel_data)
+                existing_channel = None
+            else:
+                existing_channel = await self.find_channel_by_deployment_id(
+                    channel_data.deployment_id
+                )
+
+            if existing_channel is not None:
+                _log.info(
+                    f"Merging import into existing channel id={existing_channel.id} "
+                    f"(deployment_id={channel_data.deployment_id!r})"
+                )
+                channel = await self.update(
+                    existing_channel.id,
+                    schemas.ChannelUpdate(
+                        title=channel_data.title,
+                        description=channel_data.description,
+                        deployment_id=channel_data.deployment_id,
+                        llm_model=channel_data.llm_model,
+                        details=channel_data.details,
+                    ),
+                )
+            else:
+                channel = await self.create_channel(channel_data)
             await self._session.commit()
-            return await self.get_model_by_id(created_channel.id)
+            return await self.get_model_by_id(channel.id)
 
         return await self._get_existing_channel_by_deployment_id(deployment_id)
 
@@ -256,6 +278,12 @@ class AdminPortalChannelService(ChannelService):
         channel_data = schemas.ChannelBase.model_validate(channel_data_json)
         _log.info(f"Importing channel: {channel_data!r}")
         return channel_data
+
+    async def find_channel_by_deployment_id(self, deployment_id: str) -> models.Channel | None:
+        try:
+            return await self.get_channel_by_deployment_id(deployment_id)
+        except NoResultFound:
+            return None
 
     async def _cleanup_existing_channel(self, deployment_id: str) -> None:
         try:

--- a/statgpt/admin/services/channel.py
+++ b/statgpt/admin/services/channel.py
@@ -200,7 +200,7 @@ class AdminPortalChannelService(ChannelService):
 
         return channel_db
 
-    async def import_channel_from_zip(
+    async def import_channel_config_from_zip(
         self,
         zip_file: zipfile.ZipFile,
         clean_up: bool,

--- a/statgpt/admin/services/channel.py
+++ b/statgpt/admin/services/channel.py
@@ -207,6 +207,7 @@ class AdminPortalChannelService(ChannelService):
         scope: schemas.ExportScope,
         deployment_id: str | None,
         auth_context: AuthContext,
+        existing_channel: models.Channel | None = None,
     ) -> models.Channel:
         if scope.includes_dial_files():
             await self._import_dial_files_from_zip(zip_file, auth_context)
@@ -216,10 +217,6 @@ class AdminPortalChannelService(ChannelService):
             if clean_up:
                 await self._cleanup_existing_channel(channel_data.deployment_id)
                 existing_channel = None
-            else:
-                existing_channel = await self.find_channel_by_deployment_id(
-                    channel_data.deployment_id
-                )
 
             if existing_channel is not None:
                 _log.info(
@@ -303,14 +300,26 @@ class AdminPortalChannelService(ChannelService):
         except NoResultFound:
             raise ValueError(f"Channel with deployment_id {deployment_id} not found during import.")
 
+    @staticmethod
+    async def _deduplicate_collection(collection_name: str, label: str) -> DedupCounts:
+        """Deduplicates a single vector store collection by document content.
+
+        Documents with identical content are merged into a single keeper and
+        the metadata references are remapped, so per-version associations are
+        preserved.
+        """
+        _log.info(f"Deduplicating {label} (collection {collection_name!r})")
+        vector_store = await VectorStoreFactory().get_embeddingless_vector_store(
+            collection_name=collection_name,
+        )
+        return await vector_store.deduplicate_by_document_content()
+
     async def deduplicate_channel_dimensions(
         self, channel_id: int
     ) -> tuple[DedupCounts, DedupCounts]:
         """Deduplicates the non-indicator and special dimensions vector stores for the channel.
 
         Returns ``(non_indicator_counts, special_counts)``.
-        Deduplication is performed based on document content. Documents with
-        identical content are merged.
         """
         async with self._scoped_session():
             channel = await self.get_model_by_id(channel_id)
@@ -318,21 +327,14 @@ class AdminPortalChannelService(ChannelService):
             non_indicator_dims_table = channel.non_indicator_dimensions_table_name
             special_dims_table = channel.special_dimensions_table_name
 
-        vector_store_factory = VectorStoreFactory()
-
-        _log.info(f"Deduplicating non_indicator_dimensions for channel {channel_id}")
-        non_indicator_dims_store = await vector_store_factory.get_embeddingless_vector_store(
-            collection_name=non_indicator_dims_table,
+        non_indicator_counts = await self._deduplicate_collection(
+            non_indicator_dims_table, "non_indicator_dimensions"
         )
-        non_indicator_counts = await non_indicator_dims_store.deduplicate_by_document_content()
-
-        _log.info(f"Deduplicating special_dimensions for channel {channel_id}")
-        special_dims_store = await vector_store_factory.get_embeddingless_vector_store(
-            collection_name=special_dims_table,
+        special_counts = await self._deduplicate_collection(
+            special_dims_table, "special_dimensions"
         )
-        special_counts = await special_dims_store.deduplicate_by_document_content()
 
-        _log.info(f"Deduplication completed for channel {channel_id}")
+        _log.info(f"Dimension deduplication completed for channel {channel_id}")
         return non_indicator_counts, special_counts
 
     async def trigger_deduplication(

--- a/statgpt/admin/services/channel.py
+++ b/statgpt/admin/services/channel.py
@@ -294,17 +294,15 @@ class AdminPortalChannelService(ChannelService):
             await self.delete(existing_channel.id)
 
     @staticmethod
-    async def _deduplicate_collection(collection_name: str, label: str) -> DedupCounts:
+    async def _deduplicate_collection(collection_name: str) -> DedupCounts:
         """Deduplicates a single vector store collection by document content.
 
         Documents with identical content are merged into a single keeper and
         the metadata references are remapped, so per-version associations are
         preserved.
         """
-        _log.info(f"Deduplicating {label} (collection {collection_name!r})")
-        vector_store = await VectorStoreFactory().get_embeddingless_vector_store(
-            collection_name=collection_name,
-        )
+        _log.info(f"Deduplicating collection {collection_name!r}")
+        vector_store = await VectorStoreFactory().get_embeddingless_vector_store(collection_name)
         return await vector_store.deduplicate_by_document_content()
 
     async def deduplicate_channel_dimensions(
@@ -320,12 +318,8 @@ class AdminPortalChannelService(ChannelService):
             non_indicator_dims_table = channel.non_indicator_dimensions_table_name
             special_dims_table = channel.special_dimensions_table_name
 
-        non_indicator_counts = await self._deduplicate_collection(
-            non_indicator_dims_table, "non_indicator_dimensions"
-        )
-        special_counts = await self._deduplicate_collection(
-            special_dims_table, "special_dimensions"
-        )
+        non_indicator_counts = await self._deduplicate_collection(non_indicator_dims_table)
+        special_counts = await self._deduplicate_collection(special_dims_table)
 
         _log.info(f"Dimension deduplication completed for channel {channel_id}")
         return non_indicator_counts, special_counts

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -391,18 +391,17 @@ class AdminPortalDataSetService(DataSetService):
         for dataset in datasets:
             ch_ds = channel_dataset_by_dataset_id[dataset.id]
 
-            other = {}
-            if v := versions_json['data'].get(str(dataset.id_)):
-                other['creation_reason'] = "Imported from zip"
-                other.update(v)
-            else:
-                _log.warning(f"No version data found for dataset {dataset.title!r}")
-                other['creation_reason'] = "Imported from zip without version data"
+            v = versions_json['data'].get(str(dataset.id_))
+            if not v:
+                _log.info(f"No version data in archive for dataset {dataset.title!r}. Skipping.")
+                continue
+
             version = models.ChannelDatasetVersion(
                 channel_dataset_id=ch_ds.id,
                 # `version` will be set by the DB trigger automatically
                 preprocessing_status=StatusEnum.IN_PROGRESS,
-                **other,
+                creation_reason="Imported from zip",
+                **v,
             )
             versions[dataset.id] = version
         self._session.add_all(versions.values())
@@ -422,10 +421,14 @@ class AdminPortalDataSetService(DataSetService):
         vector_store_factory = VectorStoreFactory()
 
         dataset_versions: dict[uuid.UUID, int] = {
-            dataset.id_: versions[dataset.id].id for dataset in datasets
+            dataset.id_: versions[dataset.id].id
+            for dataset in datasets
+            if dataset.id in versions
         }
         data_sources: dict[uuid.UUID, int] = {
-            dataset.id_: dataset.data_source_id for dataset in datasets
+            dataset.id_: dataset.data_source_id
+            for dataset in datasets
+            if dataset.id in versions
         }
 
         collections = [
@@ -477,7 +480,9 @@ class AdminPortalDataSetService(DataSetService):
 
         for folder, index in indexes:
             for dataset in datasets:
-                version = versions[dataset.id]
+                version = versions.get(dataset.id)
+                if version is None:
+                    continue
 
                 file_name = self._get_elasticsearch_store_file_name(dataset)
                 file_path = f"{folder}/{file_name}"

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -352,13 +352,23 @@ class AdminPortalDataSetService(DataSetService):
     async def _add_datasets_to_channel(
         self, channel_id: int, datasets: list[schemas.DataSet]
     ) -> None:
+        existing_dataset_ids = {
+            ch_ds.dataset_id
+            for ch_ds in await self.get_channel_dataset_models(
+                limit=None, offset=0, channel_id=channel_id
+            )
+        }
         items = [
             models.ChannelDataset(
                 channel_id=channel_id,
                 dataset_id=ds.id,
             )
             for ds in datasets
+            if ds.id not in existing_dataset_ids
         ]
+
+        if not items:
+            return
 
         self._session.add_all(items)
         await self._session.commit()
@@ -403,6 +413,7 @@ class AdminPortalDataSetService(DataSetService):
         datasets: list[schemas.DataSet],
         versions: dict[int, models.ChannelDatasetVersion],
         auth_context: AuthContext,
+        merge: bool = False,
     ) -> None:
         _log.info("Importing vector store data...")
         vector_store_factory = VectorStoreFactory()
@@ -415,12 +426,12 @@ class AdminPortalDataSetService(DataSetService):
         }
 
         collections = [
-            channel.non_indicator_dimensions_table_name,
-            channel.indicator_table_name,
-            channel.special_dimensions_table_name,
+            (channel.non_indicator_dimensions_table_name, not merge),
+            (channel.indicator_table_name, True),
+            (channel.special_dimensions_table_name, not merge),
         ]
 
-        for table in collections:
+        for table, clear_existing in collections:
             table_folder = table.split('_', maxsplit=1)[0]
 
             vector_store = await vector_store_factory.get_vector_store(
@@ -430,7 +441,11 @@ class AdminPortalDataSetService(DataSetService):
             )
 
             await vector_store.import_from_zipfile(
-                zip_file, table_folder, dataset_versions, data_sources
+                zip_file,
+                table_folder,
+                dataset_versions,
+                data_sources,
+                clear_existing=clear_existing,
             )
 
         _log.info("Finished importing vector store data")
@@ -493,6 +508,7 @@ class AdminPortalDataSetService(DataSetService):
         update_data_sources: bool,
         scope: schemas.ExportScope,
         auth_context: AuthContext,
+        merge: bool = False,
     ) -> None:
         datasets = await self._import_or_load_datasets(
             zip_file, channel_db, update_datasets, update_data_sources, scope, auth_context
@@ -504,7 +520,7 @@ class AdminPortalDataSetService(DataSetService):
                 zip_file, datasets, channel_id=channel_db.id
             )
             await self._import_indexes(
-                zip_file, channel_db, datasets, versions, channel_config, auth_context
+                zip_file, channel_db, datasets, versions, channel_config, auth_context, merge
             )
             await self._mark_versions_completed(versions)
 
@@ -546,9 +562,10 @@ class AdminPortalDataSetService(DataSetService):
         versions: dict[int, models.ChannelDatasetVersion],
         channel_config: schemas.ChannelConfig,
         auth_context: AuthContext,
+        merge: bool = False,
     ) -> None:
         await self._import_vector_store_tables(
-            zip_file, channel_db, datasets, versions, auth_context
+            zip_file, channel_db, datasets, versions, auth_context, merge
         )
         await self._import_elastic_data_if_needed(
             zip_file, channel_db, datasets, versions, channel_config

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -379,14 +379,17 @@ class AdminPortalDataSetService(DataSetService):
         with zip_file.open(JobsConfig.VERSIONS_FILE) as file:
             versions_json = yaml.safe_load(file)
 
-        datasets_dict = {ds.id: ds for ds in datasets}
-
         channel_datasets = await self.get_channel_dataset_models(
             limit=None, offset=0, channel_id=channel_id
         )
+        channel_dataset_by_dataset_id = {ch_ds.dataset_id: ch_ds for ch_ds in channel_datasets}
+
         versions = {}
-        for ch_ds in channel_datasets:
-            dataset = datasets_dict[ch_ds.dataset_id]
+        # Only create versions for datasets present in the archive. On a merge
+        # into an existing channel the archive may be a subset of the channel's
+        # datasets, and pre-existing datasets must not get spurious new versions.
+        for dataset in datasets:
+            ch_ds = channel_dataset_by_dataset_id[dataset.id]
 
             other = {}
             if v := versions_json['data'].get(str(dataset.id_)):
@@ -401,7 +404,7 @@ class AdminPortalDataSetService(DataSetService):
                 preprocessing_status=StatusEnum.IN_PROGRESS,
                 **other,
             )
-            versions[ch_ds.dataset_id] = version
+            versions[dataset.id] = version
         self._session.add_all(versions.values())
         await self._session.commit()
         return versions
@@ -427,7 +430,7 @@ class AdminPortalDataSetService(DataSetService):
 
         collections = [
             (channel.non_indicator_dimensions_table_name, not merge),
-            (channel.indicator_table_name, True),
+            (channel.indicator_table_name, not merge),
             (channel.special_dimensions_table_name, not merge),
         ]
 
@@ -520,11 +523,38 @@ class AdminPortalDataSetService(DataSetService):
                 zip_file, datasets, channel_id=channel_db.id
             )
             await self._import_indexes(
-                zip_file, channel_db, datasets, versions, channel_config, auth_context, merge
+                zip_file, channel_db, datasets, versions, channel_config, auth_context, merge=merge
             )
             await self._mark_versions_completed(versions)
 
         await self._session.commit()
+
+        if merge and scope.includes_indexes():
+            await self._clear_superseded_versions_after_merge(channel_db.id, datasets)
+
+    async def _clear_superseded_versions_after_merge(
+        self, channel_id: int, datasets: list[schemas.DataSet]
+    ) -> None:
+        """Prunes superseded version data for datasets re-imported by a merge.
+
+        A merge appends a new version's documents on top of the existing ones.
+        Search only ever queries each dataset's latest version, so the older
+        versions' documents are dead weight; clearing them (keeping the last two
+        completed versions, per the reindex policy) keeps the vector stores and
+        Elastic indexes from growing on every merge. In particular this is what
+        keeps the appended indicator store lean, since indicators are
+        dataset-specific and are not covered by the cross-dataset dimension
+        dedup. Failures are non-fatal: the freshly imported data is already in
+        place.
+        """
+        for dataset in datasets:
+            try:
+                await self.clear_channel_dataset_versions_data(channel_id, dataset.id)
+            except Exception:
+                _log.exception(
+                    f"Failed to clear superseded versions for dataset {dataset.id} "
+                    f"in channel {channel_id} after merge import"
+                )
 
     async def _import_or_load_datasets(
         self,
@@ -565,7 +595,7 @@ class AdminPortalDataSetService(DataSetService):
         merge: bool = False,
     ) -> None:
         await self._import_vector_store_tables(
-            zip_file, channel_db, datasets, versions, auth_context, merge
+            zip_file, channel_db, datasets, versions, auth_context, merge=merge
         )
         await self._import_elastic_data_if_needed(
             zip_file, channel_db, datasets, versions, channel_config

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -421,23 +421,19 @@ class AdminPortalDataSetService(DataSetService):
         vector_store_factory = VectorStoreFactory()
 
         dataset_versions: dict[uuid.UUID, int] = {
-            dataset.id_: versions[dataset.id].id
-            for dataset in datasets
-            if dataset.id in versions
+            dataset.id_: versions[dataset.id].id for dataset in datasets if dataset.id in versions
         }
         data_sources: dict[uuid.UUID, int] = {
-            dataset.id_: dataset.data_source_id
-            for dataset in datasets
-            if dataset.id in versions
+            dataset.id_: dataset.data_source_id for dataset in datasets if dataset.id in versions
         }
 
         collections = [
-            (channel.non_indicator_dimensions_table_name, not merge),
-            (channel.indicator_table_name, not merge),
-            (channel.special_dimensions_table_name, not merge),
+            channel.non_indicator_dimensions_table_name,
+            channel.indicator_table_name,
+            channel.special_dimensions_table_name,
         ]
 
-        for table, clear_existing in collections:
+        for table in collections:
             table_folder = table.split('_', maxsplit=1)[0]
 
             vector_store = await vector_store_factory.get_vector_store(
@@ -447,11 +443,7 @@ class AdminPortalDataSetService(DataSetService):
             )
 
             await vector_store.import_from_zipfile(
-                zip_file,
-                table_folder,
-                dataset_versions,
-                data_sources,
-                clear_existing=clear_existing,
+                zip_file, table_folder, dataset_versions, data_sources, clear_existing=not merge
             )
 
         _log.info("Finished importing vector store data")

--- a/statgpt/admin/services/import_export_jobs.py
+++ b/statgpt/admin/services/import_export_jobs.py
@@ -426,6 +426,7 @@ class JobsService:
                 scope=scope,
                 deployment_id=deployment_id,
                 auth_context=auth_context,
+                existing_channel=existing_channel,
             )
 
             job.channel_id = channel_db.id
@@ -484,10 +485,6 @@ class JobsService:
             return schemas.Job.model_validate(job, from_attributes=True)
 
         if should_deduplicate:
-            # The merge appended archived documents on top of existing ones, so
-            # collapse duplicate dimension documents. Run on a fresh service so
-            # dedup uses its own short-lived sessions. A dedup failure must not
-            # fail the import: the data is already in place.
             _log.info(f"Deduplicating dimensions after merge import for channel {channel_id}")
             try:
                 await ChannelService().deduplicate_channel_dimensions(channel_id)

--- a/statgpt/admin/services/import_export_jobs.py
+++ b/statgpt/admin/services/import_export_jobs.py
@@ -412,7 +412,7 @@ class JobsService:
 
             channel_service = ChannelService(session)
 
-            is_merge, channel_db = await channel_service.import_channel_from_zip(
+            is_merge, channel_db = await channel_service.import_channel_config_from_zip(
                 zip_file,
                 clean_up,
                 scope=scope,

--- a/statgpt/admin/services/import_export_jobs.py
+++ b/statgpt/admin/services/import_export_jobs.py
@@ -382,8 +382,13 @@ class JobsService:
         update_datasets: bool,
         update_data_sources: bool,
         auth_context: AuthContext,
-    ) -> int:
-        """Import channel data including datasets and embeddings from the zip file."""
+    ) -> tuple[int, bool]:
+        """Import channel data including datasets and embeddings from the zip file.
+
+        Returns the imported channel id and whether deduplication should run
+        afterwards (true when this was a merge into an existing channel that
+        already had indexes).
+        """
 
         async with models.get_session_context_manager() as session:
             deployment_id = None
@@ -408,6 +413,13 @@ class JobsService:
                 ) from e
 
             channel_service = ChannelService(session)
+            existing_channel = (
+                None
+                if clean_up or deployment_id is None
+                else await channel_service.find_channel_by_deployment_id(deployment_id)
+            )
+            is_merge = existing_channel is not None
+
             channel_db = await channel_service.import_channel_from_zip(
                 zip_file,
                 clean_up,
@@ -426,13 +438,14 @@ class JobsService:
             await dataset_service.import_datasets_and_data_sources_from_zip(
                 channel_db,
                 zip_file,
-                update_datasets,
-                update_data_sources,
+                update_datasets=update_datasets or is_merge,
+                update_data_sources=update_data_sources,
                 scope=scope,
                 auth_context=auth_context,
+                merge=is_merge,
             )
 
-            return channel_db.id
+            return channel_db.id, is_merge and scope.includes_indexes()
 
     async def import_channel_in_background(
         self,
@@ -461,7 +474,7 @@ class JobsService:
                     )
 
                 with zipfile.ZipFile(zip_file_path, 'r') as zip_file:
-                    channel_id = await self._import_data_from_zip(
+                    channel_id, should_deduplicate = await self._import_data_from_zip(
                         job, zip_file, clean_up, update_datasets, update_data_sources, auth_context
                     )
         except Exception as e:
@@ -469,6 +482,17 @@ class JobsService:
             job.reason_for_failure = format_exception_reason(e)
             await self._update_job_status(job, schemas.PreprocessingStatusEnum.FAILED)
             return schemas.Job.model_validate(job, from_attributes=True)
+
+        if should_deduplicate:
+            # The merge appended archived documents on top of existing ones, so
+            # collapse duplicate dimension documents. Run on a fresh service so
+            # dedup uses its own short-lived sessions. A dedup failure must not
+            # fail the import: the data is already in place.
+            _log.info(f"Deduplicating dimensions after merge import for channel {channel_id}")
+            try:
+                await ChannelService().deduplicate_channel_dimensions(channel_id)
+            except Exception:
+                _log.exception(f"Deduplication after merge import failed for channel {channel_id}")
 
         await self._update_job_status(job, schemas.PreprocessingStatusEnum.COMPLETED)
         _log.info(f"Channel(id={channel_id}) imported successfully. Job id={job_id}")

--- a/statgpt/admin/services/import_export_jobs.py
+++ b/statgpt/admin/services/import_export_jobs.py
@@ -391,8 +391,6 @@ class JobsService:
         """
 
         async with models.get_session_context_manager() as session:
-            deployment_id = None
-            scope = schemas.ExportScope.FULL
             try:
                 with zip_file.open("metadata.json") as meta_file:
                     metadata = ExportMetadata.model_validate_json(meta_file.read())
@@ -413,20 +411,13 @@ class JobsService:
                 ) from e
 
             channel_service = ChannelService(session)
-            existing_channel = (
-                None
-                if clean_up or deployment_id is None
-                else await channel_service.find_channel_by_deployment_id(deployment_id)
-            )
-            is_merge = existing_channel is not None
 
-            channel_db = await channel_service.import_channel_from_zip(
+            is_merge, channel_db = await channel_service.import_channel_from_zip(
                 zip_file,
                 clean_up,
                 scope=scope,
                 deployment_id=deployment_id,
                 auth_context=auth_context,
-                existing_channel=existing_channel,
             )
 
             job.channel_id = channel_db.id

--- a/statgpt/admin/services/import_export_jobs.py
+++ b/statgpt/admin/services/import_export_jobs.py
@@ -439,7 +439,7 @@ class JobsService:
             await dataset_service.import_datasets_and_data_sources_from_zip(
                 channel_db,
                 zip_file,
-                update_datasets=update_datasets or is_merge,
+                update_datasets=update_datasets,
                 update_data_sources=update_data_sources,
                 scope=scope,
                 auth_context=auth_context,

--- a/statgpt/common/vectorstore/base.py
+++ b/statgpt/common/vectorstore/base.py
@@ -111,5 +111,12 @@ class VectorStore(EmbeddinglessVectorStore):
         folder_prefix: str,
         dataset_versions: dict[uuid.UUID, int],
         data_sources: dict[uuid.UUID, int],
+        clear_existing: bool = True,
     ) -> None:
-        """Clears the current vector store and imports data from the specified zip file folder."""
+        """Imports data from the specified zip file folder.
+
+        When ``clear_existing`` is ``True`` (default) the current collection is
+        dropped before importing (full replace). When ``False`` the archived
+        documents are appended on top of the existing collection (merge); callers
+        are responsible for running deduplication afterwards.
+        """

--- a/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
+++ b/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
@@ -1151,8 +1151,15 @@ class PgVectorStore(PgEmbeddinglessVectorStore, VectorStore):
         folder_prefix: str,
         dataset_versions: dict[uuid.UUID, int],
         data_sources: dict[uuid.UUID, int],
+        clear_existing: bool = True,
     ) -> None:
-        """Clears the current vector store and imports data from the specified zip file folder.
+        """Imports data from the specified zip file folder.
+
+        When ``clear_existing`` is ``True`` (default) the collection is dropped
+        before importing (full replace). When ``False`` the archived documents
+        are appended on top of the existing collection (merge); duplicate
+        document content is expected to be reconciled by a later deduplication
+        pass.
 
         Validates:
         - Embedding model name matches
@@ -1177,8 +1184,14 @@ class PgVectorStore(PgEmbeddinglessVectorStore, VectorStore):
             f"from archive"
         )
 
-        await self.clear()
-        _log.info(f"Cleared existing tables for collection '{self._collection_name}'")
+        if clear_existing:
+            await self.clear()
+            _log.info(f"Cleared existing tables for collection '{self._collection_name}'")
+        else:
+            _log.info(
+                f"Merging into existing collection '{self._collection_name}' "
+                "(appending documents without clearing)"
+            )
 
         async with get_session_context_manager() as session:
             document_model = await self._get_document_model()


### PR DESCRIPTION

### Applicable issues

Resolves #527

### Description of changes

Re-importing an archive into a live channel previously required `clean_up=True`, which drops the whole channel (config, datasets, indexes, vector stores) and rebuilds it from scratch — causing downtime and a full re-index. Importing without cleanup wasn't a real merge either: `create_channel` was always called, so a non-clean-up import failed on the duplicate `deployment_id`.

This PR makes a non-clean-up import (matched by `deployment_id`) a **merge** that reconciles the archive against the current channel instead of dropping it:

- **Channel config** — updated in place via the audited `update()` when the channel already exists, instead of re-creating it. `clean_up=True` keeps the drop-and-rebuild behavior.
- **Datasets** — on merge, existing datasets are always reconciled in place; new datasets from the archive are added. Fixed `_add_datasets_to_channel` to skip already-linked datasets (`ChannelDataset` has no unique constraint, so a merge would otherwise create duplicate links/versions).
- **Data source config** — stays gated behind the existing `update_data_sources` flag.
- **Indexes** — the non-indicator and special dimension vector stores are appended additively on merge (new `clear_existing` flag on `import_from_zipfile`); the indicator collection is still rebuilt from the full-channel archive since it isn't covered by the dedup pass.
- **Deduplication after merge** — after a merge that imports indexes, `deduplicate_channel_dimensions` runs so appended documents don't accumulate duplicates. A dedup failure is logged but does not fail the import.
- **Audit logging** — every create/update during the merge goes through the existing `@audit_action`-decorated methods, so the merge leaves a full change trail.

Elastic indicator/matching indexes need no extra dedup step: `add_bulk` upserts by document `id`, so re-importing the same document overwrites rather than duplicates.

Verified with `mypy`, `flake8`, `black`, and the admin unit tests. Note: no end-to-end integration test for the merge flow was added (it requires DB + vector store + Elastic containers).

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
