### PR TITLE
chore: remove unused publication_dates from DialRagMetadata

### DIFF
--- a/statgpt/app/schemas/file_rags/dial_rag.py
+++ b/statgpt/app/schemas/file_rags/dial_rag.py
@@ -264,15 +264,11 @@ class DialRagMetadataResponse(BaseModel):
 
 
 class DialRagMetadata(BaseModel):
-    publication_dates: set[StrictStr] = Field()
     publication_types: set[StrictStr] = Field()
 
     @classmethod
     def from_response(cls, response: DialRagMetadataResponse) -> "DialRagMetadata":
         return cls(
-            publication_dates=cls._extract_dimension_values(
-                response.dimensions, "publication_date"
-            ),
             publication_types=cls._extract_dimension_values(
                 response.dimensions, "publication_type"
             ),


### PR DESCRIPTION
## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- relates to #491

## Description of changes

`DialRagMetadata.publication_dates` was populated in `from_response` but never read anywhere in the codebase. Its extraction also hard-required a `publication_date` dimension in the DIAL RAG metadata response, raising `ValueError` when that dimension is absent.

This blocks the Generic RAG backend (#491), which does not send a `publication_date` dimension. Removing the dead field unblocks it. `publication_types` — the only field actually consumed by the prefilter — is unchanged.

## Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.