### PR TITLE
feat: advertise deep_research toggle in deployment configuration (#549)

### DIFF
--- a/statgpt/app/services/chat_facade.py
+++ b/statgpt/app/services/chat_facade.py
@@ -212,6 +212,24 @@ class BaseChannelConfiguration(BaseModel, metaclass=FormMetaclass):
     )
 
 
+class DeepResearchChannelConfiguration(BaseChannelConfiguration):
+    """Configuration variant that advertises the Deep Research toggle.
+
+    Used only for channels that have the Deep Research tool configured, so the
+    frontend renders the control exclusively where the capability is available.
+    """
+
+    # Re-declared so `FormMetaclass` re-emits the `dial:chatMessageInputDisabled`
+    # schema extension; otherwise this subclass would drop it relative to the base.
+    model_config = DialConfigDict(chat_message_input_disabled=False)
+
+    deep_research: bool = DialField(
+        title="Enable Deep research",
+        description="Run the request in Deep Research mode.",
+        default=False,
+    )
+
+
 class ChannelServiceFacade:
     _indicators_total_cache: AsyncLoadingCache[int] = AsyncLoadingCache(
         ttl=dial_app_settings.indicators_total_cache_ttl
@@ -278,14 +296,25 @@ class ChannelServiceFacade:
     def channel_config(self) -> ChannelConfig:
         return self._channel.details
 
+    def _is_deep_research_available(self) -> bool:
+        """Whether the channel has the Deep Research tool configured and enabled."""
+        tool = self.channel_config.deep_research
+        return tool is not None and tool.enabled
+
     async def get_dial_channel_configuration(self, auth_context: AuthContext) -> dict[str, Any]:
+        base_configuration_cls: type[BaseChannelConfiguration] = (
+            DeepResearchChannelConfiguration
+            if self._is_deep_research_available()
+            else BaseChannelConfiguration
+        )
+
         conversation_starters_config = self.channel_config.conversation_starters
         if conversation_starters_config is None:
             _log.info(
                 f"No conversation starters configuration found for channel {self._channel.title}"
             )
 
-            return BaseChannelConfiguration.model_json_schema()
+            return base_configuration_cls.model_json_schema()
 
         _log.info(
             f"Conversation starters configuration found for channel {self._channel.title}, {conversation_starters_config=}"
@@ -320,7 +349,7 @@ class ChannelServiceFacade:
         if input_placeholder is not None:
             other_fields["json_schema_extra"] = {"statgpt:inputPlaceholder": input_placeholder}
 
-        class StatGPTConfiguration(BaseChannelConfiguration):
+        class StatGPTConfiguration(base_configuration_cls):  # type: ignore[misc,valid-type]
             starter: int | None = DialField(
                 default=None, description=intro_text, buttons=buttons, **other_fields
             )

--- a/statgpt/app/services/chat_facade.py
+++ b/statgpt/app/services/chat_facade.py
@@ -222,7 +222,7 @@ class DeepResearchChannelConfiguration(BaseChannelConfiguration):
     model_config = DialConfigDict(chat_message_input_disabled=False)
 
     deep_research: bool = DialField(
-        title="Enable Deep research",
+        title="Deep research",
         description="Run the request in Deep Research mode.",
         default=False,
     )

--- a/statgpt/app/services/chat_facade.py
+++ b/statgpt/app/services/chat_facade.py
@@ -219,8 +219,6 @@ class DeepResearchChannelConfiguration(BaseChannelConfiguration):
     frontend renders the control exclusively where the capability is available.
     """
 
-    # Re-declared so `FormMetaclass` re-emits the `dial:chatMessageInputDisabled`
-    # schema extension; otherwise this subclass would drop it relative to the base.
     model_config = DialConfigDict(chat_message_input_disabled=False)
 
     deep_research: bool = DialField(

--- a/tests/unit/app/services/test_chat_facade_configuration.py
+++ b/tests/unit/app/services/test_chat_facade_configuration.py
@@ -1,0 +1,96 @@
+"""Unit tests for ChannelServiceFacade.get_dial_channel_configuration.
+
+Focus: the `deep_research` property is advertised in the DIAL configuration schema
+only when the channel has the Deep Research tool configured and enabled.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from statgpt.app.services.chat_facade import ChannelServiceFacade
+from statgpt.common.schemas.channel import (
+    ChannelConfig,
+    ConversationStarterConfig,
+    ConversationStartersConfig,
+    SupremeAgentConfig,
+)
+from statgpt.common.schemas.tools import DeepResearchTool
+
+
+def _channel_config(
+    *, deep_research: DeepResearchTool | None = None, starters=None
+) -> ChannelConfig:
+    return ChannelConfig(
+        supreme_agent=SupremeAgentConfig(
+            name="StatGPT", domain="statistics", terminology_domain="statistics"
+        ),
+        deep_research=deep_research,
+        conversation_starters=starters,
+    )
+
+
+def _deep_research_tool(*, enabled: bool = True) -> DeepResearchTool:
+    return DeepResearchTool(
+        name="deep_research",
+        description="Deep Research tool",
+        enabled=enabled,
+        details={"deployment_id": "deep-research-app"},
+    )
+
+
+def _facade(config: ChannelConfig) -> ChannelServiceFacade:
+    channel = MagicMock()
+    channel.title = "Test Channel"
+    channel.details = config
+    return ChannelServiceFacade(channel=channel)
+
+
+async def _get_schema(config: ChannelConfig) -> dict:
+    facade = _facade(config)
+    return await facade.get_dial_channel_configuration(auth_context=MagicMock())
+
+
+class TestDeepResearchConfiguration:
+
+    @pytest.mark.asyncio
+    async def test_omitted_when_tool_absent(self) -> None:
+        schema = await _get_schema(_channel_config())
+
+        assert "deep_research" not in schema["properties"]
+        # base fields are still advertised
+        assert "timezone" in schema["properties"]
+        assert "enable_debug_attachments" in schema["properties"]
+
+    @pytest.mark.asyncio
+    async def test_omitted_when_tool_disabled(self) -> None:
+        schema = await _get_schema(
+            _channel_config(deep_research=_deep_research_tool(enabled=False))
+        )
+
+        assert "deep_research" not in schema["properties"]
+
+    @pytest.mark.asyncio
+    async def test_advertised_when_tool_enabled(self) -> None:
+        schema = await _get_schema(_channel_config(deep_research=_deep_research_tool()))
+
+        prop = schema["properties"]["deep_research"]
+        assert prop["type"] == "boolean"
+        assert prop["title"] == "Enable Deep research"
+        assert prop["default"] is False
+        # the base schema stays intact aside from the added toggle
+        assert schema.get("dial:chatMessageInputDisabled") is False
+        assert schema["additionalProperties"] is False
+
+    @pytest.mark.asyncio
+    async def test_advertised_alongside_conversation_starters(self) -> None:
+        starters = ConversationStartersConfig(
+            intro_text="Welcome",
+            buttons=[ConversationStarterConfig(title="Ask", text="Ask something")],
+        )
+        schema = await _get_schema(
+            _channel_config(deep_research=_deep_research_tool(), starters=starters)
+        )
+
+        assert schema["properties"]["deep_research"]["title"] == "Enable Deep research"
+        assert "starter" in schema["properties"]

--- a/tests/unit/app/services/test_chat_facade_configuration.py
+++ b/tests/unit/app/services/test_chat_facade_configuration.py
@@ -76,7 +76,7 @@ class TestDeepResearchConfiguration:
 
         prop = schema["properties"]["deep_research"]
         assert prop["type"] == "boolean"
-        assert prop["title"] == "Enable Deep research"
+        assert prop["title"] == "Deep research"
         assert prop["default"] is False
         # the base schema stays intact aside from the added toggle
         assert schema.get("dial:chatMessageInputDisabled") is False
@@ -92,5 +92,5 @@ class TestDeepResearchConfiguration:
             _channel_config(deep_research=_deep_research_tool(), starters=starters)
         )
 
-        assert schema["properties"]["deep_research"]["title"] == "Enable Deep research"
+        assert schema["properties"]["deep_research"]["title"] == "Deep research"
         assert "starter" in schema["properties"]


### PR DESCRIPTION
# feat: advertise deep_research toggle in deployment configuration

### Applicable issues

- fixes #549

### Description of changes

Deep Research mode (per #490) is activated only when the user clicks a dedicated
control on the frontend. For that control to render, the backend must advertise the
capability through the DIAL deployment configuration endpoint
(`GET /v1/deployments/{deployment_name}/configuration`).

This PR adds a `deep_research` boolean to the configuration JSON schema returned by
`get_dial_channel_configuration`:

```json
"deep_research": {
  "type": "boolean",
  "title": "Deep research",
  "default": false
}
```

- Adds a `DeepResearchChannelConfiguration` variant of `BaseChannelConfiguration` that
  contributes the `deep_research` field (title "Deep research", default `false`).
- The property is exposed **only** when the channel has the Deep Research tool
  configured and enabled; otherwise the base schema is returned unchanged. This applies
  to both the plain and conversation-starters schema paths.
- Adds unit tests covering: property omitted when the tool is absent, omitted when the
  tool is disabled, advertised with the correct type/title/default when enabled, and
  advertised alongside conversation starters.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
