### PR TITLE
fix: store exported channel archives with application/zip content type #559

### DIFF
--- a/statgpt/admin/services/import_export_jobs.py
+++ b/statgpt/admin/services/import_export_jobs.py
@@ -25,6 +25,7 @@ from statgpt.common.schemas import AuditActionType, AuditEntityType
 from statgpt.common.settings.dial import dial_settings
 from statgpt.common.utils import (
     AttachmentsStorage,
+    MediaTypes,
     attachments_storage_factory,
     dial_client_factory,
     format_exception_reason,
@@ -307,6 +308,7 @@ class JobsService:
                     resp = await attachments_storage.put_local_file(
                         f"{JobsConfig.DIAL_EXPORT_FOLDER}/{os.path.basename(path)}",
                         path,
+                        mime_type=MediaTypes.ZIP,
                         show_progress=True,
                     )
                     file_url = resp.url

--- a/statgpt/common/utils/media_types.py
+++ b/statgpt/common/utils/media_types.py
@@ -45,3 +45,4 @@ class MediaTypes:
     UNKNOWN_BINARY = "application/octet-stream"
     XLS = "application/vnd.ms-excel"  # .xls
     XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"  # .xlsx
+    ZIP = "application/zip"  # .zip


### PR DESCRIPTION

### Applicable issues

- fixes #559

### Description of changes

After the aidial-client migration, channel export downloads lost their `.zip` extension: the archive was uploaded to DIAL storage with the default `application/octet-stream` MIME type, so the download endpoint streamed it back as a generic binary file and browsers saved it without an extension.

This restores the pre-migration behavior by uploading the archive with the correct content type:

- Pass `mime_type=MediaTypes.ZIP` at the export upload call site (`import_export_jobs.py`), so DIAL stores and later serves the archive as `application/zip`.
- Add a `ZIP = "application/zip"` constant to `MediaTypes`.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.