### PR TITLE
chore: clarify issue linking and polish wording in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,21 @@
-### Applicable issues
+## Applicable issues
 
-<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
-- fixes #
+<!--
+Please link the GitHub issues related to this PR, referencing each one by number, e.g. #123.
+Use a closing keyword to close the issue automatically on merge: closes, fixes, or resolves.
+To link an issue without closing it, use a neutral prefix such as "related to" or "part of".
+-->
+- closes #
 
-### Description of changes
+## Description of changes
 
-<!-- Please explain the changes you made right below this line. -->
+<!-- Please explain the changes you made below. -->
 
-### Checklist
+## Checklist
 
-<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
+<!-- Place an 'x' (no spaces) in all applicable boxes. Please remove the items that do not apply. -->
 
-- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
-- [ ] Deployed and tested in a `Review` environment.
+- [ ] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
+- [ ] Deployed and tested in a `Review` environment
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.


### PR DESCRIPTION
## Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
None

## Description of changes

<!-- Please explain the changes you made right below this line. -->
The `Applicable issues` section only showed `- fixes #`, with no hint that other closing keywords exist or that an issue can be linked without being closed.

The section now documents both options: the closing keywords (`closes`, `fixes`, `resolves`) that auto-close the issue on merge, and neutral prefixes such as `related to` / `part of` for a plain reference.

The rest of the template got a wording and style pass:

- Section headings raised from `###` to `##`.
- Checklist hint fixed: stray `[...]` brackets dropped, `'[X]'` → `'x'`, "fields" → "boxes"/"items".
- Grammar fixes

## Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
