### PR TITLE
chore: bump aidial-sdk to 0.39.0

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -42,6 +42,9 @@ resolutions:
     - message: ".*PyPI::aidial-client:0\\..*"
       reason: "CANT_FIX_EXCEPTION"
       comment: "Apache 2.0 License: https://github.com/epam/ai-dial-client-python/blob/development/LICENSE"
+    - message: ".*PyPI::aidial-sdk:0\\..*"
+      reason: "CANT_FIX_EXCEPTION"
+      comment: "Apache 2.0 License: https://github.com/epam/ai-dial-sdk/blob/development/LICENSE"
 
     # Pydantic ecosystem
     - message: ".*PyPI::pydantic:2\\..*"

--- a/poetry.lock
+++ b/poetry.lock
@@ -20,14 +20,14 @@ pydantic = ">=1.10,<3"
 
 [[package]]
 name = "aidial-sdk"
-version = "0.31.0"
+version = "0.39.0"
 description = "Framework to create applications and model adapters for AI DIAL"
 optional = false
-python-versions = "<4.0,>=3.9"
+python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "aidial_sdk-0.31.0-py3-none-any.whl", hash = "sha256:40b743f774fe26a1ecbc675a3503bf40ca8dc478e78cd8e90781b2d2962017cf"},
-    {file = "aidial_sdk-0.31.0.tar.gz", hash = "sha256:dc714bc366952057a157db6dde9fe2724390617ba3958772450680919b30b970"},
+    {file = "aidial_sdk-0.39.0-py3-none-any.whl", hash = "sha256:f16d4899e4e474162b8c9ac4ec880f9ab981e80a5e6404f584918e5f337ec2d3"},
+    {file = "aidial_sdk-0.39.0.tar.gz", hash = "sha256:3577f5c15ddb2f8c8037219e797af17d406234596f67b02a5985245f7516c601"},
 ]
 
 [package.dependencies]
@@ -6844,4 +6844,4 @@ mcp = ["fastmcp"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "3ea36b2ef77f4dc9fd826ee6ec46f7616cd7838efab197b2c26f740db5fa033f"
+content-hash = "4d27295e18d89344adc7f5f880e34dee7f18186d516b055bbd37c709b36933e8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT"
 license-files = ["LICENSE"]
 dependencies = [
     # Core framework & API
-    'aidial-sdk[telemetry] (>=0.31.0,<0.32.0)',  # DIAL integration SDK
+    'aidial-sdk[telemetry] (>=0.39.0,<0.40.0)',  # DIAL integration SDK
     'fastapi (>=0.133.0,<1.0.0)',                # Web framework; >=0.133 required for starlette 1.x
     'pydantic (>=2.11.7,<3.0.0)',                # Data validation
     'pydantic-core (>=2.33.2,<3.0.0)',           # Pydantic core functionality


### PR DESCRIPTION
## Applicable issues

None

## Description of changes

Bumps `aidial-sdk` from `0.31.0` to `0.39.0` (constraint `>=0.39.0,<0.40.0`).

The lock diff touches only `aidial-sdk` itself — no transitive bumps were required, since the
already-locked `fastapi 0.137.1` / `starlette 1.3.1` satisfy what `0.38.0` requires.

Two breaking changes were released in this range, neither of which affects this project:

- `0.32.0` dropped Python 3.9 support — the project requires `>=3.11,<3.12`.
- `0.36.0` deprecated addons — addons are not used anywhere in the codebase.

Also adds an ORT license resolution for `aidial-sdk`. Starting with `0.39.0` the package is built with `poetry-core 2.2`, which declares the license through the PEP 639 `License-Expression` field instead of the legacy `License` field and classifier. ORT does not read that field and fails with `NO_LICENSE_IN_DEPENDENCY`, even though the wheel still ships the Apache 2.0 `LICENSE` file. This is the same reason the existing `zipp`, `importlib-metadata`, `setuptools` and `packaging` resolutions are needed.

## Checklist

<!-- Place an 'x' (no spaces) in all applicable boxes. Please remove the items that do not apply. -->

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
