### PR TITLE
fix: handle invalid message history gracefully

### DIFF
--- a/statgpt/app/application/channel_completion.py
+++ b/statgpt/app/application/channel_completion.py
@@ -19,6 +19,7 @@ from statgpt.app.services.chat_facade import ChannelServiceFacade
 from statgpt.app.settings.dial_app import dial_app_settings
 from statgpt.app.utils.dial_exceptions import RateLimitException
 from statgpt.app.utils.dial_stages import optional_timed_stage
+from statgpt.app.utils.message_history import History, InvalidHistoryError, dump_dial_messages
 from statgpt.common.schemas.token_usage import TokenUsagePricedItem
 from statgpt.common.settings.application import application_settings
 from statgpt.common.settings.dial import dial_settings
@@ -35,6 +36,10 @@ from statgpt.common.utils.token_usage_context import TokenUsageManager, token_us
 from statgpt.common.utils.token_usage_utils import TokenUsageCostCalculator, TokenUsageDisplayer
 
 _log = logging.getLogger(__name__)
+
+_INVALID_HISTORY_MESSAGE = (
+    "This conversation contains a message that cannot be processed. Please start a new chat."
+)
 
 
 class ChannelCompletion(ChatCompletion):
@@ -140,6 +145,13 @@ class ChannelCompletion(ChatCompletion):
                 callbacks.append(TokenUsageByModelsCallback())
                 state = ChainParameters.get_state(inputs)  # default in case of error
                 try:
+                    # Interceptors run while building the history and may update `state`
+                    # (e.g. the `!show_debug_stages` command),
+                    # so build it before reading debug flags from the state.
+                    inputs[ParamsConfig.HISTORY] = await History.from_dial_with_interceptors(
+                        messages=request.messages, state=state, data_service=service
+                    )
+
                     name = '[DEBUG] Performance of request'
                     debug = state.get(StateVarsConfig.SHOW_DEBUG_STAGES, False)
                     with optional_timed_stage(choice=choice, name=name, enabled=debug) as stage:
@@ -149,6 +161,14 @@ class ChannelCompletion(ChatCompletion):
                         )
                     state = ChainParameters.get_state(chains_response)
                     state[StateVarsConfig.ERROR] = None
+                except InvalidHistoryError as e:
+                    _log.warning(f"Invalid message history: {e}")
+                    choice.append_content(_INVALID_HISTORY_MESSAGE)
+                    state[StateVarsConfig.ERROR] = str(e)
+                    state[StateVarsConfig.RECEIVED_MESSAGES] = dump_dial_messages(request.messages)
+                except DIALException as e:
+                    _log.warning(f"Request rejected: {e.message}")
+                    raise
                 except openai.RateLimitError as e:
                     _log.warning("openai.RateLimitError", exc_info=e)
                     state[StateVarsConfig.ERROR] = str(e)

--- a/statgpt/app/application/channel_completion.py
+++ b/statgpt/app/application/channel_completion.py
@@ -19,7 +19,12 @@ from statgpt.app.services.chat_facade import ChannelServiceFacade
 from statgpt.app.settings.dial_app import dial_app_settings
 from statgpt.app.utils.dial_exceptions import RateLimitException
 from statgpt.app.utils.dial_stages import optional_timed_stage
-from statgpt.app.utils.message_history import History, InvalidHistoryError, dump_dial_messages
+from statgpt.app.utils.message_history import (
+    CommandOnlyMessageError,
+    History,
+    InvalidHistoryError,
+    dump_dial_messages,
+)
 from statgpt.common.schemas.token_usage import TokenUsagePricedItem
 from statgpt.common.settings.application import application_settings
 from statgpt.common.settings.dial import dial_settings
@@ -39,6 +44,9 @@ _log = logging.getLogger(__name__)
 
 _INVALID_HISTORY_MESSAGE = (
     "This conversation contains a message that cannot be processed. Please start a new chat."
+)
+_COMMAND_ONLY_MESSAGE = (
+    "Your message contains only commands. Please add your question and send it again."
 )
 
 
@@ -161,6 +169,11 @@ class ChannelCompletion(ChatCompletion):
                         )
                     state = ChainParameters.get_state(chains_response)
                     state[StateVarsConfig.ERROR] = None
+                except CommandOnlyMessageError as e:
+                    # Fully explained by the command stripping, so no message dump is needed.
+                    _log.info(f"Command-only user message: {e}")
+                    choice.append_content(_COMMAND_ONLY_MESSAGE)
+                    state[StateVarsConfig.ERROR] = str(e)
                 except InvalidHistoryError as e:
                     _log.warning(f"Invalid message history: {e}")
                     choice.append_content(_INVALID_HISTORY_MESSAGE)

--- a/statgpt/app/chains/main.py
+++ b/statgpt/app/chains/main.py
@@ -1,14 +1,13 @@
 import asyncio
 
-from langchain_core.runnables import Runnable, RunnableLambda, RunnablePassthrough
+from langchain_core.runnables import Runnable, RunnableLambda
 
 from statgpt.app.chains.out_of_scope_checker import OutOfScopeChecker
 from statgpt.app.chains.parameters import ChainParameters
 from statgpt.app.chains.supreme_agent import SupremeAgentExecutor, ToolCaller
 from statgpt.app.config import StateVarsConfig
-from statgpt.app.config.chain_parameters import ChainParametersConfig
 from statgpt.app.settings.dial_app import dial_app_settings
-from statgpt.app.utils.message_history import History, dial_tool_call_to_langchain_tool_call
+from statgpt.app.utils.message_history import dial_tool_call_to_langchain_tool_call
 from statgpt.common.config import logger
 from statgpt.common.schemas import ChannelConfig
 
@@ -17,23 +16,12 @@ class MainChainFactory:
     def __init__(self, channel_config: ChannelConfig):
         self._channel_config = channel_config
 
-    @staticmethod
-    async def _init_history(inputs: dict) -> History:
-        request = ChainParameters.get_request(inputs)
-        state = ChainParameters.get_state(inputs)
-        data_service = ChainParameters.get_data_service(inputs)
-
-        return await History.from_dial_with_interceptors(
-            messages=request.messages, state=state, data_service=data_service
-        )
-
     async def create_chain(self) -> Runnable:
         out_of_scope_checker = OutOfScopeChecker(self._channel_config)
         out_of_scope_chain = await out_of_scope_checker.create_chain()
 
         return (
-            RunnablePassthrough.assign(**{ChainParametersConfig.HISTORY: self._init_history})
-            | RunnableLambda(self._direct_tool_calls_chain)
+            RunnableLambda(self._direct_tool_calls_chain)
             | out_of_scope_chain
             | RunnableLambda(self._main_chain)
             | RunnableLambda(self._update_state)

--- a/statgpt/app/chains/main.py
+++ b/statgpt/app/chains/main.py
@@ -1,5 +1,6 @@
 import asyncio
 
+from aidial_sdk.exceptions import InvalidRequestError
 from langchain_core.runnables import Runnable, RunnableLambda
 
 from statgpt.app.chains.out_of_scope_checker import OutOfScopeChecker
@@ -7,7 +8,10 @@ from statgpt.app.chains.parameters import ChainParameters
 from statgpt.app.chains.supreme_agent import SupremeAgentExecutor, ToolCaller
 from statgpt.app.config import StateVarsConfig
 from statgpt.app.settings.dial_app import dial_app_settings
-from statgpt.app.utils.message_history import dial_tool_call_to_langchain_tool_call
+from statgpt.app.utils.message_history import (
+    InvalidToolCallError,
+    dial_tool_call_to_langchain_tool_call,
+)
 from statgpt.common.config import logger
 from statgpt.common.schemas import ChannelConfig
 
@@ -44,10 +48,15 @@ class MainChainFactory:
             return inputs  # This is a common request, so we skip direct tool calls chain
 
         # parse tool calls to langchain format
-        tool_calls_parsed = []
-        for dial_tool_call in tool_calls_received:
-            lc_tool_call = dial_tool_call_to_langchain_tool_call(dial_tool_call)
-            tool_calls_parsed.append(lc_tool_call)
+        try:
+            tool_calls_parsed = [
+                dial_tool_call_to_langchain_tool_call(tool_call)
+                for tool_call in tool_calls_received
+            ]
+        except InvalidToolCallError as e:
+            # The caller sent these tool calls in the current request,
+            # so this is a bad request rather than a corrupted history.
+            raise InvalidRequestError(str(e)) from e
 
         state[StateVarsConfig.DIRECT_TOOL_CALLS] = tool_calls_parsed
 

--- a/statgpt/app/config/state.py
+++ b/statgpt/app/config/state.py
@@ -13,6 +13,7 @@ class StateVarsConfig:
     CMD_SKIP_TOOLS_EXECUTION = "cmd_skip_tools_execution"
     ERROR = 'error'
     LLM_CALL_DURATIONS = "llm_call_durations"
+    RECEIVED_MESSAGES = "received_messages"
 
     # values used in Agentic approach
     DIRECT_TOOL_CALLS = "direct_tool_calls"

--- a/statgpt/app/utils/message_history.py
+++ b/statgpt/app/utils/message_history.py
@@ -27,6 +27,18 @@ class InvalidHistoryError(Exception):
     """Raised when DIAL messages cannot be converted into a valid history."""
 
 
+class CommandOnlyMessageError(Exception):
+    """Raised when a user message consists solely of interceptable commands."""
+
+
+class InvalidToolCallError(Exception):
+    """Raised when a DIAL tool call cannot be converted into a LangChain tool call.
+
+    Callers map this to a request- or history-level error, depending on whether the tool
+    call arrived in the current request or was echoed back to us as part of the history.
+    """
+
+
 def dump_dial_messages(messages: Sequence[DialMessage]) -> list[dict]:
     """Serialize DIAL messages for debugging.
 
@@ -56,10 +68,18 @@ def _convert_content(
 
 
 def dial_tool_call_to_langchain_tool_call(tool_call: DialToolCall) -> LangChainToolCall:
+    try:
+        args = json.loads(tool_call.function.arguments)
+    except json.JSONDecodeError as e:
+        raise InvalidToolCallError(
+            f"Tool call {tool_call.id!r} ({tool_call.function.name!r})"
+            f" has invalid JSON arguments: {e}"
+        ) from e
+
     return LangChainToolCall(
         id=tool_call.id,
         name=tool_call.function.name,
-        args=json.loads(tool_call.function.arguments),
+        args=args,
         type='tool_call',
     )
 
@@ -91,21 +111,42 @@ class History:
 
         [!] Update the `state` dictionary with the flags corresponding to the commands.
         """
+        cls._validate_received_messages(messages)
+
         interceptors = [
             CommandsInterceptor.create_default(),
             SystemMessageInterceptor(data_service=data_service),
         ]
         for interceptor in interceptors:
             messages = await interceptor.process_messages(messages=messages, state=state)
-        cls._validate_messages(messages)
+
+        cls._validate_processed_messages(messages)
         return cls(messages=messages)
 
     @staticmethod
-    def _validate_messages(messages: list[DialMessage]) -> None:
-        """Fail fast on messages that cannot be converted to LangChain messages."""
+    def _validate_received_messages(messages: list[DialMessage]) -> None:
+        """Reject messages we cannot build a history from, as they were received.
+
+        Runs before the interceptors so that the reported index matches the request, and
+        so that messages emptied by interception are not reported as malformed input.
+        """
         for ix, msg in enumerate(messages):
             if msg.role == Role.USER and not msg.content:
                 raise InvalidHistoryError(f"User message at index {ix} has empty content")
+            if msg.role == Role.TOOL and not msg.tool_call_id:
+                raise InvalidHistoryError(f"Tool message at index {ix} has no tool_call_id")
+
+    @staticmethod
+    def _validate_processed_messages(messages: list[DialMessage]) -> None:
+        """Reject user messages that the interceptors emptied.
+
+        `_validate_received_messages` has already rejected empty user content, so anything
+        empty at this point was stripped by the `CommandsInterceptor`, i.e. the message
+        consisted of nothing but commands.
+        """
+        for msg in messages:
+            if msg.role == Role.USER and not msg.content:
+                raise CommandOnlyMessageError("User message consists only of commands")
 
     def prepend(self, other: 'History') -> None:
         self._messages = other._messages + self._messages
@@ -161,15 +202,22 @@ class History:
                 raise InvalidHistoryError("User message content is empty")
             return HumanMessage(content=_convert_content(usr_msg_content))
         elif msg.role == Role.ASSISTANT:
-            return AIMessage(
-                content=_convert_content(msg.content) if msg.content else '',
-                tool_calls=(
+            try:
+                tool_calls = (
                     [dial_tool_call_to_langchain_tool_call(t) for t in msg.tool_calls]
                     if msg.tool_calls
                     else []
-                ),
+                )
+            except InvalidToolCallError as e:
+                # Echoed back to us as part of the history, so the history is unusable.
+                raise InvalidHistoryError(f"Assistant message has an invalid tool call: {e}") from e
+            return AIMessage(
+                content=_convert_content(msg.content) if msg.content else '',
+                tool_calls=tool_calls,
             )
         elif msg.role == Role.TOOL:
+            if not msg.tool_call_id:
+                raise InvalidHistoryError("Tool message has no tool_call_id")
             msg_content = _convert_content(msg.content) if msg.content else ''
             return ToolMessage(content=msg_content, tool_call_id=msg.tool_call_id)
         elif msg.role == Role.SYSTEM:
@@ -289,5 +337,7 @@ class History:
                     tool_messages.append(SystemMessage.model_validate(tool_msg))
                 else:
                     logger.info(f"Tool message: {tool_msg}")
-                    raise RuntimeError(f"Unknown tool message type: {msg_type!r}")
+                    # Our own state, echoed back: an unknown type means the conversation
+                    # predates a change to the tool message format.
+                    raise InvalidHistoryError(f"Unknown tool message type: {msg_type!r}")
         return tool_messages

--- a/statgpt/app/utils/message_history.py
+++ b/statgpt/app/utils/message_history.py
@@ -23,6 +23,28 @@ from statgpt.app.utils.message_interceptors.system_msg_interceptor import System
 from statgpt.common.config import multiline_logger as logger
 
 
+class InvalidHistoryError(Exception):
+    """Raised when DIAL messages cannot be converted into a valid history."""
+
+
+def dump_dial_messages(messages: Sequence[DialMessage]) -> list[dict]:
+    """Serialize DIAL messages for debugging.
+
+    `custom_content` is dropped entirely from assistant messages - it carries the tool
+    messages, stages and attachments we echo back, which would dwarf the rest of the dump.
+    Attachment payloads are dropped from the other messages.
+    """
+    result = []
+    for msg in messages:
+        exclude: set[str] | dict[str, t.Any] = (
+            {'custom_content'}
+            if msg.role == Role.ASSISTANT
+            else {'custom_content': {'attachments': {'__all__': {'data'}}}}
+        )
+        result.append(msg.model_dump(mode='json', exclude_none=True, exclude=exclude))
+    return result
+
+
 def _convert_content(
     content: str | list[MessageContentPart],
 ) -> str | list[str | dict[str, t.Any]]:
@@ -75,7 +97,15 @@ class History:
         ]
         for interceptor in interceptors:
             messages = await interceptor.process_messages(messages=messages, state=state)
+        cls._validate_messages(messages)
         return cls(messages=messages)
+
+    @staticmethod
+    def _validate_messages(messages: list[DialMessage]) -> None:
+        """Fail fast on messages that cannot be converted to LangChain messages."""
+        for ix, msg in enumerate(messages):
+            if msg.role == Role.USER and not msg.content:
+                raise InvalidHistoryError(f"User message at index {ix} has empty content")
 
     def prepend(self, other: 'History') -> None:
         self._messages = other._messages + self._messages
@@ -128,8 +158,7 @@ class History:
         """Convert a DialMessage to a LangChain message."""
         if msg.role == Role.USER:
             if not (usr_msg_content := msg.content):
-                logger.info(f"User message content is empty: {msg=}")
-                raise ValueError("User message content is empty")
+                raise InvalidHistoryError("User message content is empty")
             return HumanMessage(content=_convert_content(usr_msg_content))
         elif msg.role == Role.ASSISTANT:
             return AIMessage(

--- a/statgpt/app/utils/message_interceptors/commands_interceptor.py
+++ b/statgpt/app/utils/message_interceptors/commands_interceptor.py
@@ -82,7 +82,11 @@ class CommandsInterceptor(BaseMessageInterceptor):
         """
         1. for last user message, remove commands and update state
         2. for rest of user messages, simply remove commands from message content
+
+        Edited messages are replaced with copies instead of being mutated in place,
+        so the caller's messages (e.g. `request.messages`) keep the content we received.
         """
+        result = list(messages)
 
         for ix, msg in enumerate(reversed(messages)):
             if msg.role != Role.USER:
@@ -94,11 +98,14 @@ class CommandsInterceptor(BaseMessageInterceptor):
 
             state_or_none = state if ix == 0 else None
 
+            content = msg.content
             for cmd in self._commands:
-                msg_edited = cmd.process_query(query=msg.content, state=state_or_none)
-                msg.content = msg_edited
+                content = cmd.process_query(query=content, state=state_or_none)
 
-        return messages
+            if content != msg.content:
+                result[len(messages) - 1 - ix] = msg.model_copy(update={'content': content})
+
+        return result
 
     def process_query(self, query: str) -> str:
         """Simply remove commands from the query, without updating state"""


### PR DESCRIPTION
## Applicable issues

None

## Description of changes

A request with an empty user message used to fail deep inside the out-of-scope checker with a bare `ValueError`, which the generic `except Exception` turned into a traceback plus a `200 OK` "An error occurred while processing your request."

`History` is now built at the request boundary (in `ChannelCompletion`, not via a `RunnablePassthrough` step in the main chain) and validates user messages up front, raising a new domain exception `InvalidHistoryError`. `ChannelCompletion` catches it, logs a single warning without a traceback, and answers "This conversation contains a message that cannot be processed. Please start a new chat." — starting a new chat, because the offending message stays in the history the client resends.

For debugging, that handler also dumps the request messages into `state['received_messages']`, trimmed of assistant `custom_content` and attachment payloads. This is why the reply is a `200`: the SDK discards the accumulated response as soon as a `DIALException` reaches the stream, which would throw the dump away.

Also added `except DIALException: raise`, so the `InvalidRequestError` (400) that `SystemMessageInterceptor` already raises is no longer downgraded to the generic 200 message.

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.