### PR TITLE
feat: mediate Deep Research clarification flow via Supreme Agent

### DIFF
--- a/statgpt/app/application/channel_completion.py
+++ b/statgpt/app/application/channel_completion.py
@@ -213,7 +213,11 @@ class ChannelCompletion(ChatCompletion):
         if custom_content := last_response.custom_content:
             if state := custom_content.state:
                 if (show_debug_stages := state.get(StateVarsConfig.SHOW_DEBUG_STAGES)) is not None:
-                    return {**defaults, StateVarsConfig.SHOW_DEBUG_STAGES: show_debug_stages}
+                    defaults[StateVarsConfig.SHOW_DEBUG_STAGES] = show_debug_stages
+                # Carry the Deep Research clarification session across turns so the Supreme
+                # Agent can mediate the multi-turn flow and resume the Deep Research run.
+                if (dr_session := state.get(StateVarsConfig.DEEP_RESEARCH_SESSION)) is not None:
+                    defaults[StateVarsConfig.DEEP_RESEARCH_SESSION] = dr_session
 
         return defaults
 

--- a/statgpt/app/chains/deep_research/deep_research_tool.py
+++ b/statgpt/app/chains/deep_research/deep_research_tool.py
@@ -1,29 +1,54 @@
 import time
-from typing import Annotated, Any
+from typing import Annotated, Any, ClassVar
 
 from mcp.types import ToolAnnotations
-from openai import APIError
 from pydantic import Field
 
+from statgpt.app.chains.deep_research.mediation import (
+    build_transcript,
+    format_auto_answers,
+    summarize_conversation,
+    triage_questions,
+)
 from statgpt.app.chains.parameters import ChainParameters
 from statgpt.app.chains.tools import GuardrailInput, StatGptTool, ToolArgs
 from statgpt.app.config import StateVarsConfig
-from statgpt.app.schemas import ToolArtifact, ToolMessageState
+from statgpt.app.schemas import (
+    DEEP_RESEARCH_ERROR_MESSAGE,
+    DeepResearchSession,
+    DeepResearchStatus,
+    ToolArtifact,
+    ToolMessageState,
+)
 from statgpt.app.utils import OpenAiToDialStreamer, openai
+from statgpt.app.utils.dial_stages import ChoiceI
+from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.config import multiline_logger as logger
 from statgpt.common.schemas import DeepResearchTool as DeepResearchToolConfig
-from statgpt.common.schemas import ToolTypes
+from statgpt.common.schemas import LLMModelConfig, ToolTypes
 from statgpt.common.schemas.llm_call_duration import LLMCallDurationItem
+from statgpt.common.schemas.tool_details import DeepResearchDetails
 from statgpt.common.utils.llm_call_duration_context import get_llm_call_duration_manager
+from statgpt.common.utils.markdown import format_as_markdown_list
 
 
 class DeepResearchArgs(ToolArgs):
     query: Annotated[str, GuardrailInput] = Field(
-        description="The natural language question to research in depth."
+        description=(
+            "The natural language input for Deep Research. For a new investigation this is the "
+            "research question. While a Deep Research session is in progress this is the user's "
+            "answer to the outstanding clarifying question(s) or their approval of the plan, "
+            "enriched with any relevant details already known from the conversation."
+        )
     )
 
 
 class DeepResearchTool(StatGptTool[DeepResearchToolConfig], tool_type=ToolTypes.DEEP_RESEARCH):
+    # Upper bound on Deep Research calls made within a single turn while the agent silently
+    # auto-answers clarifying questions from context. Prevents an endless answer/re-ask loop; on
+    # the final round any outstanding questions are handed to the user instead of auto-answered.
+    MAX_CLARIFICATION_ROUNDS: ClassVar[int] = 4
+
     @classmethod
     def get_mcp_annotations(cls) -> ToolAnnotations:
         return ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldHint=True)
@@ -33,59 +58,104 @@ class DeepResearchTool(StatGptTool[DeepResearchToolConfig], tool_type=ToolTypes.
         """Return the schema for the arguments that this tool accepts."""
         return DeepResearchArgs
 
-    def _construct_history(self, query: str) -> list[dict[str, Any]]:
+    @staticmethod
+    def _load_session(state: dict) -> DeepResearchSession:
+        """Load the active session from state, or start a fresh one.
+
+        A completed session is treated as absent so a new query begins a new
+        investigation (the finished report stays in the chat history)."""
+        session = DeepResearchSession.from_state(state)
+        if session is not None and session.is_in_progress:
+            return session
+        return DeepResearchSession()
+
+    @staticmethod
+    def _build_request_messages(
+        system_prompt: str | None, session: DeepResearchSession, query: str
+    ) -> list[dict[str, Any]]:
+        """The DIAL messages sent to Deep Research: the replayed sub-conversation
+        plus the new user input. Deep Research resumes from the `custom_content.state`
+        it stored on the last assistant message."""
         messages: list[dict[str, Any]] = []
-        # This tool reads the system prompt from `details.system_prompt`; the inherited
-        # `BaseToolDetails.prompts.system_prompt` field is intentionally not honored here.
-        if system_prompt := self._tool_config.details.system_prompt:
+        # Deep Research reads its own system prompt from its app properties and skips the
+        # system role on input; we still forward the configured prompt for parity.
+        if system_prompt:
             messages.append({'role': 'system', 'content': system_prompt})
+        messages.extend(session.messages)
         messages.append({'role': 'user', 'content': query})
         return messages
 
+    @staticmethod
+    def _parse_preparation(dr_state: dict[str, Any] | None) -> tuple[bool, list[str]]:
+        """Read Deep Research's persisted state and return ``(research_started, questions)``.
+
+        CONTRACT: Deep Research sets ``preparation.research_started`` to ``True`` only once the
+        plan is approved AND it has fully streamed the final report within this same response.
+        We rely on that to treat the session as finished; if the deployment ever emits
+        ``research_started`` before the report is delivered, the session would be closed
+        prematurely and the report never resumed."""
+        preparation = (dr_state or {}).get('preparation') or {}
+        research_started = bool(preparation.get('research_started'))
+        clarification = preparation.get('clarification') or {}
+        questions = clarification.get('questions') or []
+        return research_started, questions
+
     async def _arun(self, inputs: dict, query: str, **kwargs) -> tuple[str, ToolArtifact]:
         auth_context = ChainParameters.get_auth_context(inputs)
-        target = ChainParameters.get_target(inputs)
         choice = ChainParameters.get_choice(inputs)
         state = ChainParameters.get_state(inputs)
+        history = ChainParameters.get_history(inputs)
 
         details = self._tool_config.details
         deployment_id = details.get_deployment_id()
+        model_config = self._channel_config.supreme_agent.llm_model_config
 
-        client = openai.get_async_client(api_key=auth_context.api_key)
+        session = self._load_session(state)
+        first_call = not session.messages
 
-        create_kwargs: dict[str, Any] = dict(
-            model=deployment_id,
-            stream=True,
-            messages=self._construct_history(query),
-        )
+        # Merge any answers the agent held back from a previous turn (questions the user was not
+        # asked) with the user's new reply, so Deep Research receives every answer together.
+        user_content = query
+        if session.pending_auto_answers:
+            user_content = "\n\n".join([*session.pending_auto_answers, query])
+            session.pending_auto_answers = []
+
+        # Summarize the conversation once, at the start, and forward it to Deep Research as context.
+        if first_call:
+            if session.context_summary is None:
+                transcript = build_transcript(
+                    history.get_langchain_messages(include_tool_messages=False)
+                )
+                session.context_summary = await summarize_conversation(
+                    api_key=auth_context.api_key, model_config=model_config, transcript=transcript
+                )
+            if session.context_summary:
+                user_content = (
+                    "<conversation_summary>\n"
+                    f"{session.context_summary}\n"
+                    "</conversation_summary>\n\n"
+                    f"{user_content}"
+                )
 
         show_debug_stages = (
             state.get(StateVarsConfig.SHOW_DEBUG_STAGES, False) or details.always_show_stages
         )
+        client = openai.get_async_client(api_key=auth_context.api_key)
 
-        response: str | None = None
         time_start = time.monotonic()
         async with client:
-            stream = await client.chat.completions.create(**create_kwargs)
-            dial_streamer = OpenAiToDialStreamer(
-                target,
-                choice,
-                deployment=deployment_id,
-                stream_content=True,
+            result = await self._mediated_research_loop(
+                client=client,
+                choice=choice,
+                state=state,
+                session=session,
+                details=details,
+                deployment_id=deployment_id,
                 show_debug_stages=show_debug_stages,
-                stages_config=details.stages_config,
+                first_user_content=user_content,
+                auth_context=auth_context,
+                model_config=model_config,
             )
-
-            with dial_streamer:
-                try:
-                    async for chunk in stream:
-                        dial_streamer.send_chunk(chunk)
-                except APIError as e:
-                    logger.exception(e)
-                    response = "<error>Something went wrong</error>"
-
-                if response is None:
-                    response = dial_streamer.content_with_attachments_metadata
 
         duration_s = time.monotonic() - time_start
         if (duration_manager := get_llm_call_duration_manager()) is not None:
@@ -94,4 +164,211 @@ class DeepResearchTool(StatGptTool[DeepResearchToolConfig], tool_type=ToolTypes.
             )
 
         artifact = ToolArtifact(state=ToolMessageState(type=self.tool_type))
-        return response, artifact
+        return result, artifact
+
+    async def _mediated_research_loop(
+        self,
+        *,
+        client,
+        choice: ChoiceI,
+        state: dict,
+        session: DeepResearchSession,
+        details: DeepResearchDetails,
+        deployment_id: str,
+        show_debug_stages: bool,
+        first_user_content: str,
+        auth_context: AuthContext,
+        model_config: LLMModelConfig,
+    ) -> str:
+        """Drive one turn of the clarification flow.
+
+        Calls Deep Research, and while it only asks clarifying questions the agent can answer from
+        context, replies on the user's behalf and calls again — up to ``MAX_CLARIFICATION_ROUNDS``.
+        Stops (and returns the user-facing text) as soon as Deep Research delivers its report, or
+        as soon as a question needs the user, whose remaining questions are shown verbatim."""
+        user_content = first_user_content
+
+        for round_idx in range(self.MAX_CLARIFICATION_ROUNDS):
+            messages = self._build_request_messages(details.system_prompt, session, user_content)
+            content, dr_state, attachments, ok, streamed_live = await self._call_deep_research(
+                client=client,
+                choice=choice,
+                deployment_id=deployment_id,
+                details=details,
+                show_debug_stages=show_debug_stages,
+                messages=messages,
+            )
+
+            if not ok:
+                # Request/network/mid-stream failure. Deep Research owns this turn and is force-
+                # selected, so surface a friendly message and leave the session untouched.
+                choice.append_content(DEEP_RESEARCH_ERROR_MESSAGE)
+                return DEEP_RESEARCH_ERROR_MESSAGE
+
+            if dr_state is None:
+                logger.warning(
+                    "Deep Research returned no custom_content.state; surfacing its content as-is "
+                    "and leaving the session unchanged."
+                )
+                self._surface_to_user(choice, content, attachments)
+                return content
+
+            self._append_turn(session, user_content, content, dr_state)
+            research_started, questions = self._parse_preparation(dr_state)
+
+            if research_started:
+                # Plan approved and the final report delivered: finish the session. The report was
+                # streamed live if research_started surfaced mid-stream; otherwise flush it now.
+                if not streamed_live:
+                    self._surface_to_user(choice, content, attachments)
+                self._drop_session(state)
+                return content
+
+            if not questions:
+                # Deep Research responded without structured questions (e.g. awaiting plan
+                # approval): surface its message and wait for the user.
+                session.outstanding_questions = []
+                self._save_session(state, session)
+                self._surface_to_user(choice, content, attachments)
+                return content
+
+            answered, pending = await triage_questions(
+                api_key=auth_context.api_key,
+                model_config=model_config,
+                context=session.context_summary or "",
+                questions=questions,
+            )
+
+            is_last_round = round_idx == self.MAX_CLARIFICATION_ROUNDS - 1
+            if answered and not pending and not is_last_round:
+                # Every question answered from context: reply to Deep Research and continue
+                # silently, without involving the user.
+                user_content = "\n\n".join(format_auto_answers(answered))
+                continue
+
+            if not pending:
+                # All questions were answerable but the round cap is reached: ask the user
+                # directly rather than looping further.
+                pending = questions
+                answered = {}
+
+            # Hold the auto-answers for next turn and ask the user the rest, verbatim.
+            session.outstanding_questions = pending
+            session.pending_auto_answers = format_auto_answers(answered)
+            self._save_session(state, session)
+            message = self._format_clarification_message(pending)
+            choice.append_content(message)
+            return message
+
+        # The loop always returns above; this satisfies the type checker.
+        return DEEP_RESEARCH_ERROR_MESSAGE
+
+    @staticmethod
+    async def _call_deep_research(
+        *,
+        client,
+        choice: ChoiceI,
+        deployment_id: str,
+        details: DeepResearchDetails,
+        show_debug_stages: bool,
+        messages: list[dict[str, Any]],
+    ) -> tuple[str, dict[str, Any] | None, list[dict[str, Any]], bool, bool]:
+        """One Deep Research call.
+
+        Content starts buffered (``stream_content=False``) so the caller can filter clarifications
+        (surface only the questions the user must answer) or consume them silently while the agent
+        auto-answers. The moment Deep Research signals that research has started, we switch to live
+        streaming so the final report is shown as-is, token by token. Progress stages always stream
+        live. Returns ``(content, state, attachments, ok, streamed_live)`` with ``ok=False`` on any
+        failure; ``streamed_live`` is True once the report was streamed to the user."""
+        dial_streamer = OpenAiToDialStreamer(
+            choice,
+            choice,
+            deployment=deployment_id,
+            stream_content=False,
+            show_debug_stages=show_debug_stages,
+            stages_config=details.stages_config,
+        )
+        streamed_live = False
+        with dial_streamer:
+            try:
+                stream = await client.chat.completions.create(
+                    model=deployment_id, stream=True, messages=messages
+                )
+                async for chunk in stream:
+                    dial_streamer.send_chunk(chunk)
+                    if not streamed_live and DeepResearchTool._research_started(
+                        dial_streamer.state
+                    ):
+                        # Research has begun: stream the report as-is from here on, flushing any
+                        # buffered lead-in content in one go.
+                        dial_streamer.enable_content_streaming()
+                        streamed_live = True
+            except Exception as e:
+                logger.exception(e)
+                return "", None, [], False, False
+
+        return (
+            dial_streamer.content,
+            dial_streamer.state,
+            dial_streamer.attachments,
+            True,
+            streamed_live,
+        )
+
+    @staticmethod
+    def _research_started(dr_state: dict[str, Any] | None) -> bool:
+        research_started, _ = DeepResearchTool._parse_preparation(dr_state)
+        return research_started
+
+    @staticmethod
+    def _surface_to_user(choice: ChoiceI, content: str, attachments: list[dict[str, Any]]) -> None:
+        """Append buffered Deep Research output (content + attachments) to the visible answer."""
+        if content:
+            choice.append_content(content)
+        for attachment in attachments:
+            choice.add_attachment(
+                type=attachment.get('type'),
+                title=attachment.get('title'),
+                data=attachment.get('data'),
+                url=attachment.get('url'),
+                reference_url=attachment.get('reference_url'),
+                reference_type=attachment.get('reference_type'),
+            )
+
+    @staticmethod
+    def _format_clarification_message(questions: list[str]) -> str:
+        listed = format_as_markdown_list(questions, list_type="ordered")
+        return (
+            "Deep Research needs a bit more information before it can continue. "
+            "Please answer the following:\n\n" + listed
+        )
+
+    @staticmethod
+    def _append_turn(
+        session: DeepResearchSession,
+        user_content: str,
+        assistant_content: str,
+        dr_state: dict[str, Any],
+    ) -> None:
+        """Record a user/assistant exchange (assistant carrying Deep Research's state) so the
+        sub-conversation can be replayed on the next call/turn."""
+        session.messages.append({'role': 'user', 'content': user_content})
+        session.messages.append(
+            {
+                'role': 'assistant',
+                'content': assistant_content,
+                'custom_content': {'state': dr_state},
+            }
+        )
+        session.status = DeepResearchStatus.IN_PROGRESS
+
+    @staticmethod
+    def _save_session(state: dict, session: DeepResearchSession) -> None:
+        state[StateVarsConfig.DEEP_RESEARCH_SESSION] = session.model_dump(mode='json')
+
+    @staticmethod
+    def _drop_session(state: dict) -> None:
+        # Drop a finished session rather than persisting the (potentially large) report and
+        # accumulated state on every later turn — the report already lives in the chat history.
+        state.pop(StateVarsConfig.DEEP_RESEARCH_SESSION, None)

--- a/statgpt/app/chains/deep_research/mediation.py
+++ b/statgpt/app/chains/deep_research/mediation.py
@@ -1,0 +1,147 @@
+"""LLM helpers that let the Supreme Agent mediate the Deep Research clarification flow:
+summarize the conversation for Deep Research context, and triage Deep Research's clarifying
+questions into ones the agent can answer from context vs. ones the user must answer."""
+
+from collections.abc import Sequence
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel, Field, SecretStr
+
+from statgpt.common.config import multiline_logger as logger
+from statgpt.common.schemas import LLMModelConfig
+from statgpt.common.utils.models import get_chat_model
+
+_SUMMARY_SYSTEM_PROMPT = """\
+You condense a chat conversation into a briefing for a Deep Research assistant.
+
+Write a concise summary (a few short paragraphs or bullet points) that captures everything a \
+researcher would need to understand and scope the user's request: the research goal, the specific \
+entities/topics involved, any constraints (time range, geography, sources, format), and any \
+preferences or details the user has already stated. Do not invent information that is not present \
+in the conversation. Do not add commentary or ask questions — output only the summary.\
+"""
+
+_TRIAGE_SYSTEM_PROMPT = """\
+A Deep Research assistant asked the user the clarifying questions below before starting its \
+research. You decide, for each question, whether it can be answered CONFIDENTLY and UNAMBIGUOUSLY \
+from the conversation context alone, so the user does not have to be asked again for information \
+they already provided.
+
+Rules:
+- Only set can_answer=true when the context clearly and specifically contains the answer. When in \
+doubt, set can_answer=false so the user is asked.
+- Never guess, assume defaults, or infer preferences that the user did not express.
+- When can_answer=true, put the answer in `answer`, phrased as a direct reply to that question.
+- Return exactly one item per question, using the question's zero-based index.
+
+Conversation context:
+{context}
+
+Clarifying questions (index: question):
+{questions}\
+"""
+
+
+class _QuestionTriage(BaseModel):
+    index: int = Field(description="Zero-based index of the question this decision refers to.")
+    can_answer: bool = Field(
+        description="True only if the question can be confidently answered from the context alone."
+    )
+    answer: str | None = Field(
+        default=None, description="The answer when can_answer is true, else null."
+    )
+
+
+class _TriageResponse(BaseModel):
+    items: list[_QuestionTriage] = Field(default_factory=list)
+
+
+def build_transcript(messages: Sequence[BaseMessage]) -> str:
+    """Render the user/assistant turns of a conversation as a plain-text transcript.
+
+    Tool calls, tool results, and system messages are skipped: they are internal plumbing, not
+    part of what the user and assistant said to each other."""
+    lines: list[str] = []
+    for msg in messages:
+        if isinstance(msg, HumanMessage):
+            role = "User"
+        elif isinstance(msg, AIMessage) and not msg.tool_calls:
+            role = "Assistant"
+        else:
+            continue
+        text = msg.content if isinstance(msg.content, str) else str(msg.content)
+        if text.strip():
+            lines.append(f"{role}: {text.strip()}")
+    return "\n\n".join(lines)
+
+
+async def summarize_conversation(
+    *, api_key: str | SecretStr, model_config: LLMModelConfig, transcript: str
+) -> str | None:
+    """Summarize the conversation for Deep Research. Returns ``None`` on empty input or failure
+    (the caller then proceeds without a summary rather than failing the turn)."""
+    if not transcript.strip():
+        return None
+
+    prompt = ChatPromptTemplate.from_messages(
+        [("system", _SUMMARY_SYSTEM_PROMPT), ("user", "{transcript}")]
+    )
+    llm = get_chat_model(api_key=api_key, model_config=model_config)
+    try:
+        response = await (prompt | llm).ainvoke({"transcript": transcript})
+    except Exception as e:
+        logger.warning(f"Deep Research context summarization failed: {e!r}")
+        return None
+
+    content = response.content
+    summary = content if isinstance(content, str) else str(content)
+    return summary.strip() or None
+
+
+async def triage_questions(
+    *,
+    api_key: str | SecretStr,
+    model_config: LLMModelConfig,
+    context: str,
+    questions: list[str],
+) -> tuple[dict[str, str], list[str]]:
+    """Split clarifying questions into ``(answered, pending)``.
+
+    ``answered`` maps a question to the answer derived from context; ``pending`` is the list of
+    questions (verbatim, original wording) the user must still answer. On any failure or missing
+    context every question is treated as pending, so the user is asked rather than the flow guessing.
+    """
+    if not questions:
+        return {}, []
+    if not context.strip():
+        return {}, list(questions)
+
+    numbered = "\n".join(f"{i}: {q}" for i, q in enumerate(questions))
+    prompt = ChatPromptTemplate.from_messages([("system", _TRIAGE_SYSTEM_PROMPT)])
+    llm = get_chat_model(api_key=api_key, model_config=model_config).with_structured_output(
+        _TriageResponse, method="json_mode"
+    )
+    try:
+        result = await (prompt | llm).ainvoke({"context": context, "questions": numbered})
+        assert isinstance(result, _TriageResponse)
+    except Exception as e:
+        logger.warning(f"Deep Research question triage failed; asking the user everything: {e!r}")
+        return {}, list(questions)
+
+    decisions = {item.index: item for item in result.items}
+    answered: dict[str, str] = {}
+    pending: list[str] = []
+    for idx, question in enumerate(questions):
+        decision = decisions.get(idx)
+        if decision is not None and decision.can_answer and decision.answer:
+            answered[question] = decision.answer.strip()
+        else:
+            # Keep the original wording so the user sees Deep Research's question verbatim.
+            pending.append(question)
+    return answered, pending
+
+
+def format_auto_answers(answered: dict[str, str]) -> list[str]:
+    """Format answered questions as ``"Q: ...\\nA: ..."`` blocks for replay to Deep Research."""
+    return [f"Q: {question}\nA: {answer}" for question, answer in answered.items()]

--- a/statgpt/app/chains/supreme_agent.py
+++ b/statgpt/app/chains/supreme_agent.py
@@ -22,6 +22,8 @@ from statgpt.app.chains.tools import StatGptTool
 from statgpt.app.config import ChainParametersConfig, StateVarsConfig
 from statgpt.app.default_prompts import supreme_agent_default_prompts
 from statgpt.app.schemas import (
+    DEEP_RESEARCH_ERROR_MESSAGE,
+    DeepResearchSession,
     FailedToolArtifact,
     FailedToolMessageState,
     ToolArtifact,
@@ -38,13 +40,27 @@ from statgpt.app.utils.dial_stages import (
 from statgpt.app.utils.message_history import History
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.config import multiline_logger as logger
-from statgpt.common.schemas import ChannelConfig, FakeCall
+from statgpt.common.schemas import ChannelConfig, FakeCall, ToolTypes
 from statgpt.common.utils import InvalidLLMStreamResponse
 from statgpt.common.utils.llm_call_duration_context import get_llm_call_duration_manager
 from statgpt.common.utils.markdown import format_as_markdown_list
 from statgpt.common.utils.models import get_chat_model
 
 FAKE_TOOL_STAGE_PREFIX = '[FAKE TOOL] '
+
+DEEP_RESEARCH_MEDIATION_INSTRUCTION = """\
+A Deep Research session is IN PROGRESS and you relay between the user and Deep Research. Deep \
+Research is an interactive tool that clarifies the request and agrees on a plan with the user \
+before it runs.
+
+Deep Research is currently waiting on the following:
+{questions}
+
+The user's latest message is their reply. Call the `{tool_name}` tool to continue the session, \
+passing the user's reply verbatim as the `query` argument. Relay their answer faithfully; do not \
+invent answers to questions the user did not address — the tool handles conversation context on \
+its own.\
+"""
 
 
 class ToolCaller:
@@ -163,18 +179,28 @@ class SupremeAgent:
         auth_context: AuthContext,
         channel_config: ChannelConfig,
         tools: list[StatGptTool],
+        tool_choice: str | None = None,
     ) -> 'SupremeAgent':
-        chain = cls._create_chain(auth_context, channel_config, tools)
+        chain = cls._create_chain(auth_context, channel_config, tools, tool_choice)
         return cls(choice, chain)
 
     async def run(
-        self, history: History, configuration: StatGPTConfiguration
+        self,
+        history: History,
+        configuration: StatGPTConfiguration,
+        extra_system_message: str | None = None,
     ) -> _SupremeAgentResponse:
         chunk: AIMessageChunk
         resp: AIMessageChunk | None = None
 
+        chat_history = history.get_langchain_messages(include_tool_messages=True)
+        if extra_system_message:
+            # Ephemeral, per-run guidance (e.g. Deep Research session mediation). Not written
+            # to history so it cannot leak into later turns once the session state changes.
+            chat_history.append(SystemMessage(content=extra_system_message))
+
         inputs = {
-            'chat_history': history.get_langchain_messages(include_tool_messages=True),
+            'chat_history': chat_history,
             'today_date': configuration.get_current_date(),
         }
         first_token_time = None
@@ -222,7 +248,11 @@ class SupremeAgent:
 
     @classmethod
     def _create_chain(
-        cls, auth_context: AuthContext, channel_config: ChannelConfig, tools: list[StatGptTool]
+        cls,
+        auth_context: AuthContext,
+        channel_config: ChannelConfig,
+        tools: list[StatGptTool],
+        tool_choice: str | None = None,
     ) -> Runnable:
         prompt_template = ChatPromptTemplate.from_messages(
             [
@@ -256,7 +286,10 @@ class SupremeAgent:
             api_key=auth_context.api_key,
             model_config=channel_config.supreme_agent.llm_model_config,
         )
-        model_with_tools = model.bind_tools(tools, strict=True)
+        if tool_choice is not None:
+            model_with_tools = model.bind_tools(tools, strict=True, tool_choice=tool_choice)
+        else:
+            model_with_tools = model.bind_tools(tools, strict=True)
 
         return prompt_template | model_with_tools
 
@@ -274,9 +307,6 @@ class SupremeAgentExecutor:
         debug = state.get(StateVarsConfig.SHOW_DEBUG_STAGES, False)
 
         tool_executor = ToolCaller.from_config(self._channel_config)
-        supreme_agent = SupremeAgent.create(
-            choice, auth_context, self._channel_config, tool_executor.tools
-        )
 
         fake_history = await self._fake_tool_calls(tool_executor, inputs, show_stages=debug)
         history.prepend(fake_history)
@@ -294,10 +324,54 @@ class SupremeAgentExecutor:
         state = ChainParameters.get_state(inputs)
         skip_tools_execution = state.get(StateVarsConfig.CMD_SKIP_TOOLS_EXECUTION, False)
 
+        deep_research_tool = next(
+            (t for t in tool_executor.tools if t.tool_type == ToolTypes.DEEP_RESEARCH), None
+        )
+        deep_research_session = self._load_deep_research_session(state)
+        session_in_progress = (
+            deep_research_session is not None and deep_research_session.is_in_progress
+        )
+        # The `deep_research` configuration toggle (advertised to the frontend only where the tool
+        # is enabled) is the single switch for Deep Research mode. When on, the tool is forced via
+        # tool_choice; when off, it is hidden from the agent entirely ("fully unavailable").
+        deep_research_engaged = deep_research_tool is not None and configuration.deep_research
+
+        if session_in_progress and not deep_research_engaged:
+            # The user turned Deep Research mode off mid-session: abandon it and handle the
+            # message as a normal request.
+            logger.info("Deep Research mode turned off mid-session; abandoning the active session.")
+            self._exit_deep_research_session(state)
+            session_in_progress = False
+
+        agent_tools = tool_executor.tools
+        tool_choice: str | None = None
+        if deep_research_tool is not None:
+            if deep_research_engaged:
+                tool_choice = deep_research_tool.name
+            else:
+                agent_tools = [t for t in agent_tools if t.tool_type != ToolTypes.DEEP_RESEARCH]
+
+        supreme_agent = SupremeAgent.create(
+            choice, auth_context, self._channel_config, agent_tools, tool_choice=tool_choice
+        )
+
+        mediation_instruction: str | None = None
+        if (
+            deep_research_engaged
+            and session_in_progress
+            and deep_research_tool is not None
+            and deep_research_session is not None
+        ):
+            mediation_instruction = self._deep_research_mediation_instruction(
+                deep_research_tool.name, deep_research_session
+            )
+
         for i in range(self._channel_config.supreme_agent.max_agent_iterations):
             name = f"[DEBUG] Supreme Agent run {i + 1}"
             with optional_timed_stage(choice=choice, name=name, enabled=debug):
-                response = await supreme_agent.run(history, configuration)
+                response = await supreme_agent.run(
+                    history, configuration, extra_system_message=mediation_instruction
+                )
                 logger.info(f"Response: {response.resp!r}")
 
             tool_data_query_artifacts: list[DataQueryArtifact] = []
@@ -305,14 +379,29 @@ class SupremeAgentExecutor:
             if tool_calls := response.resp.tool_calls:
                 history.add_chunk_as_tool_message(response.resp)
 
-                res: list[ToolMessage] = await asyncio.gather(
-                    *(tool_executor.call_tool(tool_call, inputs) for tool_call in tool_calls)
+                tool_calls_to_run, rejected_messages = self._guard_deep_research_calls(
+                    tool_calls, deep_research_tool
                 )
+                res: list[ToolMessage] = await asyncio.gather(
+                    *(tool_executor.call_tool(tool_call, inputs) for tool_call in tool_calls_to_run)
+                )
+                res.extend(rejected_messages)
 
+                deep_research_msg: ToolMessage | None = None
                 for tool_msg in res:
                     history.add_tool_message(tool_msg)
 
-                    if (artifact := tool_msg.artifact) and isinstance(artifact, DataQueryArtifact):
+                    artifact = tool_msg.artifact
+                    # Capture the first (executed) Deep Research message; any later
+                    # DEEP_RESEARCH message is a rejected duplicate from the guard.
+                    if (
+                        artifact
+                        and artifact.type == ToolTypes.DEEP_RESEARCH
+                        and deep_research_msg is None
+                    ):
+                        deep_research_msg = tool_msg
+
+                    if artifact and isinstance(artifact, DataQueryArtifact):
                         tool_data_query_artifacts.append(artifact)
                         data_query_artifacts[tool_msg.tool_call_id] = artifact
 
@@ -328,6 +417,17 @@ class SupremeAgentExecutor:
                         "Further supreme agent runs are skipped due to tools execution skip"
                     )
                     return ""
+
+                if deep_research_msg is not None:
+                    # Deep Research owns this turn: it either streamed its clarifying question
+                    # / final report straight into the conversation, or failed. Either way, end
+                    # the loop — under the forced tool_choice, continuing would just re-invoke
+                    # Deep Research and, on a persistent failure, spin until max_agent_iterations.
+                    if deep_research_msg.status == ToolResponseStatus.ERROR.value:
+                        choice.append_content(DEEP_RESEARCH_ERROR_MESSAGE)
+                        return DEEP_RESEARCH_ERROR_MESSAGE
+                    dr_content = deep_research_msg.content
+                    return dr_content if isinstance(dr_content, str) else str(dr_content)
             elif response.finished:
                 if response.first_token_time is not None:
                     self._log_performance(inputs, response.start_time, response.first_token_time)
@@ -350,6 +450,63 @@ class SupremeAgentExecutor:
         warning_msg = '\n\n[WARNING] Maximum number of agent loop iterations reached. Please enter "continue" to proceed.'
         choice.append_content(warning_msg)
         return warning_msg
+
+    @staticmethod
+    def _load_deep_research_session(state: dict) -> DeepResearchSession | None:
+        return DeepResearchSession.from_state(state)
+
+    @staticmethod
+    def _exit_deep_research_session(state: dict) -> None:
+        """Abandon any active session by dropping it from state. Called when the user turns
+        Deep Research mode off mid-session; the next turn is handled as a normal request."""
+        state.pop(StateVarsConfig.DEEP_RESEARCH_SESSION, None)
+
+    @staticmethod
+    def _deep_research_mediation_instruction(tool_name: str, session: DeepResearchSession) -> str:
+        if session.outstanding_questions:
+            questions = format_as_markdown_list(session.outstanding_questions, list_type="ordered")
+        else:
+            questions = (
+                "- (Deep Research is waiting for the user to review and approve the proposed plan.)"
+            )
+        return DEEP_RESEARCH_MEDIATION_INSTRUCTION.format(tool_name=tool_name, questions=questions)
+
+    @staticmethod
+    def _guard_deep_research_calls(
+        tool_calls: list[ToolCall], deep_research_tool: StatGptTool | None
+    ) -> tuple[list[ToolCall], list[ToolMessage]]:
+        """Enforce a single Deep Research call per agent response: if the agent emits more
+        than one Deep Research call in one response, keep the first and reject the rest with
+        an error."""
+        if deep_research_tool is None:
+            return tool_calls, []
+
+        kept: list[ToolCall] = []
+        rejected: list[ToolMessage] = []
+        seen = False
+        for tool_call in tool_calls:
+            if tool_call['name'] == deep_research_tool.name:
+                if seen:
+                    rejected.append(
+                        ToolMessage(
+                            content=(
+                                "Only one Deep Research run can be active in a chat. "
+                                "This duplicate call was not executed."
+                            ),
+                            tool_call_id=tool_call['id'],
+                            status=ToolResponseStatus.ERROR.value,
+                            artifact=FailedToolArtifact(
+                                state=FailedToolMessageState(
+                                    type=ToolTypes.DEEP_RESEARCH,
+                                    error="duplicate_deep_research_call",
+                                )
+                            ),
+                        )
+                    )
+                    continue
+                seen = True
+            kept.append(tool_call)
+        return kept, rejected
 
     async def create_chain(self) -> Runnable:
         return RunnablePassthrough.assign(general_response=self.stream_response)

--- a/statgpt/app/config/state.py
+++ b/statgpt/app/config/state.py
@@ -19,3 +19,6 @@ class StateVarsConfig:
     OUT_OF_SCOPE = "out_of_scope"
     OUT_OF_SCOPE_REASONING = "out_of_scope_reasoning"
     TOOL_MESSAGES = "tool_messages"
+
+    # Supreme Agent <-> Deep Research clarification session, carried across turns.
+    DEEP_RESEARCH_SESSION = "deep_research_session"

--- a/statgpt/app/schemas/__init__.py
+++ b/statgpt/app/schemas/__init__.py
@@ -1,3 +1,4 @@
+from .deep_research import DEEP_RESEARCH_ERROR_MESSAGE, DeepResearchSession, DeepResearchStatus
 from .file_rags import DialRagState
 from .query import AppJsonQuery, AppJsonQueryWithMetadata
 from .selection_candidates import (

--- a/statgpt/app/schemas/deep_research.py
+++ b/statgpt/app/schemas/deep_research.py
@@ -1,0 +1,49 @@
+from enum import StrEnum
+from typing import Any, Self
+
+from pydantic import BaseModel, Field
+
+from statgpt.app.config.state import StateVarsConfig
+
+# User-facing message shown when a Deep Research turn fails. Shared by the tool (mid-stream /
+# request errors) and the Supreme Agent (framework-level errors that never reach the tool) so
+# both failure paths surface identical wording.
+DEEP_RESEARCH_ERROR_MESSAGE = "\n\nDeep Research could not complete this request. Please try again."
+
+
+class DeepResearchStatus(StrEnum):
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+
+
+class DeepResearchSession(BaseModel):
+    """Supreme Agent <-> Deep Research conversation, persisted in DIAL state.
+
+    Mediates the multi-turn clarification flow. `messages` is the DIAL-format
+    sub-conversation (user/assistant only) replayed to the Deep Research
+    deployment so it can resume its preparation flow; each assistant entry
+    carries Deep Research's own `custom_content.state`. `status` drives how the
+    Supreme Agent routes the next user message.
+    """
+
+    status: DeepResearchStatus = DeepResearchStatus.IN_PROGRESS
+    messages: list[dict[str, Any]] = Field(default_factory=list)
+    outstanding_questions: list[str] = Field(default_factory=list)
+    # Answers the agent derived from conversation context for clarifying questions the user was
+    # NOT asked. Held here until the user answers the remaining (verbatim) questions, then merged
+    # with the user's reply and forwarded to Deep Research so it receives every answer at once.
+    pending_auto_answers: list[str] = Field(default_factory=list)
+    # LLM summary of the conversation, generated once when the session starts and forwarded to
+    # Deep Research as context. Reused for question triage on later turns to avoid re-summarizing.
+    context_summary: str | None = None
+
+    @property
+    def is_in_progress(self) -> bool:
+        return self.status == DeepResearchStatus.IN_PROGRESS
+
+    @classmethod
+    def from_state(cls, state: dict) -> Self | None:
+        """Load and validate the session stored in DIAL state, or ``None`` if absent."""
+        if raw := state.get(StateVarsConfig.DEEP_RESEARCH_SESSION):
+            return cls.model_validate(raw)
+        return None

--- a/statgpt/app/schemas/dial_app_configuration.py
+++ b/statgpt/app/schemas/dial_app_configuration.py
@@ -28,6 +28,15 @@ class StatGPTConfiguration(BaseModel):
         "When False, each dataset produces a separate python code attachment.",
         default=False,
     )
+    # Keep in sync with `DeepResearchChannelConfiguration` in services/chat_facade.py, which
+    # advertises this toggle to the frontend only when the Deep Research tool is enabled. This
+    # model parses the value the frontend sends back on each request.
+    deep_research: bool = Field(
+        description="When True, run the request in Deep Research mode: the Supreme Agent is forced "
+        "to use the Deep Research tool. Advertised to the frontend via the deployment "
+        "configuration only when the channel has the Deep Research tool enabled.",
+        default=False,
+    )
 
     @field_validator('timezone')
     @classmethod

--- a/statgpt/app/utils/openai_to_dial_streamer.py
+++ b/statgpt/app/utils/openai_to_dial_streamer.py
@@ -40,6 +40,7 @@ class OpenAiToDialStreamer:
         self._content = ""
         self._stages: dict[int, Stage] = {}
         self._attachments: list[dict[str, Any]] = []
+        self._state: dict[str, Any] | None = None
 
     def __enter__(self):
         return self
@@ -55,6 +56,30 @@ class OpenAiToDialStreamer:
     @property
     def attachments(self) -> list[dict[str, Any]]:
         return self._attachments
+
+    @property
+    def state(self) -> dict[str, Any] | None:
+        """The `custom_content.state` set by the downstream deployment, if any."""
+        return self._state
+
+    def enable_content_streaming(self) -> None:
+        """Switch from buffering to live streaming, flushing whatever content and attachments have
+        been buffered so far. Idempotent. Lets a caller start buffered and go live once it decides
+        the response should be shown as-is (e.g. a Deep Research report once research starts)."""
+        if self._stream_content:
+            return
+        self._stream_content = True
+        if self._content:
+            self._target.append_content(self._content)
+        for attachment in self._attachments:
+            self._target.add_attachment(
+                type=attachment.get('type'),
+                title=attachment.get('title'),
+                data=attachment.get('data'),
+                url=attachment.get('url'),
+                reference_url=attachment.get('reference_url'),
+                reference_type=attachment.get('reference_type'),
+            )
 
     @property
     def attachments_metadata(self) -> str:
@@ -94,6 +119,9 @@ class OpenAiToDialStreamer:
             self._target.append_content(content)
 
     def _process_custom_content(self, custom_content: dict[str, Any]) -> None:
+        if (state := custom_content.get('state')) is not None:
+            self._state = state
+
         if attachments := custom_content.get('attachments'):
             for attachment in attachments:
                 self._process_attachment(attachment)

--- a/tests/unit/app/chains/test_deep_research_session.py
+++ b/tests/unit/app/chains/test_deep_research_session.py
@@ -1,0 +1,278 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from statgpt.app.chains.deep_research.deep_research_tool import DeepResearchTool
+from statgpt.app.chains.deep_research.mediation import (
+    build_transcript,
+    format_auto_answers,
+    triage_questions,
+)
+from statgpt.app.chains.supreme_agent import SupremeAgentExecutor
+from statgpt.app.config import StateVarsConfig
+from statgpt.app.schemas import DeepResearchSession, DeepResearchStatus, ToolResponseStatus
+from statgpt.app.utils import OpenAiToDialStreamer
+
+
+def _tool_call(name: str, id_: str) -> dict:
+    return {"name": name, "id": id_, "args": {}, "type": "tool_call"}
+
+
+class TestParsePreparation:
+    def test_clarification_questions(self):
+        dr_state = {
+            "preparation": {
+                "research_started": False,
+                "clarification": {"questions": ["When?", "Where?"]},
+            }
+        }
+        started, questions = DeepResearchTool._parse_preparation(dr_state)
+        assert started is False
+        assert questions == ["When?", "Where?"]
+
+    def test_research_started(self):
+        dr_state = {"preparation": {"research_started": True, "clarification": None}}
+        started, questions = DeepResearchTool._parse_preparation(dr_state)
+        assert started is True
+        assert questions == []
+
+    def test_missing_or_empty(self):
+        assert DeepResearchTool._parse_preparation(None) == (False, [])
+        assert DeepResearchTool._parse_preparation({}) == (False, [])
+
+
+class TestFromState:
+    def test_absent_returns_none(self):
+        assert DeepResearchSession.from_state({}) is None
+
+    def test_present_is_validated(self):
+        stored = DeepResearchSession(messages=[{"role": "user", "content": "q"}]).model_dump(
+            mode="json"
+        )
+        session = DeepResearchSession.from_state({StateVarsConfig.DEEP_RESEARCH_SESSION: stored})
+        assert session is not None
+        assert session.messages == [{"role": "user", "content": "q"}]
+
+
+class TestLoadSession:
+    def test_no_stored_session_starts_fresh(self):
+        session = DeepResearchTool._load_session({})
+        assert session.messages == []
+        assert session.is_in_progress
+
+    def test_in_progress_session_is_resumed(self):
+        stored = DeepResearchSession(
+            status=DeepResearchStatus.IN_PROGRESS,
+            messages=[{"role": "user", "content": "q"}],
+        ).model_dump(mode="json")
+        session = DeepResearchTool._load_session({StateVarsConfig.DEEP_RESEARCH_SESSION: stored})
+        assert session.messages == [{"role": "user", "content": "q"}]
+
+    def test_completed_session_treated_as_fresh(self):
+        stored = DeepResearchSession(
+            status=DeepResearchStatus.COMPLETED,
+            messages=[{"role": "user", "content": "q"}],
+        ).model_dump(mode="json")
+        session = DeepResearchTool._load_session({StateVarsConfig.DEEP_RESEARCH_SESSION: stored})
+        assert session.messages == []
+
+
+class TestSessionMutationHelpers:
+    def test_append_turn_records_user_and_assistant_with_state(self):
+        session = DeepResearchSession()
+        dr_state = {"preparation": {"research_started": False}}
+        DeepResearchTool._append_turn(session, "my query", "the question", dr_state)
+
+        assert session.status == DeepResearchStatus.IN_PROGRESS
+        assert session.messages[0] == {"role": "user", "content": "my query"}
+        assert session.messages[1]["role"] == "assistant"
+        assert session.messages[1]["content"] == "the question"
+        assert session.messages[1]["custom_content"]["state"] == dr_state
+
+    def test_save_session_serializes_new_fields(self):
+        state: dict = {}
+        session = DeepResearchSession(
+            outstanding_questions=["Where?"],
+            pending_auto_answers=["Q: When?\nA: 2024"],
+            context_summary="the summary",
+        )
+        DeepResearchTool._save_session(state, session)
+
+        stored = DeepResearchSession.model_validate(state[StateVarsConfig.DEEP_RESEARCH_SESSION])
+        assert stored.outstanding_questions == ["Where?"]
+        assert stored.pending_auto_answers == ["Q: When?\nA: 2024"]
+        assert stored.context_summary == "the summary"
+
+    def test_drop_session_removes_it(self):
+        state: dict = {
+            StateVarsConfig.DEEP_RESEARCH_SESSION: DeepResearchSession().model_dump(mode="json")
+        }
+        DeepResearchTool._drop_session(state)
+        assert StateVarsConfig.DEEP_RESEARCH_SESSION not in state
+
+    def test_drop_session_is_noop_when_absent(self):
+        state: dict = {}
+        DeepResearchTool._drop_session(state)
+        assert state == {}
+
+
+class TestSessionFieldDefaults:
+    def test_new_fields_default_empty(self):
+        session = DeepResearchSession()
+        assert session.pending_auto_answers == []
+        assert session.context_summary is None
+
+
+class TestBuildTranscript:
+    def test_keeps_only_user_and_assistant_text(self):
+        messages = [
+            SystemMessage(content="system prompt"),
+            HumanMessage(content="hello"),
+            AIMessage(content="", tool_calls=[_tool_call("t", "1")]),
+            ToolMessage(content="tool output", tool_call_id="1"),
+            AIMessage(content="hi there"),
+        ]
+        assert build_transcript(messages) == "User: hello\n\nAssistant: hi there"
+
+    def test_skips_blank_messages(self):
+        assert build_transcript([HumanMessage(content="   ")]) == ""
+
+
+class TestFormatAutoAnswers:
+    def test_formats_question_answer_blocks(self):
+        assert format_auto_answers({"When?": "2024", "Where?": "EU"}) == [
+            "Q: When?\nA: 2024",
+            "Q: Where?\nA: EU",
+        ]
+
+    def test_empty(self):
+        assert format_auto_answers({}) == []
+
+
+class TestTriageQuestionsTrivialBranches:
+    async def test_no_questions_returns_empty(self):
+        answered, pending = await triage_questions(
+            api_key="k", model_config=Mock(), context="ctx", questions=[]
+        )
+        assert answered == {}
+        assert pending == []
+
+    async def test_blank_context_marks_all_pending(self):
+        answered, pending = await triage_questions(
+            api_key="k", model_config=Mock(), context="   ", questions=["a", "b"]
+        )
+        assert answered == {}
+        # Verbatim, original wording preserved.
+        assert pending == ["a", "b"]
+
+
+class TestResearchStarted:
+    def test_true_when_flag_set(self):
+        assert (
+            DeepResearchTool._research_started({"preparation": {"research_started": True}}) is True
+        )
+
+    def test_false_for_clarification_or_missing(self):
+        assert DeepResearchTool._research_started(None) is False
+        assert (
+            DeepResearchTool._research_started(
+                {"preparation": {"clarification": {"questions": ["q"]}}}
+            )
+            is False
+        )
+
+
+class TestStreamerContentGate:
+    def _streamer(self, target):
+        return OpenAiToDialStreamer(
+            target,
+            Mock(),
+            deployment="d",
+            show_debug_stages=False,
+            stages_config=Mock(),
+            stream_content=False,
+        )
+
+    def test_enable_flushes_buffered_content_and_is_idempotent(self):
+        target = Mock()
+        streamer = self._streamer(target)
+        streamer._content = "buffered report"
+        streamer._attachments = [{"type": "text/markdown", "title": "t", "data": "d"}]
+
+        streamer.enable_content_streaming()
+
+        target.append_content.assert_called_once_with("buffered report")
+        target.add_attachment.assert_called_once()
+        # Second call must not re-flush.
+        streamer.enable_content_streaming()
+        target.append_content.assert_called_once()
+
+    def test_no_flush_when_buffer_empty(self):
+        target = Mock()
+        streamer = self._streamer(target)
+        streamer.enable_content_streaming()
+        target.append_content.assert_not_called()
+
+
+class TestBuildRequestMessages:
+    def test_fresh_session_prepends_system_prompt(self):
+        messages = DeepResearchTool._build_request_messages("SYS", DeepResearchSession(), "hello")
+        assert messages == [
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hello"},
+        ]
+
+    def test_continuation_replays_prior_conversation(self):
+        prior = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1", "custom_content": {"state": {}}},
+        ]
+        session = DeepResearchSession(messages=list(prior))
+        messages = DeepResearchTool._build_request_messages(None, session, "answer")
+        assert messages == prior + [{"role": "user", "content": "answer"}]
+
+
+class TestGuardDeepResearchCalls:
+    def test_no_deep_research_tool_keeps_all(self):
+        calls = [_tool_call("x", "1")]
+        kept, rejected = SupremeAgentExecutor._guard_deep_research_calls(calls, None)
+        assert kept == calls
+        assert rejected == []
+
+    def test_single_call_kept(self):
+        dr = SimpleNamespace(name="deep_research")
+        calls = [_tool_call("deep_research", "1"), _tool_call("other", "2")]
+        kept, rejected = SupremeAgentExecutor._guard_deep_research_calls(calls, dr)
+        assert kept == calls
+        assert rejected == []
+
+    def test_duplicate_calls_rejected(self):
+        dr = SimpleNamespace(name="deep_research")
+        calls = [
+            _tool_call("deep_research", "1"),
+            _tool_call("deep_research", "2"),
+            _tool_call("other", "3"),
+        ]
+        kept, rejected = SupremeAgentExecutor._guard_deep_research_calls(calls, dr)
+        assert [c["id"] for c in kept] == ["1", "3"]
+        assert len(rejected) == 1
+        assert rejected[0].tool_call_id == "2"
+        assert rejected[0].status == ToolResponseStatus.ERROR.value
+
+
+class TestSupremeAgentSessionHelpers:
+    def test_load_returns_none_when_absent(self):
+        assert SupremeAgentExecutor._load_deep_research_session({}) is None
+
+    def test_exit_removes_active_session(self):
+        state = {
+            StateVarsConfig.DEEP_RESEARCH_SESSION: DeepResearchSession().model_dump(mode="json")
+        }
+        SupremeAgentExecutor._exit_deep_research_session(state)
+        assert StateVarsConfig.DEEP_RESEARCH_SESSION not in state
+
+    def test_exit_is_noop_when_absent(self):
+        state: dict = {}
+        SupremeAgentExecutor._exit_deep_research_session(state)
+        assert state == {}


### PR DESCRIPTION
## Applicable issues

- closes #544

## Description of changes

The first version of the Deep Research tool (#490) was single-shot. But Deep Research is **interactive**: before running it clarifies the request and agrees a plan with the user. This PR makes the Supreme Agent **mediate** that multi-turn flow instead of blindly forwarding messages — the agent stays the single owner of the chat and its `state`.

Key points:

- **Session persisted in `state`.** A `DeepResearchSession` (status + the user/assistant sub-conversation, each assistant turn carrying Deep Research's own `custom_content.state`) is stored in DIAL `state` and carried across turns, so Deep Research resumes its preparation flow. A completed session is dropped (the report already lives in chat history); a new query starts fresh.
- **Mediated routing.** While a session is in progress the next user message is routed back into Deep Research as a continuation, not a new request. A per-run (non-persisted) system instruction tells the agent it is relaying between the user and Deep Research.
- **Auto-answering clarifications.** The conversation is summarized once and forwarded to Deep Research as context. Deep Research's clarifying questions are triaged by an LLM: questions answerable from context are answered silently on the user's behalf (looping up to `MAX_CLARIFICATION_ROUNDS = 4`); only the remainder are surfaced to the user, verbatim. Held-back auto-answers are merged with the user's reply on the next turn so Deep Research gets every answer at once.
- **`deep_research` config toggle.** When on, the tool is forced via `tool_choice`; when off, it is hidden from the agent entirely. Turning it off mid-session abandons the session and handles the message normally.
- **Streaming.** Deep Research output is buffered so clarifications can be filtered/consumed, then switches to live streaming the moment `research_started` is signalled, so the final report renders as-is.
- **Single run per chat.** A guard rejects duplicate Deep Research calls within one agent response.

## Implementation details to discuss 

<details>

<summary>Open points worth a review</summary>

- **`research_started` contract.** We treat the session as finished only when Deep Research's persisted `preparation.research_started` is `True`. This assumes the deployment sets that flag **only after** the final report has fully streamed in the same response. If a deployment emits it earlier, the session would close prematurely and the report never resume. Is this contract safe to rely on?
- **State shape coupling.** We read Deep Research's internal `preparation.clarification.questions` / `research_started` out of its opaque `custom_content.state`. This couples us to the deployment's internal schema — worth agreeing how stable that is / whether we need a version guard.
- **Round cap (`MAX_CLARIFICATION_ROUNDS = 4`).** On the final round any still-answerable questions are handed to the user instead of auto-answered, to avoid an endless answer/re-ask loop. Is 4 the right ceiling?
- **Triage aggressiveness.** The triage prompt errs toward asking the user when in doubt. Tuning this trades off "don't bother the user" vs "don't guess wrong" — needs real-conversation validation.
- **Error handling.** Both the tool (mid-stream/request errors) and the agent (framework-level errors) surface a shared `DEEP_RESEARCH_ERROR_MESSAGE` and leave the session untouched. Under forced `tool_choice`, the agent loop ends on a Deep Research result rather than re-invoking, to avoid spinning to `max_agent_iterations`.
- **Config sync.** `StatGPTConfiguration.deep_research` must stay in sync with the `DeepResearchChannelConfiguration` that advertises the toggle to the frontend only when the tool is enabled.

</details>

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.