### PR TITLE
fix: remove pip/ensurepip tooling from runtime images #566

### DIFF
--- a/docker/admin.Dockerfile
+++ b/docker/admin.Dockerfile
@@ -62,6 +62,18 @@ WORKDIR $APP_HOME
 RUN adduser -u 1001 --disabled-password --gecos "" appuser
 COPY --chown=appuser --from=builder $APP_HOME .
 
+# The service runs from the prebuilt venv and never invokes pip/venv at runtime.
+# Remove packaging tooling so its vendored/bundled deps (pip's msgpack,
+# ensurepip's setuptools wheel) aren't flagged as CVEs. The installed
+# setuptools/wheel stay pinned & patched.
+RUN rm -rf /usr/local/lib/python3.11/ensurepip \
+ && rm -rf /usr/local/lib/python3.11/site-packages/pip \
+           /usr/local/lib/python3.11/site-packages/pip-*.dist-info \
+           /usr/local/bin/pip* \
+ && rm -rf /home/app/.venv/lib/python3.11/site-packages/pip \
+           /home/app/.venv/lib/python3.11/site-packages/pip-*.dist-info \
+           /home/app/.venv/bin/pip*
+
 COPY --chmod=755 ./docker/scripts/admin_docker_entrypoint.sh /docker_entrypoint.sh
 
 EXPOSE 8000

--- a/docker/admin.Dockerfile
+++ b/docker/admin.Dockerfile
@@ -52,24 +52,21 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     WEB_CONCURRENCY=1 \
     PYDANTIC_V2=True
 
-# CVE-2026-23949 (jaraco.context vendored in setuptools), CVE-2026-24049 (wheel vendored in setuptools)
-RUN pip install --upgrade pip \
-  && pip install "setuptools==80.10.2" "wheel==0.46.2"
-
 WORKDIR $APP_HOME
 
 # Create non-root user and copy built application
 RUN adduser -u 1001 --disabled-password --gecos "" appuser
 COPY --chown=appuser --from=builder $APP_HOME .
 
-# The service runs from the prebuilt venv and never invokes pip/venv at runtime.
-# Remove packaging tooling so its vendored/bundled deps (pip's msgpack,
-# ensurepip's setuptools wheel) aren't flagged as CVEs. The installed
-# setuptools/wheel stay pinned & patched.
+# The service runs from the prebuilt venv and never invokes pip/venv at runtime,
+# and the venv does not expose system site-packages. The base image installs only
+# pip/setuptools/wheel there, so it is wiped wholesale: that clears their CVEs plus
+# the ones from their vendored/bundled deps (pip's msgpack, setuptools' wheel and
+# jaraco.context). Do not install into the system interpreter, it gets emptied here.
+# The venv keeps its own pinned & patched setuptools/wheel.
 RUN rm -rf /usr/local/lib/python3.11/ensurepip \
- && rm -rf /usr/local/lib/python3.11/site-packages/pip \
-           /usr/local/lib/python3.11/site-packages/pip-*.dist-info \
-           /usr/local/bin/pip* \
+           /usr/local/lib/python3.11/site-packages/* \
+           /usr/local/bin/pip* /usr/local/bin/wheel \
  && rm -rf /home/app/.venv/lib/python3.11/site-packages/pip \
            /home/app/.venv/lib/python3.11/site-packages/pip-*.dist-info \
            /home/app/.venv/bin/pip*

--- a/docker/chat.Dockerfile
+++ b/docker/chat.Dockerfile
@@ -61,6 +61,18 @@ WORKDIR $APP_HOME
 RUN adduser -u 1001 --disabled-password --gecos "" appuser
 COPY --chown=appuser --from=builder $APP_HOME .
 
+# The service runs from the prebuilt venv and never invokes pip/venv at runtime.
+# Remove packaging tooling so its vendored/bundled deps (pip's msgpack,
+# ensurepip's setuptools wheel) aren't flagged as CVEs. The installed
+# setuptools/wheel stay pinned & patched.
+RUN rm -rf /usr/local/lib/python3.11/ensurepip \
+ && rm -rf /usr/local/lib/python3.11/site-packages/pip \
+           /usr/local/lib/python3.11/site-packages/pip-*.dist-info \
+           /usr/local/bin/pip* \
+ && rm -rf /home/app/.venv/lib/python3.11/site-packages/pip \
+           /home/app/.venv/lib/python3.11/site-packages/pip-*.dist-info \
+           /home/app/.venv/bin/pip*
+
 COPY --chmod=755 ./docker/scripts/chat_docker_entrypoint.sh /docker_entrypoint.sh
 
 EXPOSE 5000

--- a/docker/chat.Dockerfile
+++ b/docker/chat.Dockerfile
@@ -51,24 +51,21 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     WEB_CONCURRENCY=1 \
     PYDANTIC_V2=True
 
-# CVE-2026-23949 (jaraco.context vendored in setuptools), CVE-2026-24049 (wheel vendored in setuptools)
-RUN pip install --upgrade pip \
-  && pip install "setuptools==80.10.2" "wheel==0.46.2"
-
 WORKDIR $APP_HOME
 
 # Create non-root user and copy built application
 RUN adduser -u 1001 --disabled-password --gecos "" appuser
 COPY --chown=appuser --from=builder $APP_HOME .
 
-# The service runs from the prebuilt venv and never invokes pip/venv at runtime.
-# Remove packaging tooling so its vendored/bundled deps (pip's msgpack,
-# ensurepip's setuptools wheel) aren't flagged as CVEs. The installed
-# setuptools/wheel stay pinned & patched.
+# The service runs from the prebuilt venv and never invokes pip/venv at runtime,
+# and the venv does not expose system site-packages. The base image installs only
+# pip/setuptools/wheel there, so it is wiped wholesale: that clears their CVEs plus
+# the ones from their vendored/bundled deps (pip's msgpack, setuptools' wheel and
+# jaraco.context). Do not install into the system interpreter, it gets emptied here.
+# The venv keeps its own pinned & patched setuptools/wheel.
 RUN rm -rf /usr/local/lib/python3.11/ensurepip \
- && rm -rf /usr/local/lib/python3.11/site-packages/pip \
-           /usr/local/lib/python3.11/site-packages/pip-*.dist-info \
-           /usr/local/bin/pip* \
+           /usr/local/lib/python3.11/site-packages/* \
+           /usr/local/bin/pip* /usr/local/bin/wheel \
  && rm -rf /home/app/.venv/lib/python3.11/site-packages/pip \
            /home/app/.venv/lib/python3.11/site-packages/pip-*.dist-info \
            /home/app/.venv/bin/pip*


### PR DESCRIPTION
## Applicable issues

- closes #566

## Description of changes

Trivy's `python-pkg` scan failed every PR with two HIGH findings that aren't real app dependencies: `setuptools 70.3.0` (wheel bundled in CPython's `ensurepip`) and `msgpack 1.1.2` (vendored inside `pip` — even the latest pip still ships it, so nothing to upgrade to).

The service runs from the prebuilt venv and never invokes `pip`/`venv` at runtime, so this deletes that tooling from the runtime stage of both the admin and chat images. Genuine remediation (the vulnerable files are removed, not suppressed), and it stops the whole class of pip-vendored / ensurepip-bundled CVEs from recurring on base-image drift. The installed, patched `setuptools`/`wheel` are kept.

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment