### PR TITLE
fix: Session-level advisory locks are leaked onto pooled connections

### DIFF
--- a/statgpt/common/models/__init__.py
+++ b/statgpt/common/models/__init__.py
@@ -1,5 +1,6 @@
 from .database import (
     SessionMakerSingleton,
+    get_engine,
     get_readonly_session_context_manager,
     get_session,
     get_session_context_manager,

--- a/statgpt/common/models/database.py
+++ b/statgpt/common/models/database.py
@@ -100,6 +100,12 @@ class SessionMaker:
     def __init__(self, engine_config: dict):
         self._engine_config = engine_config
         self._postgres_settings = PostgresSettings()
+        self._engine: AsyncEngine | None = None
+
+    @property
+    def engine(self) -> AsyncEngine | None:
+        """The engine created by `create()`, or None if `create()` has not been called."""
+        return self._engine
 
     @staticmethod
     async def _test_connection(engine: AsyncEngine) -> bool:
@@ -190,6 +196,7 @@ class SessionMaker:
     async def create(self) -> async_sessionmaker[AsyncSession]:
         _log.debug("Creating session maker")
         engine = await self.create_engine()
+        self._engine = engine
         session_maker = async_sessionmaker(
             engine,
             expire_on_commit=False,
@@ -202,6 +209,7 @@ class SessionMaker:
 
 class SessionMakerSingleton:
     instance: async_sessionmaker[AsyncSession] | None = None
+    engine: AsyncEngine | None = None
     _lock = asyncio.Lock()
 
     @classmethod
@@ -217,7 +225,9 @@ class SessionMakerSingleton:
                 return cls.instance
 
             _log.debug("Creating new SessionMakerSingleton instance")
-            cls.instance = await SessionMaker(SessionMaker.DEFAULT_ENGINE_CONFIG).create()
+            session_maker = SessionMaker(SessionMaker.DEFAULT_ENGINE_CONFIG)
+            cls.instance = await session_maker.create()
+            cls.engine = session_maker.engine
             return cls.instance
 
 
@@ -240,6 +250,21 @@ class ReadOnlySessionMakerSingleton:
             _log.debug("Creating new ReadOnlySessionMakerSingleton instance")
             cls.instance = await SessionMaker(SessionMaker.READONLY_ENGINE_CONFIG).create()
             return cls.instance
+
+
+async def get_engine() -> AsyncEngine:
+    """Returns the engine backing the default sessions, creating it if needed.
+
+    Intended for code that must pin a unit of work to a single connection for its whole
+    duration -- notably session-level advisory locks, which belong to the PostgreSQL
+    connection rather than to the AsyncSession that issued them. An AsyncSession cannot
+    provide that guarantee: it returns its connection to the pool on every commit.
+    """
+    await SessionMakerSingleton.get_or_create()
+    engine = SessionMakerSingleton.engine
+    if engine is None:
+        raise DatabaseConnectionError("Default engine is not available")
+    return engine
 
 
 # Dependency

--- a/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
+++ b/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
@@ -18,13 +18,17 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from langchain_core.documents import Document
 from sqlalchemy import delete, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
 from sqlalchemy.schema import CreateTable
 from sqlalchemy.sql import text
 from sqlalchemy.sql.elements import TextClause
 from sqlalchemy.sql.expression import func
 
-from statgpt.common.models import get_readonly_session_context_manager, get_session_context_manager
+from statgpt.common.models import (
+    get_engine,
+    get_readonly_session_context_manager,
+    get_session_context_manager,
+)
 from statgpt.common.schemas.llm_call_duration import LLMCallDurationItem
 from statgpt.common.settings.database import PostgresSettings
 from statgpt.common.settings.document import DimensionValueDocumentMetadataFields
@@ -168,9 +172,29 @@ class PgEmbeddinglessVectorStore(EmbeddinglessVectorStore):
         # Use first 8 bytes to generate a bigint for PostgreSQL advisory lock
         return int.from_bytes(hash_bytes[:8], byteorder='big', signed=True)
 
+    @asynccontextmanager
+    async def _lock_connection(self) -> AsyncIterator[AsyncConnection]:
+        """Opens a connection dedicated to holding advisory locks.
+
+        Advisory locks taken with pg_try_advisory_lock belong to the PostgreSQL connection,
+        not to the AsyncSession that issued them. An AsyncSession returns its connection to
+        the pool on every commit and checks out a possibly different one for the next
+        statement, so a lock acquired before a commit cannot be released afterwards: the
+        unlock lands on another connection, returns false, and the lock stays held by an idle
+        pooled connection until it is recycled. Owning a connection for the whole critical
+        section keeps acquire and release on the same backend.
+
+        AUTOCOMMIT keeps that connection out of an open transaction while it does nothing but
+        hold locks -- advisory locks are independent of transactions, and the acquisition loop
+        would otherwise sit 'idle in transaction' for up to the full timeout.
+        """
+        engine = await get_engine()
+        async with engine.connect() as conn:
+            yield await conn.execution_options(isolation_level="AUTOCOMMIT")
+
     async def _acquire_dataset_lock(
         self,
-        session: AsyncSession,
+        conn: AsyncConnection,
         dataset_id: uuid.UUID,
     ) -> int:
         """Acquires a session-level advisory lock for the given dataset_id within this channel.
@@ -179,19 +203,16 @@ class PgEmbeddinglessVectorStore(EmbeddinglessVectorStore):
         pg_advisory_lock to avoid hanging indefinitely when the lock is contended.
 
         Returns the lock key which should be passed to _release_dataset_lock.
-        This lock persists across multiple transactions until explicitly released.
+        The lock is held by `conn` until explicitly released or `conn` is closed.
         This prevents concurrent modifications to the same dataset within the channel.
         """
         lock_key = self._dataset_lock_key(dataset_id)
-        # Ensure session is in a clean state before acquiring lock
-        if session.in_transaction() and not session.is_active:
-            await session.rollback()
 
         timeout_s = self._postgres_settings.advisory_lock_timeout
         current_interval = 0.1
         deadline = time.monotonic() + timeout_s
         while True:
-            result = await session.execute(
+            result = await conn.execute(
                 text("SELECT pg_try_advisory_lock(:lock_key)"), {"lock_key": lock_key}
             )
             if result.scalar():
@@ -209,56 +230,71 @@ class PgEmbeddinglessVectorStore(EmbeddinglessVectorStore):
             await asyncio.sleep(min(current_interval, remaining))
             current_interval = min(current_interval * 1.5, 5.0)
 
-    async def _release_dataset_lock(self, session: AsyncSession, lock_key: int) -> None:
-        """Releases a session-level advisory lock.
+    async def _release_dataset_lock(self, conn: AsyncConnection, lock_key: int) -> bool:
+        """Releases a session-level advisory lock held by `conn`.
 
-        Handles PendingRollback state to ensure lock is always released.
+        Returns True when the lock was released and `conn` is still usable.
+
+        pg_advisory_unlock returns false rather than raising when the connection does not own
+        the lock, so the result is checked explicitly -- an unnoticed failure would leave the
+        lock held by a pooled connection and block every later operation on the dataset. In
+        that case, and on any error, the connection is discarded instead of being returned to
+        the pool: closing it for real makes PostgreSQL drop every advisory lock it holds.
+
+        Never raises: this runs on the cleanup path, where an exception would mask whatever
+        failure is already propagating.
         """
         try:
-            # Rollback if session is in a failed transaction state
-            if session.in_transaction() and not session.is_active:
-                await session.rollback()
-            await session.execute(
+            released = await conn.scalar(
                 text("SELECT pg_advisory_unlock(:lock_key)"), {"lock_key": lock_key}
             )
-        except Exception as e:
-            _log.error(f"Failed to release advisory lock (key={lock_key}): {e}")
-            # Still try to rollback to clean up the session
-            try:
-                await session.rollback()
-            except Exception:
-                pass
-            raise
+        except Exception:
+            _log.exception(
+                f"Failed to release advisory lock (key={lock_key}). Discarding the connection."
+            )
+            await conn.invalidate()
+            return False
+
+        if not released:
+            _log.error(
+                f"Advisory lock (key={lock_key}) was not held by this connection. "
+                f"Discarding the connection to make sure the lock is not leaked."
+            )
+            await conn.invalidate()
+            return False
+
         _log.debug(f"Released advisory lock (key={lock_key})")
+        return True
 
     @asynccontextmanager
-    async def _dataset_lock(
-        self, session: AsyncSession, dataset_id: uuid.UUID
-    ) -> AsyncIterator[None]:
+    async def _dataset_lock(self, dataset_id: uuid.UUID) -> AsyncIterator[None]:
         """Context manager for acquiring and releasing dataset advisory lock."""
-        lock_key = await self._acquire_dataset_lock(session, dataset_id)
-        try:
+        async with self._dataset_locks([dataset_id]):
             yield
-        finally:
-            await self._release_dataset_lock(session, lock_key)
 
     @asynccontextmanager
-    async def _dataset_locks(
-        self, session: AsyncSession, dataset_ids: list[uuid.UUID]
-    ) -> AsyncIterator[None]:
+    async def _dataset_locks(self, dataset_ids: list[uuid.UUID]) -> AsyncIterator[None]:
         """Context manager for acquiring and releasing multiple dataset advisory locks.
 
-        Sorts dataset_ids to ensure deterministic lock ordering and prevent deadlocks.
+        Sorts dataset_ids to ensure deterministic lock ordering and prevent deadlocks, and
+        deduplicates them so that a key is never locked twice on the same connection.
+
+        Acquisition happens inside the try block so that locks taken before a later one times
+        out are still released.
         """
-        sorted_dataset_ids = sorted(dataset_ids)
-        lock_keys = [
-            await self._acquire_dataset_lock(session, ds_id) for ds_id in sorted_dataset_ids
-        ]
-        try:
-            yield
-        finally:
-            for lock_key in lock_keys:
-                await self._release_dataset_lock(session, lock_key)
+        sorted_dataset_ids = sorted(set(dataset_ids))
+
+        async with self._lock_connection() as conn:
+            lock_keys: list[int] = []
+            try:
+                for ds_id in sorted_dataset_ids:
+                    lock_keys.append(await self._acquire_dataset_lock(conn, ds_id))
+                yield
+            finally:
+                for lock_key in reversed(lock_keys):
+                    if not await self._release_dataset_lock(conn, lock_key):
+                        # The connection was discarded, which drops every lock it held.
+                        break
 
     async def _get_dataset_ids_by_version_ids(
         self, session: AsyncSession, version_ids: list[int]
@@ -288,7 +324,7 @@ class PgEmbeddinglessVectorStore(EmbeddinglessVectorStore):
             else:
                 dataset_ids_to_lock = await self._get_dataset_ids_by_version_ids(session, version_ids)  # type: ignore
 
-            async with self._dataset_locks(session, dataset_ids_to_lock):
+            async with self._dataset_locks(dataset_ids_to_lock):
                 document_ids = await self._remove_dataset_metadata(
                     session, dataset_id=dataset_id, version_ids=version_ids
                 )
@@ -615,9 +651,10 @@ class PgVectorStore(PgEmbeddinglessVectorStore, VectorStore):
             )
             batches_with_embeddings.append((batch, embeddings))
 
-        # Phase 2: DB writes in a single session (advisory lock + inserts)
-        async with get_session_context_manager() as session:
-            async with self._dataset_lock(session, dataset_id):
+        # Phase 2: DB writes under the dataset advisory lock, which is held on its own
+        # connection so that the commits below cannot invalidate it.
+        async with self._dataset_lock(dataset_id):
+            async with get_session_context_manager() as session:
                 document_model: type[BaseDocument] = await self._get_document_model()
                 metadata_model: type[BaseDocumentMetadata] = await self._get_metadata_model()
 
@@ -634,7 +671,7 @@ class PgVectorStore(PgEmbeddinglessVectorStore, VectorStore):
                     ]
 
                     session.add_all(items)
-                    await session.commit()
+                    await session.commit()  # 1
                     _log.info(f"Added {len(items)} documents")
 
                     mappings = [
@@ -647,7 +684,7 @@ class PgVectorStore(PgEmbeddinglessVectorStore, VectorStore):
                         for item, doc in zip(items, batch)
                     ]
                     session.add_all(mappings)
-                    await session.commit()
+                    await session.commit()  # 2
                     _log.info(f"Added {len(mappings)} document mappings")
 
     async def search_with_similarity_score(

--- a/tests/unit/common/vectorstore/test_pg_vector_store_locks.py
+++ b/tests/unit/common/vectorstore/test_pg_vector_store_locks.py
@@ -1,0 +1,222 @@
+"""Tests for the dataset advisory locks of `PgEmbeddinglessVectorStore`.
+
+These guard the invariant the locks depend on: a session-level advisory lock belongs to the
+PostgreSQL connection that took it, so acquire and release must happen on the *same*
+connection. Holding the lock through an `AsyncSession` instead broke that, because a session
+returns its connection to the pool on every commit -- the unlock then landed on a different
+connection, silently returned false, and left the lock held by an idle pooled connection.
+"""
+
+import uuid
+from typing import Any
+
+import pytest
+
+from statgpt.common.settings.database import PostgresSettings
+from statgpt.common.vectorstore.pg_vector_store import pg_vector_store as module
+from statgpt.common.vectorstore.pg_vector_store.pg_vector_store import PgEmbeddinglessVectorStore
+
+DATASET_A = uuid.UUID("dee4481b-33d9-5268-aeab-decb5f071821")
+DATASET_B = uuid.UUID("e5135496-a933-4692-b8bf-b8e9f60d38fa")
+
+
+class _FakeResult:
+    def __init__(self, value: Any) -> None:
+        self._value = value
+
+    def scalar(self) -> Any:
+        return self._value
+
+
+class FakeConnection:
+    """Records advisory lock traffic.
+
+    `execute` is only ever used to take locks and `scalar` to release them, which is what lets
+    this double tell the two apart.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int]] = []
+        self.execution_options_seen: list[dict[str, Any]] = []
+        self.invalidated = False
+        self.closed = False
+        # Keys pg_try_advisory_lock should refuse to grant, and non-default unlock results.
+        self.ungrantable_keys: set[int] = set()
+        self.unlock_results: dict[int, bool] = {}
+
+    async def execution_options(self, **opts: Any) -> "FakeConnection":
+        self.execution_options_seen.append(opts)
+        return self
+
+    async def execute(self, _statement: Any, params: dict[str, Any]) -> _FakeResult:
+        key = params["lock_key"]
+        self.calls.append(("lock", key))
+        return _FakeResult(key not in self.ungrantable_keys)
+
+    async def scalar(self, _statement: Any, params: dict[str, Any]) -> bool:
+        key = params["lock_key"]
+        self.calls.append(("unlock", key))
+        return self.unlock_results.get(key, True)
+
+    async def invalidate(self) -> None:
+        self.invalidated = True
+
+    def locked_keys(self) -> list[int]:
+        return [key for op, key in self.calls if op == "lock"]
+
+    def unlocked_keys(self) -> list[int]:
+        return [key for op, key in self.calls if op == "unlock"]
+
+
+class FakeEngine:
+    """Hands out the same connection every time, and counts how often one was asked for."""
+
+    def __init__(self, conn: FakeConnection) -> None:
+        self._conn = conn
+        self.connect_count = 0
+
+    def connect(self) -> "FakeEngine":
+        self.connect_count += 1
+        return self
+
+    async def __aenter__(self) -> FakeConnection:
+        return self._conn
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        self._conn.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _postgres_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PostgresSettings refuses to build without connection env vars."""
+    for name, value in {
+        "PGVECTOR_HOST": "localhost",
+        "PGVECTOR_PORT": "5432",
+        "PGVECTOR_DATABASE": "test",
+        "PGVECTOR_USER": "test",
+        "PGVECTOR_PASSWORD": "test",
+    }.items():
+        monkeypatch.setenv(name, value)
+
+
+@pytest.fixture
+def store() -> PgEmbeddinglessVectorStore:
+    store = PgEmbeddinglessVectorStore("SpecialDimensions_12")
+    # Keep the acquisition loop short: these tests exercise timeouts.
+    store._postgres_settings = PostgresSettings(advisory_lock_timeout=0.05)
+    return store
+
+
+def _bind_engine(monkeypatch: pytest.MonkeyPatch, conn: FakeConnection) -> FakeEngine:
+    engine = FakeEngine(conn)
+
+    async def fake_get_engine() -> FakeEngine:
+        return engine
+
+    monkeypatch.setattr(module, "get_engine", fake_get_engine)
+    return engine
+
+
+async def test_lock_is_acquired_and_released_on_the_same_connection(
+    store: PgEmbeddinglessVectorStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = FakeConnection()
+    engine = _bind_engine(monkeypatch, conn)
+    key = store._dataset_lock_key(DATASET_A)
+
+    async with store._dataset_lock(DATASET_A):
+        assert conn.calls == [("lock", key)], "the lock must be held for the whole body"
+
+    assert conn.calls == [("lock", key), ("unlock", key)]
+    assert engine.connect_count == 1, "the lock must not be spread over several connections"
+    assert conn.closed
+    assert not conn.invalidated
+
+
+async def test_lock_connection_uses_autocommit(
+    store: PgEmbeddinglessVectorStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A connection that does nothing but hold locks must not sit idle in a transaction."""
+    conn = FakeConnection()
+    _bind_engine(monkeypatch, conn)
+
+    async with store._dataset_lock(DATASET_A):
+        pass
+
+    assert conn.execution_options_seen == [{"isolation_level": "AUTOCOMMIT"}]
+
+
+async def test_locks_are_acquired_in_sorted_dataset_order_and_released_in_reverse(
+    store: PgEmbeddinglessVectorStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = FakeConnection()
+    engine = _bind_engine(monkeypatch, conn)
+    expected = [store._dataset_lock_key(ds) for ds in sorted([DATASET_B, DATASET_A])]
+
+    async with store._dataset_locks([DATASET_B, DATASET_A]):
+        pass
+
+    assert conn.locked_keys() == expected
+    assert conn.unlocked_keys() == list(reversed(expected))
+    assert engine.connect_count == 1
+
+
+async def test_already_acquired_locks_are_released_when_a_later_one_times_out(
+    store: PgEmbeddinglessVectorStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The old code acquired locks outside its `try`, so a timeout leaked the earlier ones."""
+    conn = FakeConnection()
+    _bind_engine(monkeypatch, conn)
+    first_key, second_key = (store._dataset_lock_key(ds) for ds in sorted([DATASET_A, DATASET_B]))
+    conn.ungrantable_keys = {second_key}
+
+    with pytest.raises(TimeoutError):
+        async with store._dataset_locks([DATASET_A, DATASET_B]):
+            pytest.fail("the body must not run when a lock cannot be acquired")
+
+    assert conn.unlocked_keys() == [first_key], "the already acquired lock was leaked"
+
+
+async def test_duplicate_dataset_ids_are_locked_once(
+    store: PgEmbeddinglessVectorStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A key locked twice on one connection would need two unlocks to be released."""
+    conn = FakeConnection()
+    _bind_engine(monkeypatch, conn)
+    key = store._dataset_lock_key(DATASET_A)
+
+    async with store._dataset_locks([DATASET_A, DATASET_A]):
+        pass
+
+    assert conn.calls == [("lock", key), ("unlock", key)]
+
+
+async def test_connection_is_discarded_when_unlock_reports_the_lock_was_not_held(
+    store: PgEmbeddinglessVectorStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """pg_advisory_unlock returns false rather than raising, which is how the leak went unseen."""
+    conn = FakeConnection()
+    _bind_engine(monkeypatch, conn)
+    conn.unlock_results = {store._dataset_lock_key(DATASET_A): False}
+
+    async with store._dataset_lock(DATASET_A):
+        pass
+
+    assert conn.invalidated, "a connection that may still hold the lock must not be reused"
+
+
+async def test_release_failure_does_not_mask_the_error_from_the_body(
+    store: PgEmbeddinglessVectorStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class ExplodingConnection(FakeConnection):
+        async def scalar(self, _statement: Any, params: dict[str, Any]) -> bool:
+            raise RuntimeError("connection is gone")
+
+    conn = ExplodingConnection()
+    _bind_engine(monkeypatch, conn)
+
+    with pytest.raises(ValueError, match="body failed"):
+        async with store._dataset_lock(DATASET_A):
+            raise ValueError("body failed")
+
+    assert conn.invalidated


### PR DESCRIPTION
## Applicable issues

- fixes #583 

## Description of changes

Fixed leak of session-level locks on pooled connections.

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.