### PR TITLE
fix: Batch onboarding aborts on the first failing dataset

### DIFF
--- a/statgpt/cli/README.md
+++ b/statgpt/cli/README.md
@@ -129,6 +129,10 @@ statgpt> channel reindex -c my-channel --mode all
 | `--mode`        | `all`, `channel`, or `dataset`           |
 | `--dataset-urn` | Dataset URN (required when mode=dataset) |
 
+In `all` mode each dataset is submitted independently: a dataset the server rejects is
+reported and the rest are still queued. See [Batch Summaries and Exit
+Codes](#batch-summaries-and-exit-codes).
+
 ### content init
 
 ```
@@ -145,16 +149,49 @@ statgpt> content init --datasets urn1,urn2        # specific datasets only
 | `--datasets`  | Comma-separated dataset URNs to process                                  |
 | `-o, --only`  | Components: `channels`, `datasources`, `datasets`, `glossaries`, `files` |
 | `-y, --yes`   | Skip all confirmation prompts and process ALL available content          |
+| `--verify`    | After processing, check each dataset can be loaded from its data source   |
 
 **Notes:**
 
 - Specifying `datasets` automatically includes `datasources` (dependency)
 - Interactive selectors: arrow keys to navigate, space to toggle, enter to confirm
 - **Important:** Using `-y` without `--datasets` processes ALL available datasets for selected clients
+- `--verify` re-reads every dataset from its source server-side, so it costs an extra pass;
+  it catches datasets that were registered successfully but cannot actually be loaded
+  (incompatible structure, unreachable endpoint) and would otherwise never index
 - For non-interactive use in CI/CD, always specify `--client-id` and optionally `--datasets`:
   ```bash
   statgpt --non-interactive content init --client-id my-client --datasets urn1,urn2 -y
   ```
+
+## Batch Summaries and Exit Codes
+
+`content init` and `channel reindex` process many independent items. A failure in one item
+does not stop the others: each item is isolated, and the command prints a summary at the end
+listing what failed or was skipped, with the reason.
+
+```
+Content initialization summary
+┌───────────┬────────────────┬────────────────────────┬───────────────────────┐
+│ Status    │ Type           │ Item                   │ Details               │
+├───────────┼────────────────┼────────────────────────┼───────────────────────┤
+│ FAILED    │ dataset        │ AG:DF_PRICES(1.0)      │ HTTP 400: unsupporte… │
+│ SKIPPED   │ dataset        │ AG:DF_TRADE(1.0)       │ data source 'oecd' i… │
+└───────────┴────────────────┴────────────────────────┴───────────────────────┘
+✗ 1 failed, 1 skipped, 12 ok, 3 unchanged
+```
+
+- `FAILED` — the item itself could not be processed.
+- `SKIPPED` — not attempted, because something it depends on failed or is missing (for
+  example a dataset whose data source failed: registering it without a source would leave it
+  unusable, so it is not attempted).
+
+**Exit code:** these commands exit `1` when any item failed, and `0` only when none did.
+Successes are still applied — a partial failure does not roll anything back.
+
+> If you have CI that treats exit `0` as "everything was onboarded", note that this was
+> previously unreliable: a batch aborted on its first failure and still exited `0` whenever
+> the failure happened to fall on the last item.
 
 ## Environment Variables
 

--- a/statgpt/cli/__init__.py
+++ b/statgpt/cli/__init__.py
@@ -7,6 +7,7 @@ from statgpt.cli.commands import create_registry
 from statgpt.cli.commands.base import CommandRegistry
 from statgpt.cli.repl import run_repl
 from statgpt.cli.settings import cli_runtime
+from statgpt.cli.shared.batch_report import BatchPartialFailureError
 from statgpt.cli.shared.console import console, print_error
 from statgpt.cli.shared.logging import setup_logging
 
@@ -65,6 +66,10 @@ async def _execute_direct(registry: CommandRegistry, args: list[str]) -> int:
             console.print("[dim]Run 'statgpt help' for available commands.[/dim]")
             return 1
         return 0
+    except BatchPartialFailureError:
+        # Some items in a batch failed. The summary is already on screen; report it through
+        # the exit code so a pipeline cannot read a truncated run as a complete one.
+        return 1
     except Exception as e:
         print_error(f"Command failed: {e}")
         if cli_runtime.debug:

--- a/statgpt/cli/commands/base.py
+++ b/statgpt/cli/commands/base.py
@@ -4,6 +4,7 @@ import shlex
 from dataclasses import dataclass, field
 from typing import Any, Callable, Coroutine
 
+from statgpt.cli.shared.batch_report import BatchPartialFailureError
 from statgpt.cli.shared.console import console, print_error
 
 
@@ -181,6 +182,10 @@ class Command:
         except ValueError as e:
             print_error(str(e))
             console.print(f"\n{self.get_help()}")
+        except BatchPartialFailureError:
+            # The batch summary already lists what failed; re-raise quietly so the entry
+            # point can set a non-zero exit code without repeating it.
+            raise
         except Exception as e:
             print_error(f"Command failed: {e}")
             raise

--- a/statgpt/cli/commands/channel.py
+++ b/statgpt/cli/commands/channel.py
@@ -6,6 +6,7 @@ import os
 from collections import Counter
 
 import questionary
+from pydantic import ValidationError
 from rich.table import Table
 
 from statgpt.cli.commands.base import Command, CommandArg, CommandGroup
@@ -18,6 +19,7 @@ from statgpt.cli.shared import (
     print_error,
     print_info,
     print_success,
+    print_warning,
     select_item_interactive,
     spinner_status,
 )
@@ -40,7 +42,11 @@ def _get_urn_display(dataset: DataSet | None) -> str:
     urn_data = dataset.details.get("urn")
     if not urn_data:
         return "N/A"
-    return UrnReference.model_validate(urn_data).short_urn()
+    try:
+        return UrnReference.model_validate(urn_data).short_urn()
+    except ValidationError as e:
+        print_warning(str(e))
+        return str(urn_data)
 
 
 def _dataset_label(dataset: DataSet) -> str:

--- a/statgpt/cli/commands/channel.py
+++ b/statgpt/cli/commands/channel.py
@@ -11,6 +11,7 @@ from rich.table import Table
 from statgpt.cli.commands.base import Command, CommandArg, CommandGroup
 from statgpt.cli.settings import cli_runtime, cli_settings
 from statgpt.cli.shared import (
+    BatchPartialFailureError,
     NonInteractiveError,
     console,
     get_admin_client,
@@ -40,6 +41,12 @@ def _get_urn_display(dataset: DataSet | None) -> str:
     if not urn_data:
         return "N/A"
     return UrnReference.model_validate(urn_data).short_urn()
+
+
+def _dataset_label(dataset: DataSet) -> str:
+    """Name a dataset for a summary line, falling back to its title when it has no URN."""
+    urn = _get_urn_display(dataset)
+    return dataset.title if urn == "N/A" else urn
 
 
 async def import_handler(
@@ -588,11 +595,22 @@ async def reindex_handler(
             msg = "Reindexing all datasets in channel..."
 
         with spinner_status(msg):
-            await client.reload_channel_indicators(
+            report = await client.reload_channel_indicators(
                 channel_id=selected_channel.id,
                 dataset_ids=dataset_ids,
                 max_n_embeddings=max_embeddings,
+                labels={ds.id: _dataset_label(ds) for ds in datasets},
             )
+
+        report.render()
+
+        if report.has_failures:
+            print_info(
+                "Reindexing was not started for the datasets listed above; the rest are"
+                " queued. Check progress with"
+                f" [cyan]channel status -c {selected_channel.deployment_id}[/cyan]"
+            )
+            raise BatchPartialFailureError("Reindexing failed to start for some datasets")
 
         print_success("Reindex operation started")
 

--- a/statgpt/cli/commands/content.py
+++ b/statgpt/cli/commands/content.py
@@ -11,6 +11,8 @@ from statgpt.cli.commands.base import Command, CommandArg, CommandGroup
 from statgpt.cli.settings import cli_settings
 from statgpt.cli.shared import (
     AdminClient,
+    BatchPartialFailureError,
+    BatchReport,
     confirm_interactive,
     console,
     get_admin_client,
@@ -103,7 +105,7 @@ def _load_available_datasets(client_config_dir: str) -> list[tuple[str, str]]:
         return []
 
     datasets: list[tuple[str, str]] = []
-    for filename in os.listdir(datasets_dir):
+    for filename in sorted(os.listdir(datasets_dir)):
         if not filename.endswith(".yaml"):
             continue
         cfg = utils.read_yaml(os.path.join(datasets_dir, filename))
@@ -122,6 +124,7 @@ async def init_handler(
     datasets: str | None = None,
     only: str | None = None,
     yes: bool = False,
+    verify: bool = False,
 ) -> None:
     """Initialize content (channels, data sources, datasets, glossaries)."""
     config_dir = cli_settings.config_dir
@@ -228,32 +231,50 @@ async def init_handler(
             all_datasets = await client.get_datasets()
             existing_datasets = {str(ds.id_): ds for ds in all_datasets}
 
+        report = BatchReport(title="Content initialization summary")
+
         for client_name in available_clients:
             print_info(f"\nProcessing client: {client_name}")
             client_config_dir = os.path.join(clients_dir, client_name)
+            failures_before = len(report.failed)
 
             try:
                 await _process_client(
                     admin_client=client,
+                    report=report,
                     client_id=client_name,
                     client_config_dir=client_config_dir,
                     existing_datasets=existing_datasets,
                     dataset_ids=dataset_ids,
                     components=components,
+                    verify=verify,
                 )
-                print_success(f"Client {client_name} processed successfully")
             except Exception as e:
+                # A client-level failure (an unreadable or invalid top-level config) must
+                # not abandon the clients after it.
                 print_error(f"Failed to process client {client_name}: {e}")
-                raise
+                report.record_failed("client", client_name, str(e))
+                continue
+
+            if len(report.failed) == failures_before:
+                print_success(f"Client {client_name} processed successfully")
+            else:
+                print_warning(f"Client {client_name} processed with failures")
+
+    report.render()
+    if report.has_failures:
+        raise BatchPartialFailureError("Content initialization completed with failures")
 
 
 async def _process_client(
     admin_client: AdminClient,
+    report: BatchReport,
     client_id: str,
     client_config_dir: str,
     existing_datasets: dict[str, DataSet],
     dataset_ids: set[str] | None,
     components: set[str],
+    verify: bool = False,
 ) -> None:
     """Process a single client configuration."""
     # Load configurations
@@ -276,26 +297,36 @@ async def _process_client(
     if "channels" in components:
         process_glossaries = "glossaries" in components
         channels = await _process_channels(
-            admin_client, channel_cfg, tools_cfg, onboarding_cfg, process_glossaries, glossaries_dir
+            admin_client,
+            report,
+            channel_cfg,
+            tools_cfg,
+            onboarding_cfg,
+            process_glossaries,
+            glossaries_dir,
         )
 
     # Process data sources
     data_sources: dict[str, DataSource] = {}
     if "datasources" in components:
         data_sources_cfg = utils.read_yaml(f"{client_config_dir}/data_sources.yaml")
-        data_sources = await _process_data_sources(admin_client, data_sources_cfg)
+        data_sources = await _process_data_sources(admin_client, report, data_sources_cfg)
 
     # Process datasets
     if "datasets" in components:
-        await _process_datasets(
+        touched = await _process_datasets(
             admin_client,
+            report,
             client_id,
             client_config_dir,
             data_sources,
             channels,
             existing_datasets,
             dataset_ids,
+            link_channels="channels" in components,
         )
+        if verify:
+            await _verify_datasets(admin_client, report, touched)
 
 
 async def _upload_dial_files(dial_files_dir: str) -> None:
@@ -425,51 +456,74 @@ def _dataset_changed(
 
 async def _process_channels(
     client: AdminClient,
+    report: BatchReport,
     channel_cfg: dict[str, Any],
     tools_cfg: dict[str, Any],
     onboarding_cfg: dict[str, Any] | None,
     process_glossaries: bool,
     glossaries_dir: str,
 ) -> dict[str, Channel]:
-    """Process channel configurations."""
+    """Process channel configurations.
+
+    Returns only the channels that are now in place; a channel that failed is left out, so
+    datasets referring to it are recorded as skipped rather than linked to nothing.
+    """
     print_info("Processing channels...")
 
     existing = {ch.deployment_id: ch for ch in await client.get_channels()}
     channels: dict[str, Channel] = {}
 
     for ch_cfg in channel_cfg.get("channels", []):
-        deployment_id = ch_cfg["deployment_id"]
+        deployment_id = ch_cfg.get("deployment_id")
+        if not deployment_id:
+            print_error("  Channel config is missing 'deployment_id'")
+            report.record_failed("channel", "<unnamed>", "config is missing 'deployment_id'")
+            continue
 
-        # Add tools to channel config
-        _add_tools_to_channel(ch_cfg, tools_cfg)
-        _add_onboarding_to_channel(ch_cfg, onboarding_cfg)
+        try:
+            # Add tools to channel config
+            _add_tools_to_channel(ch_cfg, tools_cfg)
+            _add_onboarding_to_channel(ch_cfg, onboarding_cfg)
 
-        if deployment_id in existing:
-            existing_ch = existing[deployment_id]
-            if _channel_changed(ch_cfg, existing_ch):
-                _warn_if_deprecated_rag(ch_cfg)
-                channel = await client.update_channel(existing_ch.id, ch_cfg)
-                print_info(f"  Updated channel: {deployment_id}")
+            if deployment_id in existing:
+                existing_ch = existing[deployment_id]
+                if _channel_changed(ch_cfg, existing_ch):
+                    _warn_if_deprecated_rag(ch_cfg)
+                    channel = await client.update_channel(existing_ch.id, ch_cfg)
+                    print_info(f"  Updated channel: {deployment_id}")
+                    report.record_ok("channel", deployment_id)
+                else:
+                    channel = existing_ch
+                    print_info(f"  Channel unchanged: {deployment_id}")
+                    report.record_unchanged("channel", deployment_id)
             else:
-                channel = existing_ch
-                print_info(f"  Channel unchanged: {deployment_id}")
-        else:
-            # Create new channel
-            _warn_if_deprecated_rag(ch_cfg)
-            channel = await client.create_channel(ch_cfg)
-            print_info(f"  Created channel: {deployment_id}")
+                # Create new channel
+                _warn_if_deprecated_rag(ch_cfg)
+                channel = await client.create_channel(ch_cfg)
+                print_info(f"  Created channel: {deployment_id}")
+                report.record_ok("channel", deployment_id)
+        except Exception as e:
+            print_error(f"  Failed channel {deployment_id}: {e}")
+            report.record_failed("channel", deployment_id, str(e))
+            continue
 
         channels[deployment_id] = channel
 
-        # Process glossary
+        # Process glossary. Isolated from the channel itself: the channel is already in
+        # place, so a malformed CSV must not take it back out of `channels`.
         glossary_file = ch_cfg.get("glossary")
         if process_glossaries and glossary_file:
             glossary_path = os.path.join(glossaries_dir, glossary_file)
             if os.path.exists(glossary_path):
-                rows = utils.read_csv_as_dict_list(glossary_path)
-                terms = _parse_glossary_rows(rows, glossary_file)
-                await _process_glossary(client, channel, terms)
-                print_info(f"  Processed glossary: {glossary_file}")
+                try:
+                    rows = utils.read_csv_as_dict_list(glossary_path)
+                    terms = _parse_glossary_rows(rows, glossary_file)
+                    await _process_glossary(client, channel, terms)
+                    print_info(f"  Processed glossary: {glossary_file}")
+                    report.record_ok("glossary", f"{deployment_id}: {glossary_file}")
+                except Exception as e:
+                    print_error(f"  Failed glossary {glossary_file}: {e}")
+                    report.record_failed("glossary", f"{deployment_id}: {glossary_file}", str(e))
 
     return channels
 
@@ -598,9 +652,14 @@ async def _process_glossary(
 
 async def _process_data_sources(
     client: AdminClient,
+    report: BatchReport,
     data_sources_cfg: dict[str, Any],
 ) -> dict[str, DataSource]:
-    """Process data source configurations."""
+    """Process data source configurations.
+
+    Returns only the data sources that are now in place; datasets referring to a failed
+    one are recorded as skipped rather than registered without a source.
+    """
     print_info("Processing data sources...")
 
     existing = {ds.title: ds for ds in await client.get_data_sources()}
@@ -608,24 +667,36 @@ async def _process_data_sources(
     data_sources: dict[str, DataSource] = {}
 
     for ds_cfg in data_sources_cfg.get("dataSources", []):
-        title = ds_cfg["title"]
+        title = ds_cfg.get("title")
+        if not title:
+            print_error("  Data source config is missing 'title'")
+            report.record_failed("data source", "<unnamed>", "config is missing 'title'")
+            continue
 
-        # Replace type name with type_id
-        type_name = ds_cfg.pop("type", None)
-        if type_name:
-            ds_cfg["type_id"] = ds_types.get(type_name)
+        try:
+            # Replace type name with type_id
+            type_name = ds_cfg.pop("type", None)
+            if type_name:
+                ds_cfg["type_id"] = ds_types.get(type_name)
 
-        if title in existing:
-            existing_ds = existing[title]
-            if _data_source_changed(ds_cfg, existing_ds):
-                ds = await client.update_data_source(existing_ds.id, ds_cfg)
-                print_info(f"  Updated data source: {title}")
+            if title in existing:
+                existing_ds = existing[title]
+                if _data_source_changed(ds_cfg, existing_ds):
+                    ds = await client.update_data_source(existing_ds.id, ds_cfg)
+                    print_info(f"  Updated data source: {title}")
+                    report.record_ok("data source", title)
+                else:
+                    ds = existing_ds
+                    print_info(f"  Data source unchanged: {title}")
+                    report.record_unchanged("data source", title)
             else:
-                ds = existing_ds
-                print_info(f"  Data source unchanged: {title}")
-        else:
-            ds = await client.create_data_source(ds_cfg)
-            print_info(f"  Created data source: {title}")
+                ds = await client.create_data_source(ds_cfg)
+                print_info(f"  Created data source: {title}")
+                report.record_ok("data source", title)
+        except Exception as e:
+            print_error(f"  Failed data source {title}: {e}")
+            report.record_failed("data source", title, str(e))
+            continue
 
         data_sources[title] = ds
 
@@ -663,23 +734,36 @@ def _display_channel_results(results: list[ChannelDatasetUpdateResult]) -> None:
 
 async def _process_datasets(
     client: AdminClient,
+    report: BatchReport,
     client_id: str,
     client_config_dir: str,
     data_sources: dict[str, DataSource],
     channels: dict[str, Channel],
     existing_datasets: dict[str, DataSet],
     dataset_ids: set[str] | None,
-) -> None:
-    """Process dataset configurations."""
+    link_channels: bool = True,
+) -> list[tuple[str, DataSet]]:
+    """Process dataset configurations.
+
+    Each dataset is isolated: one that fails is recorded and the rest still run, so a single
+    unsupported dataset cannot truncate the batch.
+
+    Returns:
+        (label, dataset) for every dataset now in place, for optional verification.
+    """
     print_info("Processing datasets...")
+
+    touched: list[tuple[str, DataSet]] = []
 
     datasets_dir = os.path.join(client_config_dir, "datasets")
     if not os.path.exists(datasets_dir):
         print_warning(f"No datasets directory found: {datasets_dir}")
-        return
+        return touched
 
     datasets_cfg: list[dict[str, Any]] = []
-    for filename in os.listdir(datasets_dir):
+    # Sorted so a re-run of the same configs produces the same report; filesystem order
+    # made the truncation point - and so the set of onboarded datasets - look random.
+    for filename in sorted(os.listdir(datasets_dir)):
         if not filename.endswith(".yaml"):
             continue
         file_path = os.path.join(datasets_dir, filename)
@@ -690,56 +774,97 @@ async def _process_datasets(
     datasets_needing_reindex: dict[str, list[str]] = defaultdict(list)
 
     for ds_cfg in datasets_cfg:
-        urn_data = ds_cfg.get("details", {}).get("urn")
-        urn = UrnReference.model_validate(urn_data).short_urn() if urn_data else None
+        try:
+            # Broad: `details` may be absent, null or not a mapping at all. Any malformed
+            # entry has to be reported against itself, not abort the entries after it.
+            details = ds_cfg.get("details") or {}
+            urn_data = details.get("urn")
+            urn = UrnReference.model_validate(urn_data).short_urn() if urn_data else None
+        except Exception as e:
+            title = ds_cfg.get("title") or ds_cfg.get("id_") or "<unnamed>"
+            print_error(f"  Failed dataset {title}: cannot read config: {e}")
+            report.record_failed("dataset", str(title), f"cannot read config: {e}")
+            continue
 
         # Filter by dataset IDs if specified
         if dataset_ids and urn not in dataset_ids:
             continue
 
+        label = urn or ds_cfg.get("title") or str(ds_cfg.get("id_") or "<unnamed>")
+
         # Link to data source
         ds_name = ds_cfg.pop("dataSource", None)
-        if ds_name and ds_name in data_sources:
+        if ds_name:
+            if ds_name not in data_sources:
+                # Registering the dataset without `data_source_id` would either be rejected
+                # or leave it unusable, so do not attempt it - and say which it was waiting on.
+                reason = f"data source '{ds_name}' is not available (failed or not configured)"
+                print_warning(f"  Skipped dataset {label}: {reason}")
+                report.record_skipped("dataset", label, reason)
+                continue
             ds_cfg["data_source_id"] = data_sources[ds_name].id
 
         dataset_id_str = ds_cfg.get("id_")
 
-        if dataset_id_str and dataset_id_str in existing_datasets:
-            existing_dataset = existing_datasets[dataset_id_str]
-            linked_ds = data_sources.get(ds_name) if ds_name else None
-            if _dataset_changed(ds_cfg, existing_dataset, linked_ds):
-                response = await client.update_dataset(existing_dataset.id, ds_cfg)
-                dataset = response.dataset
-                print_info(f"  Updated dataset: {urn}")
+        try:
+            if dataset_id_str and dataset_id_str in existing_datasets:
+                existing_dataset = existing_datasets[dataset_id_str]
+                linked_ds = data_sources.get(ds_name) if ds_name else None
+                if _dataset_changed(ds_cfg, existing_dataset, linked_ds):
+                    response = await client.update_dataset(existing_dataset.id, ds_cfg)
+                    dataset = response.dataset
+                    print_info(f"  Updated dataset: {urn}")
+                    report.record_ok("dataset", label)
 
-                # Display channel datasets update results
-                _display_channel_results(response.channel_results)
+                    # Display channel datasets update results
+                    _display_channel_results(response.channel_results)
 
-                # Collect datasets needing reindex for summary
-                for r in response.channel_results:
-                    if r.status == ChannelDatasetUpdateStatus.NEEDS_REINDEX:
-                        datasets_needing_reindex[r.channel.deployment_id].append(urn or "None")
+                    # Collect datasets needing reindex for summary
+                    for r in response.channel_results:
+                        if r.status == ChannelDatasetUpdateStatus.NEEDS_REINDEX:
+                            datasets_needing_reindex[r.channel.deployment_id].append(urn or "None")
+                else:
+                    dataset = existing_dataset
+                    print_info(f"  Dataset unchanged: {urn}")
+                    report.record_unchanged("dataset", label)
             else:
-                dataset = existing_dataset
-                print_info(f"  Dataset unchanged: {urn}")
-        else:
-            dataset = await client.create_dataset(ds_cfg)
-            print_info(f"  Created dataset: {urn}")
+                dataset = await client.create_dataset(ds_cfg)
+                print_info(f"  Created dataset: {urn}")
+                report.record_ok("dataset", label)
+        except Exception as e:
+            print_error(f"  Failed dataset {label}: {e}")
+            report.record_failed("dataset", label, str(e))
+            continue
+
+        touched.append((label, dataset))
 
         # Link to channels
+        if not link_channels:
+            continue
+
         for ch_name in ds_cfg.get("channels", []):
             if ch_name not in channels:
+                # Recorded rather than passed over silently: an unlinked dataset is invisible
+                # to the chat backend, which reads as "onboarded but never indexed".
+                reason = f"channel '{ch_name}' is not available (failed or not configured)"
+                print_warning(f"    Not linked to channel {ch_name}: {reason}")
+                report.record_skipped("dataset link", f"{label} -> {ch_name}", reason)
                 continue
+
             channel = channels[ch_name]
             ch_id = channel.id
 
-            if ch_id not in channel_datasets:
-                channel_datasets[ch_id] = await client.get_channel_datasets(ch_id)
+            try:
+                if ch_id not in channel_datasets:
+                    channel_datasets[ch_id] = await client.get_channel_datasets(ch_id)
 
-            # Check if already linked
-            if not any(cd.dataset_id == dataset.id for cd in channel_datasets[ch_id]):
-                await client.add_dataset_to_channel(ch_id, dataset.id)
-                print_info(f"    Linked to channel: {ch_name}")
+                # Check if already linked
+                if not any(cd.dataset_id == dataset.id for cd in channel_datasets[ch_id]):
+                    await client.add_dataset_to_channel(ch_id, dataset.id)
+                    print_info(f"    Linked to channel: {ch_name}")
+            except Exception as e:
+                print_error(f"    Failed to link {label} to channel {ch_name}: {e}")
+                report.record_failed("dataset link", f"{label} -> {ch_name}", str(e))
 
     if datasets_needing_reindex:
         print_info("-" * 50)
@@ -747,6 +872,47 @@ async def _process_datasets(
         for ch_deployment_id, ds_urns in datasets_needing_reindex.items():
             ds_list = ", ".join(ds_urns)
             print_warning(f"    {ch_deployment_id}: {ds_list}")
+
+    return touched
+
+
+async def _verify_datasets(
+    client: AdminClient,
+    report: BatchReport,
+    touched: list[tuple[str, DataSet]],
+) -> None:
+    """Report datasets that are registered but cannot be loaded from their data source.
+
+    A dataset can be created and linked successfully and still be unusable - an
+    incompatible DSD, an unreachable endpoint - in which case it never indexes and never
+    answers a question. The admin API loads datasets tolerantly and reports that as a
+    per-dataset ``status``, so re-reading them turns a silent gap into a summary line.
+
+    This re-loads every dataset from its source server side, so it is opt-in.
+    """
+    if not touched:
+        return
+
+    print_info("Verifying dataset status...")
+
+    try:
+        current = {str(ds.id_): ds for ds in await client.get_datasets()}
+    except Exception as e:
+        print_error(f"Could not verify dataset status: {e}")
+        report.record_failed("verification", "all datasets", str(e))
+        return
+
+    for label, dataset in touched:
+        latest = current.get(str(dataset.id_))
+        if latest is None:
+            report.record_failed("dataset status", label, "dataset is not registered")
+            continue
+        if latest.status.status == "online":
+            continue
+
+        details = latest.status.details or "no details provided"
+        print_error(f"  {label} is {latest.status.status}: {details}")
+        report.record_failed("dataset status", label, f"{latest.status.status}: {details}")
 
 
 init_command = Command(
@@ -771,6 +937,14 @@ init_command = Command(
             name="yes",
             short_name="y",
             description="Skip confirmation prompt",
+            is_flag=True,
+        ),
+        CommandArg(
+            name="verify",
+            description=(
+                "After processing, check that each dataset can be loaded from its data"
+                " source (re-reads every dataset server-side)"
+            ),
             is_flag=True,
         ),
     ],

--- a/statgpt/cli/commands/content.py
+++ b/statgpt/cli/commands/content.py
@@ -232,6 +232,7 @@ async def init_handler(
             existing_datasets = {str(ds.id_): ds for ds in all_datasets}
 
         report = BatchReport(title="Content initialization summary")
+        touched: list[tuple[str, DataSet]] = []
 
         for client_name in available_clients:
             print_info(f"\nProcessing client: {client_name}")
@@ -239,15 +240,16 @@ async def init_handler(
             failures_before = len(report.failed)
 
             try:
-                await _process_client(
-                    admin_client=client,
-                    report=report,
-                    client_id=client_name,
-                    client_config_dir=client_config_dir,
-                    existing_datasets=existing_datasets,
-                    dataset_ids=dataset_ids,
-                    components=components,
-                    verify=verify,
+                touched.extend(
+                    await _process_client(
+                        admin_client=client,
+                        report=report,
+                        client_id=client_name,
+                        client_config_dir=client_config_dir,
+                        existing_datasets=existing_datasets,
+                        dataset_ids=dataset_ids,
+                        components=components,
+                    )
                 )
             except Exception as e:
                 # A client-level failure (an unreadable or invalid top-level config) must
@@ -260,6 +262,11 @@ async def init_handler(
                 print_success(f"Client {client_name} processed successfully")
             else:
                 print_warning(f"Client {client_name} processed with failures")
+
+        # Verified once for every client at the end: the extra pass re-reads the whole dataset
+        # list, and doing that per client would repeat it for no extra information.
+        if verify:
+            await _verify_datasets(client, report, touched)
 
     report.render()
     if report.has_failures:
@@ -274,9 +281,12 @@ async def _process_client(
     existing_datasets: dict[str, DataSet],
     dataset_ids: set[str] | None,
     components: set[str],
-    verify: bool = False,
-) -> None:
-    """Process a single client configuration."""
+) -> list[tuple[str, DataSet]]:
+    """Process a single client configuration.
+
+    Returns:
+        (label, dataset) for every dataset now in place, for optional verification.
+    """
     # Load configurations
     tools_cfg = utils.read_yaml(f"{client_config_dir}/tools.yaml")
     channel_cfg = utils.read_yaml(f"{client_config_dir}/channels.yaml")
@@ -288,7 +298,7 @@ async def _process_client(
     # Upload DIAL files
     if "files" in components:
         if os.path.exists(dial_files_dir):
-            await _upload_dial_files(dial_files_dir)
+            await _upload_dial_files(report, client_id, dial_files_dir)
         else:
             print_info(f"No DIAL files directory found at {dial_files_dir}")
 
@@ -313,29 +323,35 @@ async def _process_client(
         data_sources = await _process_data_sources(admin_client, report, data_sources_cfg)
 
     # Process datasets
-    if "datasets" in components:
-        touched = await _process_datasets(
-            admin_client,
-            report,
-            client_id,
-            client_config_dir,
-            data_sources,
-            channels,
-            existing_datasets,
-            dataset_ids,
-            link_channels="channels" in components,
-        )
-        if verify:
-            await _verify_datasets(admin_client, report, touched)
+    if "datasets" not in components:
+        return []
+
+    return await _process_datasets(
+        admin_client,
+        report,
+        client_id,
+        client_config_dir,
+        data_sources,
+        channels,
+        existing_datasets,
+        dataset_ids,
+        link_channels="channels" in components,
+    )
 
 
-async def _upload_dial_files(dial_files_dir: str) -> None:
-    """Upload files to DIAL storage."""
+async def _upload_dial_files(report: BatchReport, client_id: str, dial_files_dir: str) -> None:
+    """Upload files to DIAL storage.
+
+    Each file is isolated and recorded: one that fails does not stop the rest, and the summary
+    accounts for the upload rather than reporting "nothing to do" over the top of it.
+    """
     dial_url = cli_settings.dial_url
     dial_api_key = cli_settings.dial_api_key
 
     if not dial_url or not dial_api_key:
-        print_warning("DIAL credentials not configured, skipping file upload")
+        reason = "DIAL credentials are not configured"
+        print_warning(f"{reason}, skipping file upload")
+        report.record_skipped("files", client_id, reason)
         return
 
     print_info("Uploading files to DIAL...")
@@ -350,11 +366,20 @@ async def _upload_dial_files(dial_files_dir: str) -> None:
                     mime_type = _get_mime_type(file)
                     print_info(f"  Uploading: {dial_path}")
 
-                    with open(file_path, "rb") as f:
-                        content = f.read()
+                    try:
+                        with open(file_path, "rb") as f:
+                            content = f.read()
                         await storage.put_file(dial_path, mime_type, content)
+                    except Exception as e:
+                        print_error(f"  Failed file {dial_path}: {e}")
+                        report.record_failed("file", dial_path, str(e))
+                        continue
+
+                    report.record_ok("file", dial_path)
     except Exception as e:
+        # Reaching DIAL at all failed, so nothing after this point would upload either.
         print_error(f"Failed to connect to DIAL: {e}")
+        report.record_failed("files", client_id, str(e))
         return
 
 

--- a/statgpt/cli/repl.py
+++ b/statgpt/cli/repl.py
@@ -11,6 +11,7 @@ from statgpt.cli.commands.base import CommandRegistry
 from statgpt.cli.completer import StatGPTCompleter
 from statgpt.cli.settings import cli_runtime, cli_settings
 from statgpt.cli.shared.auth import get_token_info, is_logged_in
+from statgpt.cli.shared.batch_report import BatchPartialFailureError
 from statgpt.cli.shared.console import console, print_banner, print_error
 
 # Prompt style
@@ -146,6 +147,9 @@ class REPL:
                 self._running = False
                 console.print("\n[dim]Goodbye![/dim]")
                 break
+            except BatchPartialFailureError:
+                # The batch summary already lists what failed; nothing to add here.
+                continue
             except Exception as e:
                 print_error(f"Error: {e}")
                 if cli_runtime.debug:

--- a/statgpt/cli/shared/__init__.py
+++ b/statgpt/cli/shared/__init__.py
@@ -17,6 +17,12 @@ from statgpt.cli.shared.auth import (
     login,
     register_provider,
 )
+from statgpt.cli.shared.batch_report import (
+    BatchItemResult,
+    BatchItemStatus,
+    BatchPartialFailureError,
+    BatchReport,
+)
 from statgpt.cli.shared.console import (
     SpinnerStatus,
     console,
@@ -68,6 +74,11 @@ __all__ = [
     "AdminClient",
     "AuthenticationRequired",
     "get_admin_client",
+    # Batch reporting
+    "BatchItemResult",
+    "BatchItemStatus",
+    "BatchPartialFailureError",
+    "BatchReport",
     # Logging
     "setup_logging",
     "get_logger",

--- a/statgpt/cli/shared/admin_client.py
+++ b/statgpt/cli/shared/admin_client.py
@@ -9,6 +9,7 @@ from pydantic import TypeAdapter
 
 from statgpt.cli.settings import cli_settings
 from statgpt.cli.shared.auth import get_cached_token
+from statgpt.cli.shared.batch_report import BatchReport
 from statgpt.common.schemas import (
     Channel,
     ChannelDatasetBase,
@@ -53,6 +54,41 @@ class AuthenticationRequired(Exception):
 
     def __init__(self) -> None:
         super().__init__("Authentication required. Run 'auth login' first.")
+
+
+def _detail_text(detail: Any) -> str | None:
+    """Human-readable text from a FastAPI ``detail`` payload, whatever shape it has.
+
+    The reindex endpoints answer with ``InvalidConfigurationError.to_dict()`` - a dict
+    carrying ``error`` - either on its own or inside a list, while validation errors use
+    ``msg`` and plain aborts use a string.
+    """
+    if isinstance(detail, str):
+        return detail or None
+    if isinstance(detail, dict):
+        for key in ("error", "msg", "message"):
+            value = detail.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return None
+    if isinstance(detail, list):
+        parts = [text for text in (_detail_text(item) for item in detail) if text]
+        return "; ".join(parts) or None
+    return None
+
+
+def _describe_error(resp: httpx.Response) -> str:
+    """One-line reason for a failed response, preferring the API's ``detail`` field."""
+    prefix = f"HTTP {resp.status_code}"
+    try:
+        payload = resp.json()
+    except ValueError:
+        payload = None
+
+    text = _detail_text(payload.get("detail")) if isinstance(payload, dict) else None
+    if not text:
+        text = resp.text.strip()
+    return f"{prefix}: {text}" if text else prefix
 
 
 class AdminClient:
@@ -215,23 +251,59 @@ class AdminClient:
         channel_id: int,
         dataset_ids: list[int] | None = None,
         max_n_embeddings: int | None = None,
-    ) -> None:
-        """Reload indicators for channel or specific datasets."""
+        labels: dict[int, str] | None = None,
+    ) -> BatchReport:
+        """Reload indicators for a channel or for specific datasets.
+
+        Per-dataset rejections are recorded and do not stop the datasets after them: the
+        endpoint answers 400 for a dataset whose configuration cannot be loaded, and one
+        such dataset must not block a bulk reindex.
+
+        Authentication failures still raise, since they are not a per-dataset problem and
+        would otherwise be reported once per dataset.
+
+        Args:
+            channel_id: Channel to reindex.
+            dataset_ids: Datasets to reindex, or None to reindex the whole channel.
+            max_n_embeddings: Debugging cap on the number of documents embedded.
+            labels: Dataset id -> display name (a URN), so the summary is readable.
+
+        Returns:
+            One result per submitted dataset.
+        """
         params: dict[str, Any] = {}
         if max_n_embeddings is not None:
             params["max_n_embeddings"] = max_n_embeddings
+
+        report = BatchReport(title="Reindex summary")
 
         if dataset_ids is None:
             # Reload all datasets in channel
             url = self._url(f"/channels/{channel_id}/datasets/reload-indicators")
             resp = await self._client.post(url, params=params)
-            self._raise_for_status(resp)
-        else:
-            # Reload specific datasets
-            for dataset_id in dataset_ids:
-                url = self._url(f"/channels/{channel_id}/datasets/{dataset_id}/reload-indicators")
-                resp = await self._client.post(url, params=params)
+            if resp.is_success:
+                report.record_ok("channel", str(channel_id))
+            else:
+                report.record_failed("channel", str(channel_id), _describe_error(resp))
+            return report
+
+        # Reload specific datasets
+        for dataset_id in dataset_ids:
+            label = (labels or {}).get(dataset_id) or str(dataset_id)
+            url = self._url(f"/channels/{channel_id}/datasets/{dataset_id}/reload-indicators")
+            resp = await self._client.post(url, params=params)
+
+            if resp.is_success:
+                report.record_ok("dataset", label)
+                continue
+            if resp.status_code in (401, 403):
                 self._raise_for_status(resp)
+
+            detail = _describe_error(resp)
+            _log.warning("Reindex rejected for dataset %s: %s", label, detail)
+            report.record_failed("dataset", label, detail)
+
+        return report
 
     async def deduplicate_channel(self, channel_id: int) -> DeduplicationJob:
         """Trigger channel deduplication; returns the created job for polling."""

--- a/statgpt/cli/shared/batch_report.py
+++ b/statgpt/cli/shared/batch_report.py
@@ -1,0 +1,156 @@
+"""Per-item outcome tracking for batch CLI operations.
+
+Batch commands (``content init``, ``channel reindex``) process many independent items.
+A failure in one item must not stop the ones after it, otherwise a single unsupported
+dataset silently truncates the batch and which datasets survive depends on the order
+the configs happen to be read in. Handlers therefore record an outcome per item and
+render one summary at the end, instead of raising on the first error.
+"""
+
+from collections import Counter
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+from rich.markup import escape
+from rich.table import Table
+
+from statgpt.cli.shared.console import console, print_error, print_success, print_warning
+
+# Error bodies and titles are arbitrary text; keep a single table cell readable.
+_MAX_MESSAGE_LENGTH = 300
+
+
+class BatchPartialFailureError(Exception):
+    """Raised after a batch summary has been rendered, when at least one item failed.
+
+    The summary already explains what went wrong, so the CLI entry points map this to a
+    non-zero exit code without printing another error line on top of it.
+    """
+
+
+class BatchItemStatus(StrEnum):
+    OK = "ok"
+    UNCHANGED = "unchanged"
+    SKIPPED = "skipped"
+    """Not attempted, because something it depends on failed or is missing."""
+    FAILED = "failed"
+
+
+# Statuses worth listing individually: the ones a user has to act on. Successes are
+# already reported inline while the batch runs.
+_ACTIONABLE = (BatchItemStatus.FAILED, BatchItemStatus.SKIPPED)
+
+_RENDER_ORDER = {
+    BatchItemStatus.FAILED: 0,
+    BatchItemStatus.SKIPPED: 1,
+    BatchItemStatus.OK: 2,
+    BatchItemStatus.UNCHANGED: 3,
+}
+
+_STATUS_STYLES = {
+    BatchItemStatus.FAILED: "red",
+    BatchItemStatus.SKIPPED: "yellow",
+    BatchItemStatus.OK: "green",
+    BatchItemStatus.UNCHANGED: "dim",
+}
+
+
+def _one_line(message: str | None) -> str:
+    """Collapse a message to a single truncated line fit for a table cell."""
+    if not message:
+        return ""
+    collapsed = " ".join(message.split())
+    if len(collapsed) > _MAX_MESSAGE_LENGTH:
+        collapsed = collapsed[: _MAX_MESSAGE_LENGTH - 1].rstrip() + "…"
+    return collapsed
+
+
+class BatchItemResult(BaseModel):
+    kind: str = Field(description="What the item is, e.g. 'dataset' or 'data source'")
+    item_id: str = Field(description="How the user identifies the item, e.g. a dataset URN")
+    status: BatchItemStatus
+    message: str | None = Field(
+        default=None, description="Why it failed, or what it was waiting on when skipped"
+    )
+
+
+class BatchReport(BaseModel):
+    """Accumulates per-item outcomes of one batch operation."""
+
+    title: str
+    items: list[BatchItemResult] = Field(default_factory=list)
+
+    def record(
+        self, kind: str, item_id: str, status: BatchItemStatus, message: str | None = None
+    ) -> None:
+        self.items.append(
+            BatchItemResult(kind=kind, item_id=item_id, status=status, message=message)
+        )
+
+    def record_ok(self, kind: str, item_id: str) -> None:
+        self.record(kind, item_id, BatchItemStatus.OK)
+
+    def record_unchanged(self, kind: str, item_id: str) -> None:
+        self.record(kind, item_id, BatchItemStatus.UNCHANGED)
+
+    def record_skipped(self, kind: str, item_id: str, message: str) -> None:
+        self.record(kind, item_id, BatchItemStatus.SKIPPED, message)
+
+    def record_failed(self, kind: str, item_id: str, message: str) -> None:
+        self.record(kind, item_id, BatchItemStatus.FAILED, message)
+
+    @property
+    def failed(self) -> list[BatchItemResult]:
+        return [item for item in self.items if item.status == BatchItemStatus.FAILED]
+
+    @property
+    def skipped(self) -> list[BatchItemResult]:
+        return [item for item in self.items if item.status == BatchItemStatus.SKIPPED]
+
+    @property
+    def has_failures(self) -> bool:
+        return any(item.status == BatchItemStatus.FAILED for item in self.items)
+
+    def extend(self, other: "BatchReport") -> None:
+        """Merge another report's items into this one, keeping this report's title."""
+        self.items.extend(other.items)
+
+    def counts(self) -> dict[BatchItemStatus, int]:
+        counter = Counter(item.status for item in self.items)
+        return {status: counter[status] for status in _RENDER_ORDER if counter[status]}
+
+    def render(self) -> None:
+        """Print failures and skips as a table, then a count per status."""
+        console.print()
+        console.print(f"[bold cyan]{escape(self.title)}[/bold cyan]")
+
+        if not self.items:
+            console.print("[dim]Nothing to do.[/dim]")
+            return
+
+        actionable = [item for item in self.items if item.status in _ACTIONABLE]
+        if actionable:
+            table = Table(show_header=True, header_style="bold")
+            table.add_column("Status", width=9)
+            table.add_column("Type", width=14)
+            table.add_column("Item", ratio=2)
+            table.add_column("Details", ratio=3)
+
+            for item in sorted(actionable, key=lambda i: (_RENDER_ORDER[i.status], i.item_id)):
+                style = _STATUS_STYLES[item.status]
+                table.add_row(
+                    f"[{style}]{item.status.value.upper()}[/{style}]",
+                    escape(item.kind),
+                    escape(item.item_id),
+                    escape(_one_line(item.message)),
+                )
+
+            console.print(table)
+
+        summary = ", ".join(f"{count} {status.value}" for status, count in self.counts().items())
+        if self.has_failures:
+            print_error(summary)
+        elif self.skipped:
+            print_warning(summary)
+        else:
+            print_success(summary)

--- a/statgpt/cli/shared/batch_report.py
+++ b/statgpt/cli/shared/batch_report.py
@@ -111,10 +111,6 @@ class BatchReport(BaseModel):
     def has_failures(self) -> bool:
         return any(item.status == BatchItemStatus.FAILED for item in self.items)
 
-    def extend(self, other: "BatchReport") -> None:
-        """Merge another report's items into this one, keeping this report's title."""
-        self.items.extend(other.items)
-
     def counts(self) -> dict[BatchItemStatus, int]:
         counter = Counter(item.status for item in self.items)
         return {status: counter[status] for status in _RENDER_ORDER if counter[status]}

--- a/tests/unit/cli/commands/test_channel_dataset_labels.py
+++ b/tests/unit/cli/commands/test_channel_dataset_labels.py
@@ -1,0 +1,56 @@
+"""Tests that labelling a channel's datasets cannot abort the batch being labelled.
+
+`channel reindex` builds a label for every dataset in the channel up front, so a single
+dataset whose `details["urn"]` cannot be parsed must not stop the others from being submitted.
+"""
+
+import datetime
+import uuid
+from typing import Any
+
+from statgpt.cli.commands.channel import _dataset_label, _get_urn_display
+from statgpt.common.schemas import DataSet
+from statgpt.common.schemas.dataset import Status
+
+_NOW = datetime.datetime(2026, 1, 1)
+
+
+def _dataset(title: str, details: dict[str, Any]) -> DataSet:
+    return DataSet(
+        id=1,
+        id_=uuid.uuid5(uuid.NAMESPACE_URL, title),
+        created_at=_NOW,
+        updated_at=_NOW,
+        title=title,
+        description="",
+        data_source_id=1,
+        details=details,
+        data_source=None,
+        status=Status(status="online"),
+    )
+
+
+def test_a_valid_urn_is_labelled_by_its_short_form() -> None:
+    dataset = _dataset(
+        "Prices", {"urn": {"agency_id": "AG", "resource_id": "DF_A", "version": "1.0"}}
+    )
+
+    assert _dataset_label(dataset) == "AG:DF_A(1.0)"
+
+
+def test_a_dataset_without_a_urn_falls_back_to_its_title() -> None:
+    assert _dataset_label(_dataset("Prices", {})) == "Prices"
+
+
+def test_an_unparseable_urn_does_not_raise(capsys) -> None:
+    """A junk `urn` block used to raise ValidationError and abort the whole reindex."""
+    dataset = _dataset("Prices", {"urn": {"nope": 1}})
+
+    label = _dataset_label(dataset)
+
+    assert label, "the dataset still needs a name in the summary"
+    assert "validation error" in capsys.readouterr().out, "the malformed config is still reported"
+
+
+def test_a_urn_that_is_not_a_mapping_does_not_raise() -> None:
+    assert _get_urn_display(_dataset("Prices", {"urn": "AG:DF_A(1.0)"}))

--- a/tests/unit/cli/commands/test_content_init_isolation.py
+++ b/tests/unit/cli/commands/test_content_init_isolation.py
@@ -1,0 +1,328 @@
+"""Tests that one failing dataset does not truncate a `content init` batch.
+
+The customer's reproduction, as a test: several valid dataset configs plus one that fails.
+Every valid dataset must be processed and the bad one reported, whatever order the config
+files happen to be read in.
+"""
+
+import datetime
+import os
+import uuid
+from typing import Any
+
+import pytest
+import yaml
+
+from statgpt.cli.commands.content import _process_datasets, _verify_datasets
+from statgpt.cli.shared.batch_report import BatchReport
+from statgpt.common.schemas import Channel, DataSet, DataSource, DataSourceType
+from statgpt.common.schemas.dataset import Status
+
+_NOW = datetime.datetime(2026, 1, 1)
+_SOURCE_TITLE = "sdmx-source"
+
+
+def _urn(resource_id: str) -> dict[str, Any]:
+    return {"agency_id": "AG", "resource_id": resource_id, "version": "1.0"}
+
+
+def _dataset_cfg(resource_id: str, *, source: str | None = _SOURCE_TITLE) -> dict[str, Any]:
+    cfg: dict[str, Any] = {
+        "title": resource_id,
+        "details": {"urn": _urn(resource_id)},
+        "channels": ["channel-a"],
+    }
+    if source is not None:
+        cfg["dataSource"] = source
+    return cfg
+
+
+def _data_source() -> DataSource:
+    return DataSource(
+        id=1,
+        created_at=_NOW,
+        updated_at=_NOW,
+        title=_SOURCE_TITLE,
+        description="",
+        type_id=3,
+        details={},
+        type=DataSourceType(id=3, created_at=_NOW, updated_at=_NOW, name="SDMX21", description=""),
+    )
+
+
+def _dataset(title: str, *, status: str = "online", details: str = "") -> DataSet:
+    return DataSet(
+        id=abs(hash(title)) % 10_000,
+        id_=uuid.uuid5(uuid.NAMESPACE_URL, title),
+        created_at=_NOW,
+        updated_at=_NOW,
+        title=title,
+        description="",
+        data_source_id=1,
+        details={"urn": _urn(title)},
+        data_source=None,
+        status=Status(status=status, details=details),
+    )
+
+
+class _StubAdminClient:
+    """Minimal stand-in for AdminClient, recording what the batch actually attempted."""
+
+    def __init__(self, failing_titles: set[str] | None = None):
+        self._failing_titles = failing_titles or set()
+        self.created: list[str] = []
+        self.linked: list[tuple[int, int]] = []
+        self.all_datasets: list[DataSet] = []
+
+    async def create_dataset(self, ds_cfg: dict[str, Any]) -> DataSet:
+        title = ds_cfg["title"]
+        if title in self._failing_titles:
+            raise RuntimeError(f"unsupported DSD for {title}")
+        self.created.append(title)
+        return _dataset(title)
+
+    async def get_channel_datasets(self, channel_id: int) -> list[Any]:
+        return []
+
+    async def add_dataset_to_channel(self, channel_id: int, dataset_id: int) -> None:
+        self.linked.append((channel_id, dataset_id))
+
+    async def get_datasets(self, channel_id: int | None = None, limit: int = 5000):
+        return self.all_datasets
+
+
+def _write_configs(datasets_dir: str, configs: dict[str, list[dict[str, Any]]]) -> None:
+    """Write one YAML file per entry, so filename order is under the test's control."""
+    os.makedirs(datasets_dir, exist_ok=True)
+    for filename, datasets in configs.items():
+        with open(os.path.join(datasets_dir, filename), "w", encoding="utf-8") as f:
+            yaml.safe_dump({"dataSets": datasets}, f)
+
+
+async def _run(
+    tmp_path,
+    configs: dict[str, list[dict[str, Any]]],
+    *,
+    client: _StubAdminClient,
+    channels: dict[str, Any] | None = None,
+    data_sources: dict[str, DataSource] | None = None,
+    link_channels: bool = True,
+) -> tuple[BatchReport, list[tuple[str, DataSet]]]:
+    _write_configs(os.path.join(str(tmp_path), "datasets"), configs)
+    report = BatchReport(title="Summary")
+
+    touched = await _process_datasets(
+        client,  # type: ignore[arg-type]
+        report,
+        "client-a",
+        str(tmp_path),
+        {_SOURCE_TITLE: _data_source()} if data_sources is None else data_sources,
+        {"channel-a": _channel()} if channels is None else channels,
+        {},
+        None,
+        link_channels=link_channels,
+    )
+    return report, touched
+
+
+def _channel() -> Channel:
+    return Channel(
+        id=11,
+        created_at=_NOW,
+        updated_at=_NOW,
+        deployment_id="channel-a",
+        title="Channel A",
+        description="",
+        llm_model="gpt-4o",
+        details={  # type: ignore[arg-type]
+            "supremeAgent": {"name": "bot", "domain": "stats", "terminologyDomain": "stats"}
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_failing_dataset_does_not_stop_the_ones_after_it(tmp_path) -> None:
+    client = _StubAdminClient(failing_titles={"DF_B"})
+
+    report, _ = await _run(
+        tmp_path,
+        {
+            "a.yaml": [_dataset_cfg("DF_A")],
+            "b.yaml": [_dataset_cfg("DF_B")],
+            "c.yaml": [_dataset_cfg("DF_C")],
+            "d.yaml": [_dataset_cfg("DF_D")],
+        },
+        client=client,
+    )
+
+    assert client.created == ["DF_A", "DF_C", "DF_D"]
+    assert [item.item_id for item in report.failed] == ["AG:DF_B(1.0)"]
+    assert "unsupported DSD for DF_B" in (report.failed[0].message or "")
+    assert report.has_failures
+
+
+@pytest.mark.asyncio
+async def test_the_report_does_not_depend_on_config_file_order(tmp_path) -> None:
+    """Renaming the failing config used to change which datasets got onboarded."""
+    forward = _StubAdminClient(failing_titles={"DF_B"})
+    report_forward, _ = await _run(
+        tmp_path / "forward",
+        {
+            "01_a.yaml": [_dataset_cfg("DF_A")],
+            "02_b.yaml": [_dataset_cfg("DF_B")],
+            "03_c.yaml": [_dataset_cfg("DF_C")],
+        },
+        client=forward,
+    )
+
+    reverse = _StubAdminClient(failing_titles={"DF_B"})
+    report_reverse, _ = await _run(
+        tmp_path / "reverse",
+        {
+            "01_c.yaml": [_dataset_cfg("DF_C")],
+            "02_b.yaml": [_dataset_cfg("DF_B")],
+            "03_a.yaml": [_dataset_cfg("DF_A")],
+        },
+        client=reverse,
+    )
+
+    assert sorted(forward.created) == sorted(reverse.created) == ["DF_A", "DF_C"]
+    assert {(i.item_id, i.status) for i in report_forward.items} == {
+        (i.item_id, i.status) for i in report_reverse.items
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_dataset_whose_data_source_is_unavailable_is_skipped_not_created(tmp_path) -> None:
+    """Creating it without `data_source_id` would leave it unusable, so do not try."""
+    client = _StubAdminClient()
+
+    report, _ = await _run(
+        tmp_path,
+        {"a.yaml": [_dataset_cfg("DF_A"), _dataset_cfg("DF_B", source="missing-source")]},
+        client=client,
+    )
+
+    assert client.created == ["DF_A"]
+    assert not report.has_failures, "a knock-on skip is not a failure of the dataset itself"
+    assert [item.item_id for item in report.skipped] == ["AG:DF_B(1.0)"]
+    assert "missing-source" in (report.skipped[0].message or "")
+
+
+@pytest.mark.asyncio
+async def test_a_dataset_with_no_data_source_key_is_still_processed(tmp_path) -> None:
+    """Configs may carry `data_source_id` directly; that path must keep working."""
+    client = _StubAdminClient()
+
+    report, _ = await _run(tmp_path, {"a.yaml": [_dataset_cfg("DF_A", source=None)]}, client=client)
+
+    assert client.created == ["DF_A"]
+    assert not report.has_failures
+    assert not report.skipped
+
+
+@pytest.mark.asyncio
+async def test_an_unavailable_channel_is_recorded_rather_than_passed_over(tmp_path) -> None:
+    """An unlinked dataset is invisible to the chat backend; that must not be silent."""
+    client = _StubAdminClient()
+
+    report, _ = await _run(tmp_path, {"a.yaml": [_dataset_cfg("DF_A")]}, client=client, channels={})
+
+    assert client.created == ["DF_A"]
+    assert client.linked == []
+    assert [item.item_id for item in report.skipped] == ["AG:DF_A(1.0) -> channel-a"]
+
+
+@pytest.mark.asyncio
+async def test_no_channel_noise_when_channels_were_not_requested(tmp_path) -> None:
+    """`--only datasets` does not process channels, so absent links are expected."""
+    client = _StubAdminClient()
+
+    report, _ = await _run(
+        tmp_path, {"a.yaml": [_dataset_cfg("DF_A")]}, client=client, link_channels=False
+    )
+
+    assert client.created == ["DF_A"]
+    assert not report.skipped
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_urn_is_reported_against_the_dataset(tmp_path) -> None:
+    client = _StubAdminClient()
+
+    report, _ = await _run(
+        tmp_path,
+        {"a.yaml": [{"title": "DF_BAD", "details": {"urn": {"nope": 1}}}, _dataset_cfg("DF_A")]},
+        client=client,
+    )
+
+    assert client.created == ["DF_A"]
+    assert [item.item_id for item in report.failed] == ["DF_BAD"]
+    assert "cannot read config" in (report.failed[0].message or "")
+
+
+@pytest.mark.asyncio
+async def test_a_null_details_block_does_not_abort_the_batch(tmp_path) -> None:
+    """`details:` with no value reads back as None, and `None.get(...)` would raise.
+
+    A dataset with no URN is tolerated (it is simply labelled by title), so the point here
+    is that reading the config cannot throw its way out of the loop.
+    """
+    client = _StubAdminClient()
+
+    report, _ = await _run(
+        tmp_path,
+        {"a.yaml": [{"title": "DF_NO_URN", "details": None}, _dataset_cfg("DF_A")]},
+        client=client,
+    )
+
+    assert client.created == ["DF_NO_URN", "DF_A"]
+    assert not report.has_failures
+    assert [item.item_id for item in report.items] == ["DF_NO_URN", "AG:DF_A(1.0)"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_link_does_not_lose_the_dataset(tmp_path) -> None:
+    client = _StubAdminClient()
+
+    async def _boom(channel_id: int, dataset_id: int) -> None:
+        raise RuntimeError("link rejected")
+
+    client.add_dataset_to_channel = _boom  # type: ignore[method-assign]
+
+    report, touched = await _run(tmp_path, {"a.yaml": [_dataset_cfg("DF_A")]}, client=client)
+
+    assert client.created == ["DF_A"]
+    assert [label for label, _ in touched] == ["AG:DF_A(1.0)"]
+    assert [item.item_id for item in report.failed] == ["AG:DF_A(1.0) -> channel-a"]
+
+
+@pytest.mark.asyncio
+async def test_verification_reports_a_dataset_that_cannot_be_loaded() -> None:
+    """Registered and linked, but unloadable - it would never index and never answer."""
+    client = _StubAdminClient()
+    unloadable = _dataset("DF_B", status="offline", details="failed to load the dataflow")
+    client.all_datasets = [_dataset("DF_A"), unloadable]
+
+    report = BatchReport(title="Summary")
+    await _verify_datasets(
+        client,  # type: ignore[arg-type]
+        report,
+        [("AG:DF_A(1.0)", _dataset("DF_A")), ("AG:DF_B(1.0)", unloadable)],
+    )
+
+    assert [item.item_id for item in report.failed] == ["AG:DF_B(1.0)"]
+    assert "failed to load the dataflow" in (report.failed[0].message or "")
+
+
+@pytest.mark.asyncio
+async def test_verification_is_quiet_when_every_dataset_is_online() -> None:
+    client = _StubAdminClient()
+    client.all_datasets = [_dataset("DF_A")]
+
+    report = BatchReport(title="Summary")
+    await _verify_datasets(
+        client, report, [("AG:DF_A(1.0)", _dataset("DF_A"))]  # type: ignore[arg-type]
+    )
+
+    assert not report.items

--- a/tests/unit/cli/shared/test_admin_client_reindex.py
+++ b/tests/unit/cli/shared/test_admin_client_reindex.py
@@ -1,0 +1,162 @@
+"""Tests that a rejected dataset does not stop a bulk reindex."""
+
+import httpx
+import pytest
+
+from statgpt.cli.shared.admin_client import AdminAPIError, AdminClient
+from statgpt.cli.shared.batch_report import BatchItemStatus
+
+_CHANNEL_ID = 7
+_DATASET_IDS = [1, 2, 3, 4]
+_LABELS = {1: "AG:DF_A(1.0)", 2: "AG:DF_B(1.0)", 3: "AG:DF_C(1.0)", 4: "AG:DF_D(1.0)"}
+
+
+def _client(handler) -> tuple[AdminClient, list[str]]:
+    """Build a client over a mock transport, recording the paths it requests."""
+    requested: list[str] = []
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        requested.append(request.url.path)
+        return handler(request)
+
+    transport = httpx.MockTransport(_record)
+    return AdminClient(httpx.AsyncClient(transport=transport), "http://admin.invalid"), requested
+
+
+def _dataset_id_of(request: httpx.Request) -> int:
+    return int(request.url.path.rstrip("/").split("/")[-2])
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_dataset_does_not_stop_the_others() -> None:
+    """The reported failure: the first 4xx used to abort before the later datasets."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if _dataset_id_of(request) == 2:
+            return httpx.Response(
+                400, json={"detail": {"dataset_urn": "AG:DF_B(1.0)", "error": "unsupported DSD"}}
+            )
+        return httpx.Response(202, json={})
+
+    client, requested = _client(handler)
+    report = await client.reload_channel_indicators(
+        channel_id=_CHANNEL_ID, dataset_ids=_DATASET_IDS, labels=_LABELS
+    )
+
+    assert len(requested) == 4, "every dataset must be submitted, including those after the failure"
+
+    by_status = {item.item_id: item.status for item in report.items}
+    assert by_status == {
+        "AG:DF_A(1.0)": BatchItemStatus.OK,
+        "AG:DF_B(1.0)": BatchItemStatus.FAILED,
+        "AG:DF_C(1.0)": BatchItemStatus.OK,
+        "AG:DF_D(1.0)": BatchItemStatus.OK,
+    }
+    assert report.has_failures
+
+
+@pytest.mark.asyncio
+async def test_the_failure_message_carries_the_reason_from_the_api() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400, json={"detail": {"dataset_urn": "AG:DF_A(1.0)", "error": "unsupported DSD"}}
+        )
+
+    client, _ = _client(handler)
+    report = await client.reload_channel_indicators(
+        channel_id=_CHANNEL_ID, dataset_ids=[1], labels=_LABELS
+    )
+
+    assert report.failed[0].message == "HTTP 400: unsupported DSD"
+
+
+@pytest.mark.asyncio
+async def test_a_detail_list_is_joined() -> None:
+    """The channel-wide endpoint answers with a list of InvalidConfigurationError dicts."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"detail": [{"error": "first"}, {"error": "second"}]})
+
+    client, _ = _client(handler)
+    report = await client.reload_channel_indicators(
+        channel_id=_CHANNEL_ID, dataset_ids=[1], labels=_LABELS
+    )
+
+    assert report.failed[0].message == "HTTP 400: first; second"
+
+
+@pytest.mark.asyncio
+async def test_a_non_json_error_body_still_yields_a_usable_message() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, text="<html>Bad Gateway</html>")
+
+    client, _ = _client(handler)
+    report = await client.reload_channel_indicators(
+        channel_id=_CHANNEL_ID, dataset_ids=[1], labels=_LABELS
+    )
+
+    assert report.failed[0].message == "HTTP 502: <html>Bad Gateway</html>"
+
+
+@pytest.mark.asyncio
+async def test_an_empty_error_body_still_yields_a_usable_message() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    client, _ = _client(handler)
+    report = await client.reload_channel_indicators(
+        channel_id=_CHANNEL_ID, dataset_ids=[1], labels=_LABELS
+    )
+
+    assert report.failed[0].message == "HTTP 500"
+
+
+@pytest.mark.asyncio
+async def test_an_auth_failure_aborts_instead_of_repeating_per_dataset() -> None:
+    """401 is not a per-dataset problem, so it must not be reported four times."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "Not authenticated"})
+
+    client, requested = _client(handler)
+
+    with pytest.raises(AdminAPIError):
+        await client.reload_channel_indicators(
+            channel_id=_CHANNEL_ID, dataset_ids=_DATASET_IDS, labels=_LABELS
+        )
+
+    assert len(requested) == 1
+
+
+@pytest.mark.asyncio
+async def test_datasets_without_a_label_fall_back_to_their_id() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(202, json={})
+
+    client, _ = _client(handler)
+    report = await client.reload_channel_indicators(channel_id=_CHANNEL_ID, dataset_ids=[9])
+
+    assert report.items[0].item_id == "9"
+
+
+@pytest.mark.asyncio
+async def test_channel_wide_reindex_posts_once() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(202, json={})
+
+    client, requested = _client(handler)
+    report = await client.reload_channel_indicators(channel_id=_CHANNEL_ID, dataset_ids=None)
+
+    assert requested == [f"/admin/api/v1/channels/{_CHANNEL_ID}/datasets/reload-indicators"]
+    assert not report.has_failures
+
+
+@pytest.mark.asyncio
+async def test_channel_wide_reindex_records_its_rejection() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"detail": [{"error": "unsupported DSD"}]})
+
+    client, _ = _client(handler)
+    report = await client.reload_channel_indicators(channel_id=_CHANNEL_ID, dataset_ids=None)
+
+    assert report.failed[0].message == "HTTP 400: unsupported DSD"

--- a/tests/unit/cli/shared/test_batch_report.py
+++ b/tests/unit/cli/shared/test_batch_report.py
@@ -1,0 +1,109 @@
+"""Tests for the batch outcome report shared by `content init` and `channel reindex`."""
+
+import re
+
+from statgpt.cli.shared.batch_report import BatchItemStatus, BatchReport
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(out: str) -> str:
+    """Drop styling, so assertions read the text and not Rich's colour codes."""
+    return _ANSI.sub("", out)
+
+
+def _report() -> BatchReport:
+    report = BatchReport(title="Summary")
+    report.record_ok("dataset", "A")
+    report.record_unchanged("dataset", "B")
+    report.record_skipped("dataset", "C", "its data source failed")
+    report.record_failed("dataset", "D", "HTTP 400: bad DSD")
+    return report
+
+
+def test_counts_cover_every_recorded_status() -> None:
+    counts = _report().counts()
+
+    assert counts == {
+        BatchItemStatus.FAILED: 1,
+        BatchItemStatus.SKIPPED: 1,
+        BatchItemStatus.OK: 1,
+        BatchItemStatus.UNCHANGED: 1,
+    }
+
+
+def test_counts_omit_statuses_that_did_not_occur() -> None:
+    report = BatchReport(title="Summary")
+    report.record_ok("dataset", "A")
+
+    assert report.counts() == {BatchItemStatus.OK: 1}
+
+
+def test_failed_and_skipped_are_reported_separately() -> None:
+    report = _report()
+
+    assert [item.item_id for item in report.failed] == ["D"]
+    assert [item.item_id for item in report.skipped] == ["C"]
+
+
+def test_has_failures_is_true_only_for_failures() -> None:
+    assert _report().has_failures
+
+    skipped_only = BatchReport(title="Summary")
+    skipped_only.record_skipped("dataset", "C", "its data source failed")
+    assert not skipped_only.has_failures
+
+    assert not BatchReport(title="Summary").has_failures
+
+
+def test_extend_aggregates_across_clients_and_keeps_the_title() -> None:
+    first = BatchReport(title="Overall")
+    first.record_ok("dataset", "A")
+
+    second = BatchReport(title="Client 2")
+    second.record_failed("dataset", "D", "boom")
+
+    first.extend(second)
+
+    assert first.title == "Overall"
+    assert [item.item_id for item in first.items] == ["A", "D"]
+    assert first.has_failures
+
+
+def test_render_lists_failures_before_skips_and_omits_successes(capsys) -> None:
+    """The table is for items needing action; successes are already logged inline."""
+    _report().render()
+
+    out = _plain(capsys.readouterr().out)
+    assert out.index("FAILED") < out.index("SKIPPED")
+    # "A" and "B" succeeded, so they get no row - only the counts mention them.
+    assert "HTTP 400: bad DSD" in out
+    assert "its data source failed" in out
+    assert "1 failed, 1 skipped, 1 ok, 1 unchanged" in out
+
+
+def test_render_escapes_markup_in_error_bodies(capsys) -> None:
+    """A JSON `detail` list is square-bracketed; Rich must not read it as markup."""
+    report = BatchReport(title="Summary")
+    report.record_failed("dataset", "D", '[{"error": "bad DSD"}]')
+
+    report.render()
+
+    assert '[{"error": "bad DSD"}]' in _plain(capsys.readouterr().out)
+
+
+def test_render_truncates_a_very_long_message(capsys) -> None:
+    report = BatchReport(title="Summary")
+    report.record_failed("dataset", "D", "x" * 5000)
+
+    report.render()
+
+    out = _plain(capsys.readouterr().out)
+    assert "…" in out
+    assert "x" * 400 not in out
+
+
+def test_render_handles_an_empty_report(capsys) -> None:
+    BatchReport(title="Summary").render()
+
+    assert "Nothing to do." in _plain(capsys.readouterr().out)

--- a/tests/unit/cli/shared/test_batch_report.py
+++ b/tests/unit/cli/shared/test_batch_report.py
@@ -56,20 +56,6 @@ def test_has_failures_is_true_only_for_failures() -> None:
     assert not BatchReport(title="Summary").has_failures
 
 
-def test_extend_aggregates_across_clients_and_keeps_the_title() -> None:
-    first = BatchReport(title="Overall")
-    first.record_ok("dataset", "A")
-
-    second = BatchReport(title="Client 2")
-    second.record_failed("dataset", "D", "boom")
-
-    first.extend(second)
-
-    assert first.title == "Overall"
-    assert [item.item_id for item in first.items] == ["A", "D"]
-    assert first.has_failures
-
-
 def test_render_lists_failures_before_skips_and_omits_successes(capsys) -> None:
     """The table is for items needing action; successes are already logged inline."""
     _report().render()

--- a/tests/unit/cli/test_exit_code.py
+++ b/tests/unit/cli/test_exit_code.py
@@ -1,0 +1,51 @@
+"""Tests that a partially-failed batch is reported through the process exit code.
+
+A summary on stdout is not enough: a pipeline that reads exit 0 as "everything was
+onboarded" would keep mistaking a truncated run for a complete one.
+"""
+
+import pytest
+
+from statgpt.cli import _execute_direct
+from statgpt.cli.commands.base import Command, CommandRegistry
+from statgpt.cli.shared.batch_report import BatchPartialFailureError
+
+
+def _registry(handler) -> CommandRegistry:
+    registry = CommandRegistry(version="test")
+    registry.register_command(Command(name="run", description="test command", handler=handler))
+    return registry
+
+
+@pytest.mark.asyncio
+async def test_a_partial_failure_exits_non_zero_without_a_duplicate_error(capsys) -> None:
+    async def handler() -> None:
+        print("summary already rendered")
+        raise BatchPartialFailureError("some items failed")
+
+    exit_code = await _execute_direct(_registry(handler), ["run"])
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "summary already rendered" in out
+    assert "Command failed" not in out, "the summary already explained it"
+    assert "some items failed" not in out
+
+
+@pytest.mark.asyncio
+async def test_a_clean_run_exits_zero() -> None:
+    async def handler() -> None:
+        return None
+
+    assert await _execute_direct(_registry(handler), ["run"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_an_unexpected_error_still_reports_itself(capsys) -> None:
+    async def handler() -> None:
+        raise RuntimeError("something unrelated broke")
+
+    exit_code = await _execute_direct(_registry(handler), ["run"])
+
+    assert exit_code == 1
+    assert "something unrelated broke" in capsys.readouterr().out


### PR DESCRIPTION
## Applicable issues
#585 

## Description of changes

`content init` and `channel reindex` process many independent items, but both aborted on the first one that failed: the rest of the batch was never attempted, the CLI still exited `0` whenever the failure landed on the last item, and which datasets survived depended on `os.listdir` order. Each item is now isolated — a failure is recorded against that item and the batch continues.

- **Per-item outcomes, one summary.** New `statgpt/cli/shared/batch_report.py` records an outcome per item (`ok`, `unchanged`, `skipped`, `failed`) and renders a single table at the end listing only what needs action.
- **`SKIPPED` is distinct from `FAILED`.** A dataset whose data source failed is not attempted at all, because registering it without `data_source_id` would leave it unusable. That is a knock-on effect rather than a fault of the dataset, so it does not set the exit code.
- **Exit code.** Partial failure raises `BatchPartialFailureError` after the summary is rendered, which the entry point maps to exit `1` without printing a second error line over the table. Successes are still applied — a partial failure rolls nothing back.
- **Determinism.** `os.listdir` is sorted in `_load_available_datasets` and `_process_datasets`, so a re-run of the same configs produces the same report and the same set of onboarded datasets.
- **`content init --verify` (opt-in).** A dataset can be created and linked successfully and still be unloadable — an incompatible DSD, an unreachable endpoint — in which case it never indexes and never answers a question. `--verify` re-reads the datasets afterwards and reports any that are not `online`. It costs one extra pass over the dataset list, so it is opt-in; the pass runs once per command, not once per client.
- **Failure reasons come from the server.** `_detail_text` unwraps the three shapes the admin API's `detail` field actually takes (a string, an `InvalidConfigurationError.to_dict()`, or a list of them), so a row carries the reason rather than a bare status code. Error bodies are escaped and truncated before rendering, so a JSON payload cannot be read as Rich markup.

```
Content initialization summary
┌───────────┬────────────────┬────────────────────────┬───────────────────────┐
│ Status    │ Type           │ Item                   │ Details               │
├───────────┼────────────────┼────────────────────────┼───────────────────────┤
│ FAILED    │ dataset        │ AG:DF_PRICES(1.0)      │ HTTP 400: unsupporte… │
│ SKIPPED   │ dataset        │ AG:DF_TRADE(1.0)       │ data source 'oecd' i… │
└───────────┴────────────────┴────────────────────────┴───────────────────────┘
✗ 1 failed, 1 skipped, 12 ok, 3 unchanged
```

## Checklist

<!-- Place an 'x' (no spaces) in all applicable boxes. Please remove the items that do not apply. -->

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
