### PR TITLE
fix: hold dataset advisory locks on a dedicated connection #583

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6841,4 +6841,4 @@ mcp = ["fastmcp"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "6d2869a667f3b59bafa5bb10bf6efe41f5ce23ab81b093cdcc850b8b9cf69b44"
+content-hash = "b07e711af9668c7f1be877cbef354995f571d61a7ba3f0f2e2d7d726f6a09b05"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     'plotly (>=5.21.0,<6.0.0)',                  # Data visualization
 
     # Database & Vector storage
+    'sqlalchemy (>=2.0.45,<3.0.0)',              # ORM and async database toolkit
     'asyncpg (>=0.29.0,<0.30.0)',                # Async PostgreSQL driver
     'pgvector (>=0.2.5,<0.3.0)',                 # Vector similarity search
     'alembic (>=1.13.1,<2.0.0)',                 # Database migrations

--- a/statgpt/common/models/__init__.py
+++ b/statgpt/common/models/__init__.py
@@ -1,5 +1,7 @@
 from .database import (
     SessionMakerSingleton,
+    advisory_lock_context_manager,
+    get_connection_context_manager,
     get_readonly_session_context_manager,
     get_session,
     get_session_context_manager,

--- a/statgpt/common/models/database.py
+++ b/statgpt/common/models/database.py
@@ -1,11 +1,13 @@
 import asyncio
 import logging
+import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import (
     AsyncAttrs,
+    AsyncConnection,
     AsyncEngine,
     AsyncSession,
     async_sessionmaker,
@@ -100,6 +102,12 @@ class SessionMaker:
     def __init__(self, engine_config: dict):
         self._engine_config = engine_config
         self._postgres_settings = PostgresSettings()
+        self._engine: AsyncEngine | None = None
+
+    @property
+    def engine(self) -> AsyncEngine | None:
+        """The engine built by `create()`, or None if `create()` has not been called yet."""
+        return self._engine
 
     @staticmethod
     async def _test_connection(engine: AsyncEngine) -> bool:
@@ -190,6 +198,7 @@ class SessionMaker:
     async def create(self) -> async_sessionmaker[AsyncSession]:
         _log.debug("Creating session maker")
         engine = await self.create_engine()
+        self._engine = engine
         session_maker = async_sessionmaker(
             engine,
             expire_on_commit=False,
@@ -202,6 +211,7 @@ class SessionMaker:
 
 class SessionMakerSingleton:
     instance: async_sessionmaker[AsyncSession] | None = None
+    _engine: AsyncEngine | None = None
     _lock = asyncio.Lock()
 
     @classmethod
@@ -217,8 +227,18 @@ class SessionMakerSingleton:
                 return cls.instance
 
             _log.debug("Creating new SessionMakerSingleton instance")
-            cls.instance = await SessionMaker(SessionMaker.DEFAULT_ENGINE_CONFIG).create()
+            session_maker = SessionMaker(SessionMaker.DEFAULT_ENGINE_CONFIG)
+            cls.instance = await session_maker.create()
+            cls._engine = session_maker.engine
             return cls.instance
+
+    @classmethod
+    async def get_or_create_engine(cls) -> AsyncEngine:
+        """Returns the engine backing the default sessions, creating it if needed."""
+        await cls.get_or_create()
+        if cls._engine is None:
+            raise DatabaseConnectionError("Default engine is not available")
+        return cls._engine
 
 
 class ReadOnlySessionMakerSingleton:
@@ -279,10 +299,22 @@ async def get_readonly_session() -> AsyncGenerator[AsyncSession, None]:
 
 
 @asynccontextmanager
-async def get_session_context_manager() -> AsyncGenerator[AsyncSession, None]:
+async def get_session_context_manager(
+    connection: AsyncConnection | None = None,
+) -> AsyncGenerator[AsyncSession, None]:
+    """Yield a database session.
+
+    When `connection` is given, the session runs on that connection instead of checking one out
+    of the pool. A connection-bound session keeps its connection across commits, which an
+    engine-bound one does not -- see `advisory_lock_context_manager` for why that matters.
+    The session configuration (`expire_on_commit=False`, `autoflush=False`) is the same either
+    way, because both go through the shared session maker.
+    """
     _log.debug("get_session_context_manager: Acquiring non-expiring session")
     session_maker = await SessionMakerSingleton.get_or_create()
-    async with session_maker() as session:
+    # Passing bind=None explicitly would override the engine the session maker is bound to.
+    session_kwargs = {"bind": connection} if connection is not None else {}
+    async with session_maker(**session_kwargs) as session:
         session_id = id(session)
         _log.debug(
             f"get_session_context_manager: Session opened (id={session_id}, expire_on_commit=False)"
@@ -308,3 +340,131 @@ async def get_readonly_session_context_manager() -> AsyncGenerator[AsyncSession,
             yield session
         finally:
             _log.debug(f"get_readonly_session_context_manager: Session closed (id={session_id})")
+
+
+@asynccontextmanager
+async def get_connection_context_manager() -> AsyncGenerator[AsyncConnection, None]:
+    """Yield a raw connection from the default engine, closing it on exit."""
+    engine = await SessionMakerSingleton.get_or_create_engine()
+    async with engine.connect() as connection:
+        connection_id = id(connection)
+        _log.debug(f"get_connection_context_manager: Connection opened (id={connection_id})")
+        try:
+            yield connection
+        finally:
+            _log.debug(f"get_connection_context_manager: Connection closed (id={connection_id})")
+
+
+async def _try_acquire_advisory_lock(connection: AsyncConnection, lock_key: int) -> bool:
+    """Attempts to take the advisory lock on `connection`. Opens and closes nothing."""
+    acquired = await connection.scalar(
+        text("SELECT pg_try_advisory_lock(:lock_key)"), {"lock_key": lock_key}
+    )
+    if not acquired:
+        return False
+
+    # End the transaction the statement above started: the connection then holds the lock while
+    # idle rather than sitting 'idle in transaction', and a session bound to it afterwards
+    # begins and owns its own transactions.
+    await connection.commit()
+    return True
+
+
+async def _release_advisory_lock(connection: AsyncConnection, lock_key: int) -> None:
+    """Releases an advisory lock held by `connection`.
+
+    pg_advisory_unlock returns false rather than raising when the connection does not own the
+    lock, so the result is checked explicitly -- an unnoticed failure would leave the lock held
+    by a pooled connection and block every later operation on the same key. In that case, and on
+    any error, the connection is invalidated: closing the socket for real makes PostgreSQL drop
+    every advisory lock the backend held.
+
+    Never raises, other than to propagate cancellation. Failures are only logged, because this
+    runs on the cleanup path, where an exception would mask whatever failure is already
+    propagating. Closing the connection is left to whoever opened it.
+    """
+    try:
+        released = await connection.scalar(
+            text("SELECT pg_advisory_unlock(:lock_key)"), {"lock_key": lock_key}
+        )
+        await connection.commit()
+    except Exception:
+        _log.exception(f"Failed to release advisory lock (key={lock_key}). Discarding connection.")
+        await _invalidate_connection(connection)
+        return
+    except BaseException:
+        # CancelledError (a background task timing out raises it) is not an `Exception`: without
+        # this clause the connection would return to the pool with the unlock possibly never sent.
+        _log.error(
+            f"Release of advisory lock (key={lock_key}) was interrupted. Discarding connection."
+        )
+        await _invalidate_connection(connection)
+        raise
+
+    if not released:
+        _log.error(
+            f"Advisory lock (key={lock_key}) was not held by this connection. "
+            f"Discarding the connection to make sure the lock is not leaked."
+        )
+        await _invalidate_connection(connection)
+        return
+
+    _log.debug(f"Released advisory lock (key={lock_key})")
+
+
+async def _invalidate_connection(connection: AsyncConnection) -> None:
+    """Discards a connection so PostgreSQL drops the locks it holds.
+
+    Never raises, other than to propagate cancellation -- and even then the socket has already
+    been force-closed by the driver, so the locks are gone regardless.
+    """
+    try:
+        await connection.invalidate()
+    except Exception:
+        # invalidate() raises if the connection is already closed; there is nothing left to do.
+        _log.exception("Failed to invalidate connection")
+
+
+@asynccontextmanager
+async def advisory_lock_context_manager(
+    lock_key: int, timeout: float, description: str
+) -> AsyncGenerator[AsyncConnection, None]:
+    """Acquires a PostgreSQL session-level advisory lock, yielding the connection that owns it.
+
+    A session-level advisory lock belongs to the PostgreSQL connection that took it, not to the
+    AsyncSession that issued the statement. An AsyncSession bound to the engine returns its
+    connection to the pool on every commit and checks out a possibly different one next, so a
+    lock taken before a commit cannot be released after it: the unlock lands on another
+    connection, silently returns false, and the lock stays held by an idle pooled connection
+    until it is recycled. Owning one connection for the whole critical section is what keeps
+    acquire and release on the same backend. Bind work to it with
+    `get_session_context_manager(connection=...)`.
+
+    Uses pg_try_advisory_lock in a polling loop rather than the blocking pg_advisory_lock, so a
+    contended lock fails with TimeoutError instead of hanging indefinitely. The connection is
+    opened per attempt and closed again before backing off, so no pooled connection is held
+    while waiting.
+
+    Raises TimeoutError if the lock cannot be acquired within `timeout` seconds.
+    """
+    current_interval = 0.1
+    deadline = time.monotonic() + timeout
+
+    while True:
+        async with get_connection_context_manager() as connection:
+            if await _try_acquire_advisory_lock(connection, lock_key):
+                _log.debug(f"Acquired advisory lock for {description} (key={lock_key})")
+                try:
+                    yield connection
+                finally:
+                    await _release_advisory_lock(connection, lock_key)
+                return
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"Could not acquire advisory lock for {description} "
+                f"(key={lock_key}) within {timeout}s"
+            )
+        await asyncio.sleep(min(current_interval, remaining))
+        current_interval = min(current_interval * 1.5, 5.0)

--- a/statgpt/common/vectorstore/base.py
+++ b/statgpt/common/vectorstore/base.py
@@ -35,7 +35,13 @@ class EmbeddinglessVectorStore(ABC):
     async def remove_documents_by(
         self, *, dataset_id: uuid.UUID | None = None, version_ids: list[int] | None = None
     ) -> None:
-        """Removes all documents by dataset_id or version_ids."""
+        """Removes all documents by dataset_id or version_ids.
+
+        Only one dataset is removed per call: `version_ids` must all belong to the same dataset,
+        since implementations may serialize the removal per dataset.
+
+        Raises ValueError if neither argument is given, or if `version_ids` span several datasets.
+        """
 
     @abstractmethod
     async def deduplicate_by_document_content(self) -> DedupCounts:

--- a/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
+++ b/statgpt/common/vectorstore/pg_vector_store/pg_vector_store.py
@@ -1,4 +1,3 @@
-import asyncio
 import hashlib
 import io
 import json
@@ -18,13 +17,17 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from langchain_core.documents import Document
 from sqlalchemy import delete, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
 from sqlalchemy.schema import CreateTable
 from sqlalchemy.sql import text
 from sqlalchemy.sql.elements import TextClause
 from sqlalchemy.sql.expression import func
 
-from statgpt.common.models import get_readonly_session_context_manager, get_session_context_manager
+from statgpt.common.models import (
+    advisory_lock_context_manager,
+    get_readonly_session_context_manager,
+    get_session_context_manager,
+)
 from statgpt.common.schemas.llm_call_duration import LLMCallDurationItem
 from statgpt.common.settings.database import PostgresSettings
 from statgpt.common.settings.document import DimensionValueDocumentMetadataFields
@@ -168,135 +171,87 @@ class PgEmbeddinglessVectorStore(EmbeddinglessVectorStore):
         # Use first 8 bytes to generate a bigint for PostgreSQL advisory lock
         return int.from_bytes(hash_bytes[:8], byteorder='big', signed=True)
 
-    async def _acquire_dataset_lock(
-        self,
-        session: AsyncSession,
-        dataset_id: uuid.UUID,
-    ) -> int:
-        """Acquires a session-level advisory lock for the given dataset_id within this channel.
-
-        Uses pg_try_advisory_lock with a polling loop instead of the blocking
-        pg_advisory_lock to avoid hanging indefinitely when the lock is contended.
-
-        Returns the lock key which should be passed to _release_dataset_lock.
-        This lock persists across multiple transactions until explicitly released.
-        This prevents concurrent modifications to the same dataset within the channel.
-        """
-        lock_key = self._dataset_lock_key(dataset_id)
-        # Ensure session is in a clean state before acquiring lock
-        if session.in_transaction() and not session.is_active:
-            await session.rollback()
-
-        timeout_s = self._postgres_settings.advisory_lock_timeout
-        current_interval = 0.1
-        deadline = time.monotonic() + timeout_s
-        while True:
-            result = await session.execute(
-                text("SELECT pg_try_advisory_lock(:lock_key)"), {"lock_key": lock_key}
-            )
-            if result.scalar():
-                _log.debug(
-                    f"Acquired advisory lock for collection={self._collection_name} "
-                    f"dataset={dataset_id} (key={lock_key})"
-                )
-                return lock_key
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise TimeoutError(
-                    f"Could not acquire advisory lock for collection={self._collection_name} "
-                    f"dataset={dataset_id} (key={lock_key}) within {timeout_s}s"
-                )
-            await asyncio.sleep(min(current_interval, remaining))
-            current_interval = min(current_interval * 1.5, 5.0)
-
-    async def _release_dataset_lock(self, session: AsyncSession, lock_key: int) -> None:
-        """Releases a session-level advisory lock.
-
-        Handles PendingRollback state to ensure lock is always released.
-        """
-        try:
-            # Rollback if session is in a failed transaction state
-            if session.in_transaction() and not session.is_active:
-                await session.rollback()
-            await session.execute(
-                text("SELECT pg_advisory_unlock(:lock_key)"), {"lock_key": lock_key}
-            )
-        except Exception as e:
-            _log.error(f"Failed to release advisory lock (key={lock_key}): {e}")
-            # Still try to rollback to clean up the session
-            try:
-                await session.rollback()
-            except Exception:
-                pass
-            raise
-        _log.debug(f"Released advisory lock (key={lock_key})")
-
     @asynccontextmanager
-    async def _dataset_lock(
-        self, session: AsyncSession, dataset_id: uuid.UUID
-    ) -> AsyncIterator[None]:
-        """Context manager for acquiring and releasing dataset advisory lock."""
-        lock_key = await self._acquire_dataset_lock(session, dataset_id)
-        try:
-            yield
-        finally:
-            await self._release_dataset_lock(session, lock_key)
+    async def _dataset_lock(self, dataset_id: uuid.UUID) -> AsyncIterator[AsyncConnection]:
+        """Locks the given dataset within this collection, yielding the connection holding it.
 
-    @asynccontextmanager
-    async def _dataset_locks(
-        self, session: AsyncSession, dataset_ids: list[uuid.UUID]
-    ) -> AsyncIterator[None]:
-        """Context manager for acquiring and releasing multiple dataset advisory locks.
-
-        Sorts dataset_ids to ensure deterministic lock ordering and prevent deadlocks.
+        Pass the yielded connection to `get_session_context_manager` so the work runs on the
+        connection that owns the lock; a session bound to the engine instead would return its
+        connection to the pool on the first commit and orphan the lock there.
         """
-        sorted_dataset_ids = sorted(dataset_ids)
-        lock_keys = [
-            await self._acquire_dataset_lock(session, ds_id) for ds_id in sorted_dataset_ids
-        ]
-        try:
-            yield
-        finally:
-            for lock_key in lock_keys:
-                await self._release_dataset_lock(session, lock_key)
+        async with advisory_lock_context_manager(
+            self._dataset_lock_key(dataset_id),
+            timeout=self._postgres_settings.advisory_lock_timeout,
+            description=f"collection={self._collection_name} dataset={dataset_id}",
+        ) as connection:
+            yield connection
 
     async def _get_dataset_ids_by_version_ids(
         self, session: AsyncSession, version_ids: list[int]
     ) -> list[uuid.UUID]:
         """Get all unique dataset_ids associated with given version_ids."""
         model = await self._get_metadata_model()
+        if not await self._check_if_table_exists(session, model.__tablename__):
+            return []
         res = await session.scalars(
             select(model.dataset_id).distinct().where(model.version_id.in_(version_ids))
         )
         return [item for item in res.all()]
+
+    async def _resolve_dataset_id(self, version_ids: list[int]) -> uuid.UUID | None:
+        """Returns the single dataset owning `version_ids`, or None if they match nothing.
+
+        Runs in its own short-lived session so that no connection is held while the caller waits
+        for the dataset lock.
+        """
+        async with get_readonly_session_context_manager() as session:
+            dataset_ids = await self._get_dataset_ids_by_version_ids(session, version_ids)
+
+        if not dataset_ids:
+            return None
+        if len(dataset_ids) > 1:
+            raise ValueError(
+                f"Expected version_ids {version_ids} to belong to a single dataset, "
+                f"got {len(dataset_ids)}: {dataset_ids}"
+            )
+        return dataset_ids[0]
 
     async def remove_documents_by(
         self, *, dataset_id: uuid.UUID | None = None, version_ids: list[int] | None = None
     ) -> None:
         """Removes all documents by dataset_id or version_ids.
 
-        Uses advisory locks to prevent concurrent modifications to the same datasets.
-        All operations (metadata deletion and orphaned document cleanup) are performed
-        in a single transaction to ensure atomicity.
+        The metadata rows are deleted under the dataset's advisory lock, in a single
+        transaction. Documents left unreferenced are then swept in a separate transaction; that
+        sweep spans the whole collection, so it deliberately runs outside the per-dataset lock.
+        A failure between the two leaves unreferenced documents behind, which the next sweep
+        reclaims.
+
+        Only one dataset is supported per call: `version_ids` must all belong to the same
+        dataset, which is what every caller passes.
         """
         if not dataset_id and not version_ids:
             raise ValueError("Either dataset_id or version_ids must be provided")
 
-        async with get_session_context_manager() as session:
-            if dataset_id:
-                dataset_ids_to_lock = [dataset_id]
-            else:
-                dataset_ids_to_lock = await self._get_dataset_ids_by_version_ids(session, version_ids)  # type: ignore
+        if dataset_id is None:
+            dataset_id = await self._resolve_dataset_id(version_ids)  # type: ignore[arg-type]
+            if dataset_id is None:
+                _log.info(f"No documents found for versions {version_ids}. Nothing to remove.")
+                return
 
-            async with self._dataset_locks(session, dataset_ids_to_lock):
+        async with self._dataset_lock(dataset_id) as connection:
+            async with get_session_context_manager(connection=connection) as session:
                 document_ids = await self._remove_dataset_metadata(
                     session, dataset_id=dataset_id, version_ids=version_ids
                 )
                 _log.info(
                     f"Deleted {len(document_ids)} rows from {self._metadata_table_name!r} table"
                 )
-                await self._clear_documents_without_metadata(session)
                 await session.commit()
+
+        async with get_session_context_manager() as session:
+            await self._clear_documents_without_metadata(session)
+            await session.commit()
 
     async def _remove_dataset_metadata(
         self,
@@ -615,9 +570,10 @@ class PgVectorStore(PgEmbeddinglessVectorStore, VectorStore):
             )
             batches_with_embeddings.append((batch, embeddings))
 
-        # Phase 2: DB writes in a single session (advisory lock + inserts)
-        async with get_session_context_manager() as session:
-            async with self._dataset_lock(session, dataset_id):
+        # Phase 2: DB writes on the connection holding the dataset lock, so that the commits
+        # below cannot move the session to another connection and orphan the lock.
+        async with self._dataset_lock(dataset_id) as connection:
+            async with get_session_context_manager(connection=connection) as session:
                 document_model: type[BaseDocument] = await self._get_document_model()
                 metadata_model: type[BaseDocumentMetadata] = await self._get_metadata_model()
 
@@ -633,9 +589,11 @@ class PgVectorStore(PgEmbeddinglessVectorStore, VectorStore):
                         for doc, emb in zip(batch, embeddings)
                     ]
 
+                    # Flush rather than commit: the ids are needed to build the mappings, but
+                    # committing here would briefly publish documents with no metadata, which
+                    # the orphan sweep in `remove_documents_by` would delete.
                     session.add_all(items)
-                    await session.commit()
-                    _log.info(f"Added {len(items)} documents")
+                    await session.flush()
 
                     mappings = [
                         metadata_model(
@@ -648,7 +606,7 @@ class PgVectorStore(PgEmbeddinglessVectorStore, VectorStore):
                     ]
                     session.add_all(mappings)
                     await session.commit()
-                    _log.info(f"Added {len(mappings)} document mappings")
+                    _log.info(f"Added {len(items)} documents and {len(mappings)} mappings")
 
     async def search_with_similarity_score(
         self,

--- a/tests/integration/test_advisory_lock.py
+++ b/tests/integration/test_advisory_lock.py
@@ -7,9 +7,12 @@ held by an idle pooled connection. No test double can reproduce that; only a rea
 real PostgreSQL backend can.
 """
 
+import asyncio
 import uuid
+from collections.abc import AsyncGenerator
 
 import pytest
+import pytest_asyncio
 from sqlalchemy import text
 
 from statgpt.common.models.database import (
@@ -17,6 +20,32 @@ from statgpt.common.models.database import (
     advisory_lock_context_manager,
     get_session_context_manager,
 )
+
+
+def _reset_session_maker_singleton() -> None:
+    SessionMakerSingleton.instance = None
+    SessionMakerSingleton._engine = None
+    # The class-level lock binds itself to the event loop that first awaits it.
+    SessionMakerSingleton._lock = asyncio.Lock()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def isolated_default_engine() -> AsyncGenerator[None, None]:
+    """Gives each test its own default engine, bound to that test's event loop.
+
+    `SessionMakerSingleton` caches one connection pool per process, while pytest-asyncio runs
+    every test on a fresh event loop. A pooled connection created on an earlier loop fails on
+    checkout with "attached to a different loop", so the singleton is rebuilt for each test and
+    disposed while the loop that created it is still running.
+    """
+    _reset_session_maker_singleton()
+    try:
+        yield
+    finally:
+        engine = SessionMakerSingleton._engine
+        _reset_session_maker_singleton()
+        if engine is not None:
+            await engine.dispose()
 
 
 @pytest.fixture

--- a/tests/integration/test_advisory_lock.py
+++ b/tests/integration/test_advisory_lock.py
@@ -8,6 +8,7 @@ real PostgreSQL backend can.
 """
 
 import asyncio
+import time
 import uuid
 from collections.abc import AsyncGenerator
 
@@ -16,6 +17,7 @@ import pytest_asyncio
 from sqlalchemy import text
 
 from statgpt.common.models.database import (
+    SessionMaker,
     SessionMakerSingleton,
     advisory_lock_context_manager,
     get_session_context_manager,
@@ -67,22 +69,17 @@ async def _advisory_lock_count(key: int) -> int:
         return result or 0
 
 
-async def _release_stranded_lock(key: int) -> None:
-    """Frees a lock stranded on a pooled connection, whichever backend ended up holding it."""
-    async with get_session_context_manager() as session:
-        # The pool may well hand us the stranded connection back, in which case the lock is ours
-        # to drop directly -- pg_terminate_backend below deliberately skips the current backend.
-        await session.execute(text("SELECT pg_advisory_unlock_all()"))
-        await session.execute(
-            text(
-                "SELECT pg_terminate_backend(pid) FROM pg_locks "
-                "WHERE locktype = 'advisory' "
-                "AND ((classid::bigint << 32) | objid::bigint) = :key "
-                "AND pid <> pg_backend_pid()"
-            ),
-            {"key": key},
-        )
-        await session.commit()
+async def _wait_until_lock_is_gone(key: int, timeout: float = 5.0) -> None:
+    """Waits for every backend holding `key` to let it go.
+
+    A backend releases its advisory locks as it exits, which is shortly after its socket is
+    closed rather than at the same instant, so this cannot be asserted outright.
+    """
+    deadline = time.monotonic() + timeout
+    while await _advisory_lock_count(key) != 0:
+        if time.monotonic() >= deadline:
+            pytest.fail(f"advisory lock {key} was still held after {timeout}s")
+        await asyncio.sleep(0.05)
 
 
 async def test_lock_survives_commits_and_is_released(lock_key: int) -> None:
@@ -102,28 +99,55 @@ async def test_lock_survives_commits_and_is_released(lock_key: int) -> None:
 
 
 async def test_engine_bound_session_loses_the_lock_on_commit(lock_key: int) -> None:
-    """Documents why the dedicated connection is necessary -- the old shape, still broken."""
-    session_maker = await SessionMakerSingleton.get_or_create()
+    """Documents why the dedicated connection is necessary -- the old shape, still broken.
 
-    async with session_maker() as session:
-        acquired = await session.scalar(
-            text("SELECT pg_try_advisory_lock(:key)"), {"key": lock_key}
-        )
-        assert acquired
+    The engine is local to this test and its pool is primed with two idle connections on purpose.
+    A FIFO pool puts a released connection at the back of the queue, so the one a commit gives
+    back is provably not the one handed out next -- which is what makes the leak reproducible
+    rather than a matter of whatever the pool happened to have idle.
+    """
+    session_maker_factory = SessionMaker(
+        engine_config=dict(pool_size=2, max_overflow=0, pool_use_lifo=False)
+    )
+    session_maker = await session_maker_factory.create()
+    engine = session_maker_factory.engine
+    assert engine is not None
 
-        await session.commit()  # returns the connection, and the lock, to the pool
+    try:
+        async with engine.connect() as first, engine.connect() as second:
+            await first.execute(text("SELECT 1"))
+            await second.execute(text("SELECT 1"))
 
-        released = await session.scalar(text("SELECT pg_advisory_unlock(:key)"), {"key": lock_key})
-        assert released is False, "unlock on a different backend returns false rather than raising"
+        async with session_maker() as session:
+            holder_pid = await session.scalar(text("SELECT pg_backend_pid()"))
+            acquired = await session.scalar(
+                text("SELECT pg_try_advisory_lock(:key)"), {"key": lock_key}
+            )
+            assert acquired
 
-    # The lock is now stranded on a pooled connection -- exactly the leak from #583.
-    assert await _advisory_lock_count(lock_key) == 1
+            await session.commit()  # returns the connection, and the lock, to the pool
 
-    # Clean up. The lock cannot be released from here: it belongs to a backend we can no longer
-    # address, which is the whole point of the bug. Terminating that backend is the only way,
-    # and it is what PostgreSQL would eventually do when the pool recycles the connection.
-    await _release_stranded_lock(lock_key)
-    assert await _advisory_lock_count(lock_key) == 0
+            assert (
+                await session.scalar(text("SELECT pg_backend_pid()")) != holder_pid
+            ), "the commit must have moved the session to another connection"
+
+            released = await session.scalar(
+                text("SELECT pg_advisory_unlock(:key)"), {"key": lock_key}
+            )
+            assert (
+                released is False
+            ), "unlock on a different backend returns false rather than raising"
+
+        # The lock is now stranded on an idle pooled connection -- exactly the leak from #583.
+        # It cannot be released through this pool: it belongs to a backend that no statement can
+        # address any more, which is the whole point of the bug.
+        assert await _advisory_lock_count(lock_key) == 1
+    finally:
+        # Closing the pool closes that connection, and PostgreSQL drops the locks its backend
+        # held -- the same thing that eventually happens when the pool recycles a connection.
+        await engine.dispose()
+
+    await _wait_until_lock_is_gone(lock_key)
 
 
 async def test_second_holder_times_out_while_the_lock_is_held(lock_key: int) -> None:

--- a/tests/integration/test_advisory_lock.py
+++ b/tests/integration/test_advisory_lock.py
@@ -1,0 +1,110 @@
+"""Integration tests for the advisory lock helpers, against a real PostgreSQL.
+
+This is the test that actually guards issue #583. The bug was real connection-pool behaviour --
+an engine-bound `AsyncSession` returns its connection to the pool on every commit, so an unlock
+issued after a commit lands on a different backend, silently returns false, and leaves the lock
+held by an idle pooled connection. No test double can reproduce that; only a real pool and a
+real PostgreSQL backend can.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from statgpt.common.models.database import (
+    SessionMakerSingleton,
+    advisory_lock_context_manager,
+    get_session_context_manager,
+)
+
+
+@pytest.fixture
+def lock_key() -> int:
+    """A key unique to the test run, so parallel runs cannot collide."""
+    return int.from_bytes(uuid.uuid4().bytes[:8], byteorder="big", signed=True)
+
+
+async def _advisory_lock_count(key: int) -> int:
+    """Number of backends currently holding the advisory lock for `key`."""
+    async with get_session_context_manager() as session:
+        result = await session.scalar(
+            text(
+                "SELECT count(*) FROM pg_locks "
+                "WHERE locktype = 'advisory' AND ((classid::bigint << 32) | objid::bigint) = :key"
+            ),
+            {"key": key},
+        )
+        return result or 0
+
+
+async def _release_stranded_lock(key: int) -> None:
+    """Frees a lock stranded on a pooled connection, whichever backend ended up holding it."""
+    async with get_session_context_manager() as session:
+        # The pool may well hand us the stranded connection back, in which case the lock is ours
+        # to drop directly -- pg_terminate_backend below deliberately skips the current backend.
+        await session.execute(text("SELECT pg_advisory_unlock_all()"))
+        await session.execute(
+            text(
+                "SELECT pg_terminate_backend(pid) FROM pg_locks "
+                "WHERE locktype = 'advisory' "
+                "AND ((classid::bigint << 32) | objid::bigint) = :key "
+                "AND pid <> pg_backend_pid()"
+            ),
+            {"key": key},
+        )
+        await session.commit()
+
+
+async def test_lock_survives_commits_and_is_released(lock_key: int) -> None:
+    """The regression: commits inside the locked region must not orphan the lock."""
+    assert await _advisory_lock_count(lock_key) == 0
+
+    async with advisory_lock_context_manager(lock_key, timeout=5.0, description="test") as conn:
+        async with get_session_context_manager(connection=conn) as session:
+            for _ in range(3):
+                await session.execute(text("SELECT 1"))
+                await session.commit()
+
+        # Still held after three commits, on the same backend that took it.
+        assert await _advisory_lock_count(lock_key) == 1
+
+    assert await _advisory_lock_count(lock_key) == 0, "the lock must be gone once released"
+
+
+async def test_engine_bound_session_loses_the_lock_on_commit(lock_key: int) -> None:
+    """Documents why the dedicated connection is necessary -- the old shape, still broken."""
+    session_maker = await SessionMakerSingleton.get_or_create()
+
+    async with session_maker() as session:
+        acquired = await session.scalar(
+            text("SELECT pg_try_advisory_lock(:key)"), {"key": lock_key}
+        )
+        assert acquired
+
+        await session.commit()  # returns the connection, and the lock, to the pool
+
+        released = await session.scalar(text("SELECT pg_advisory_unlock(:key)"), {"key": lock_key})
+        assert released is False, "unlock on a different backend returns false rather than raising"
+
+    # The lock is now stranded on a pooled connection -- exactly the leak from #583.
+    assert await _advisory_lock_count(lock_key) == 1
+
+    # Clean up. The lock cannot be released from here: it belongs to a backend we can no longer
+    # address, which is the whole point of the bug. Terminating that backend is the only way,
+    # and it is what PostgreSQL would eventually do when the pool recycles the connection.
+    await _release_stranded_lock(lock_key)
+    assert await _advisory_lock_count(lock_key) == 0
+
+
+async def test_second_holder_times_out_while_the_lock_is_held(lock_key: int) -> None:
+    async with advisory_lock_context_manager(lock_key, timeout=5.0, description="holder"):
+        with pytest.raises(TimeoutError, match="within"):
+            async with advisory_lock_context_manager(
+                lock_key, timeout=0.3, description="contender"
+            ):
+                pytest.fail("the lock is already held; the body must not run")
+
+    # Once released, the same key can be taken again.
+    async with advisory_lock_context_manager(lock_key, timeout=5.0, description="after"):
+        assert await _advisory_lock_count(lock_key) == 1

--- a/tests/unit/common/models/test_advisory_lock.py
+++ b/tests/unit/common/models/test_advisory_lock.py
@@ -1,0 +1,253 @@
+"""Tests for the PostgreSQL advisory lock helpers in `statgpt.common.models.database`.
+
+These guard the invariant the locks depend on: a session-level advisory lock belongs to the
+PostgreSQL connection that took it, so acquire and release must happen on the *same* connection.
+Holding the lock through an engine-bound `AsyncSession` broke that, because such a session
+returns its connection to the pool on every commit -- the unlock then landed on a different
+connection, silently returned false, and left the lock held by an idle pooled connection.
+
+They also guard the two rules that keep the pool healthy: no connection is held while waiting
+for a contended lock, and no code path leaves a connection open.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from statgpt.common.models import database as module
+
+LOCK_KEY = 4815162342
+OTHER_KEY = 1123581321
+
+
+class FakeConnection:
+    """Records advisory lock traffic and its own open/close lifecycle."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int]] = []
+        self.commits = 0
+        self.closed = False
+        self.invalidated = False
+        # Keys pg_try_advisory_lock should refuse to grant, and non-default unlock results.
+        self.ungrantable_keys: set[int] = set()
+        self.unlock_results: dict[int, bool] = {}
+
+    async def scalar(self, statement: Any, params: dict[str, Any]) -> bool:
+        key = params["lock_key"]
+        sql = str(statement)
+        if "pg_try_advisory_lock" in sql:
+            self.calls.append(("lock", key))
+            return key not in self.ungrantable_keys
+        if "pg_advisory_unlock" in sql:
+            self.calls.append(("unlock", key))
+            return self.unlock_results.get(key, True)
+        raise AssertionError(f"unexpected statement: {sql}")
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+    async def invalidate(self) -> None:
+        self.invalidated = True
+
+    def locked_keys(self) -> list[int]:
+        return [key for op, key in self.calls if op == "lock"]
+
+    def unlocked_keys(self) -> list[int]:
+        return [key for op, key in self.calls if op == "unlock"]
+
+
+class FakeEngine:
+    """Hands out a fresh connection per `connect()` and tracks every one it produced."""
+
+    def __init__(self, template: FakeConnection | None = None) -> None:
+        self.template = template
+        self.connections: list[FakeConnection] = []
+
+    def connect(self) -> "FakeEngine":
+        return self
+
+    async def __aenter__(self) -> FakeConnection:
+        if self.template is not None:
+            conn = self.template
+        else:
+            conn = FakeConnection()
+        self.connections.append(conn)
+        return conn
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        self.connections[-1].closed = True
+
+
+@pytest.fixture
+def conn() -> FakeConnection:
+    return FakeConnection()
+
+
+@pytest.fixture
+def engine(monkeypatch: pytest.MonkeyPatch, conn: FakeConnection) -> FakeEngine:
+    return _bind_engine(monkeypatch, FakeEngine(template=conn))
+
+
+def _bind_engine(monkeypatch: pytest.MonkeyPatch, engine: FakeEngine) -> FakeEngine:
+    async def fake_get_or_create_engine() -> FakeEngine:
+        return engine
+
+    monkeypatch.setattr(
+        module.SessionMakerSingleton, "get_or_create_engine", fake_get_or_create_engine
+    )
+    return engine
+
+
+async def test_lock_is_acquired_and_released_on_the_same_connection(
+    conn: FakeConnection, engine: FakeEngine
+) -> None:
+    async with module.advisory_lock_context_manager(LOCK_KEY, 1.0, "test") as locked:
+        assert locked is conn
+        assert conn.calls == [("lock", LOCK_KEY)], "the lock must be held for the whole body"
+
+    assert conn.calls == [("lock", LOCK_KEY), ("unlock", LOCK_KEY)]
+    assert len(engine.connections) == 1, "the lock must not be spread over several connections"
+    assert conn.closed
+    assert not conn.invalidated
+
+
+async def test_transaction_is_committed_so_the_connection_is_not_idle_in_transaction(
+    conn: FakeConnection, engine: FakeEngine
+) -> None:
+    """The probe autobegins a transaction; leaving it open would block the bound session."""
+    async with module.advisory_lock_context_manager(LOCK_KEY, 1.0, "test"):
+        assert conn.commits == 1, "the acquiring statement's transaction must be closed"
+
+
+async def test_no_connection_is_held_while_waiting_for_a_contended_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each failed probe must close its connection before the backoff sleep."""
+    engine = _bind_engine(monkeypatch, FakeEngine())
+    attempts = 0
+
+    async def fake_sleep(_delay: float) -> None:
+        nonlocal attempts
+        attempts += 1
+        # Grant the lock only from the third probe onwards.
+        if attempts >= 2:
+            engine.connections[-1].ungrantable_keys = set()
+
+    monkeypatch.setattr(module.asyncio, "sleep", fake_sleep)
+
+    original_aenter = FakeEngine.__aenter__
+
+    async def refusing_aenter(self: FakeEngine) -> FakeConnection:
+        conn = await original_aenter(self)
+        if attempts < 2:
+            conn.ungrantable_keys = {LOCK_KEY}
+        return conn
+
+    monkeypatch.setattr(FakeEngine, "__aenter__", refusing_aenter)
+
+    async with module.advisory_lock_context_manager(LOCK_KEY, 10.0, "test"):
+        pass
+
+    assert len(engine.connections) == 3, "each retry must open a fresh connection"
+    assert all(c.closed for c in engine.connections), "no connection may survive its probe"
+    assert engine.connections[-1].unlocked_keys() == [LOCK_KEY]
+
+
+async def test_timeout_raises_and_leaves_no_connection_open(
+    monkeypatch: pytest.MonkeyPatch, conn: FakeConnection
+) -> None:
+    engine = _bind_engine(monkeypatch, FakeEngine(template=conn))
+    conn.ungrantable_keys = {LOCK_KEY}
+
+    with pytest.raises(TimeoutError, match="within"):
+        async with module.advisory_lock_context_manager(LOCK_KEY, 0.05, "test"):
+            pytest.fail("the body must not run when the lock cannot be acquired")
+
+    assert conn.closed
+    assert conn.unlocked_keys() == [], "nothing was locked, so nothing may be unlocked"
+    assert engine.connections, "at least one probe must have been attempted"
+
+
+async def test_connection_is_discarded_when_unlock_reports_the_lock_was_not_held(
+    conn: FakeConnection, engine: FakeEngine
+) -> None:
+    """pg_advisory_unlock returns false rather than raising, which is how the leak went unseen."""
+    conn.unlock_results = {LOCK_KEY: False}
+
+    async with module.advisory_lock_context_manager(LOCK_KEY, 1.0, "test"):
+        pass
+
+    assert conn.invalidated, "a connection that may still hold the lock must not be reused"
+    assert conn.closed
+
+
+async def test_release_failure_does_not_mask_the_error_from_the_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ExplodingConnection(FakeConnection):
+        async def scalar(self, statement: Any, params: dict[str, Any]) -> bool:
+            if "pg_advisory_unlock" in str(statement):
+                raise RuntimeError("connection is gone")
+            return await super().scalar(statement, params)
+
+    conn = ExplodingConnection()
+    _bind_engine(monkeypatch, FakeEngine(template=conn))
+
+    with pytest.raises(ValueError, match="body failed"):
+        async with module.advisory_lock_context_manager(LOCK_KEY, 1.0, "test"):
+            raise ValueError("body failed")
+
+    assert conn.invalidated
+    assert conn.closed
+
+
+async def test_cancelled_release_discards_the_connection_and_stays_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled unlock may never have reached PostgreSQL, so the connection cannot be reused."""
+
+    class CancellingConnection(FakeConnection):
+        async def scalar(self, statement: Any, params: dict[str, Any]) -> bool:
+            if "pg_advisory_unlock" in str(statement):
+                raise asyncio.CancelledError
+            return await super().scalar(statement, params)
+
+    conn = CancellingConnection()
+    _bind_engine(monkeypatch, FakeEngine(template=conn))
+
+    with pytest.raises(asyncio.CancelledError):
+        async with module.advisory_lock_context_manager(LOCK_KEY, 1.0, "test"):
+            pass
+
+    assert conn.invalidated, "a connection that may still hold the lock must not be pooled"
+    assert conn.closed
+
+
+async def test_invalidate_failing_does_not_propagate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """invalidate() raises on an already-closed connection; the cleanup path must swallow it."""
+
+    class UninvalidatableConnection(FakeConnection):
+        async def invalidate(self) -> None:
+            raise RuntimeError("This Connection is closed")
+
+    conn = UninvalidatableConnection()
+    conn.unlock_results = {LOCK_KEY: False}
+    _bind_engine(monkeypatch, FakeEngine(template=conn))
+
+    async with module.advisory_lock_context_manager(LOCK_KEY, 1.0, "test"):
+        pass
+
+    assert conn.closed
+
+
+async def test_distinct_keys_are_locked_independently(
+    conn: FakeConnection, engine: FakeEngine
+) -> None:
+    async with module.advisory_lock_context_manager(LOCK_KEY, 1.0, "a"):
+        pass
+    async with module.advisory_lock_context_manager(OTHER_KEY, 1.0, "b"):
+        pass
+
+    assert conn.locked_keys() == [LOCK_KEY, OTHER_KEY]
+    assert conn.unlocked_keys() == [LOCK_KEY, OTHER_KEY]

--- a/tests/unit/common/vectorstore/test_pg_vector_store_locks.py
+++ b/tests/unit/common/vectorstore/test_pg_vector_store_locks.py
@@ -1,0 +1,265 @@
+"""Tests for how `PgVectorStore` uses the dataset advisory lock.
+
+The lock is taken on a dedicated connection and the work is bound to that same connection, so
+that the commits inside the locked region cannot move the session elsewhere and orphan the lock
+(see `tests/unit/common/models/test_advisory_lock.py` for the lock helper itself).
+
+Also guards the two invariants around it: `remove_documents_by` scopes its delete to a single
+dataset, and `add_documents` never publishes a document without its metadata.
+"""
+
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+from langchain_core.documents import Document
+
+from statgpt.common.settings.database import PostgresSettings
+from statgpt.common.vectorstore.pg_vector_store import pg_vector_store as module
+from statgpt.common.vectorstore.pg_vector_store.pg_vector_store import (
+    PgEmbeddinglessVectorStore,
+    PgVectorStore,
+)
+
+DATASET_A = uuid.UUID("dee4481b-33d9-5268-aeab-decb5f071821")
+DATASET_B = uuid.UUID("e5135496-a933-4692-b8bf-b8e9f60d38fa")
+VERSION_ID = 7
+
+
+class FakeSession:
+    """Records the write traffic a locked region produces."""
+
+    def __init__(self) -> None:
+        self.added: list[list[Any]] = []
+        self.flushes = 0
+        self.commits = 0
+        self.bound_connection: Any = None
+
+    def add_all(self, items: list[Any]) -> None:
+        self.added.append(list(items))
+
+    async def flush(self) -> None:
+        self.flushes += 1
+        # A real flush assigns primary keys; the mappings are built from them.
+        for batch in self.added:
+            for index, item in enumerate(batch):
+                if getattr(item, "id", None) is None:
+                    item.id = index + 1
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+class FakeDocument:
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+        self.id: int | None = None
+
+
+class FakeMetadata:
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _postgres_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PostgresSettings refuses to build without connection env vars."""
+    for name, value in {
+        "PGVECTOR_HOST": "localhost",
+        "PGVECTOR_PORT": "5432",
+        "PGVECTOR_DATABASE": "test",
+        "PGVECTOR_USER": "test",
+        "PGVECTOR_PASSWORD": "test",
+    }.items():
+        monkeypatch.setenv(name, value)
+
+
+@pytest.fixture
+def session() -> FakeSession:
+    return FakeSession()
+
+
+@pytest.fixture
+def locks(monkeypatch: pytest.MonkeyPatch, session: FakeSession) -> list[uuid.UUID]:
+    """Patches the lock and the session factory; returns the list of locked dataset ids."""
+    locked: list[uuid.UUID] = []
+    sentinel = object()
+
+    @asynccontextmanager
+    async def fake_dataset_lock(_self: Any, dataset_id: uuid.UUID) -> AsyncIterator[Any]:
+        locked.append(dataset_id)
+        yield sentinel
+
+    @asynccontextmanager
+    async def fake_session_cm(connection: Any = None) -> AsyncIterator[FakeSession]:
+        session.bound_connection = connection
+        yield session
+
+    monkeypatch.setattr(PgEmbeddinglessVectorStore, "_dataset_lock", fake_dataset_lock)
+    monkeypatch.setattr(module, "get_session_context_manager", fake_session_cm)
+    return locked
+
+
+def test_lock_key_is_stable_and_scoped_to_collection_and_dataset() -> None:
+    store_a = PgEmbeddinglessVectorStore("Indicators_1")
+    store_b = PgEmbeddinglessVectorStore("Indicators_2")
+
+    assert store_a._dataset_lock_key(DATASET_A) == store_a._dataset_lock_key(DATASET_A)
+    assert store_a._dataset_lock_key(DATASET_A) != store_a._dataset_lock_key(DATASET_B)
+    assert store_a._dataset_lock_key(DATASET_A) != store_b._dataset_lock_key(DATASET_A)
+    # PostgreSQL advisory keys are signed bigints.
+    assert -(2**63) <= store_a._dataset_lock_key(DATASET_A) < 2**63
+
+
+class TestRemoveDocumentsBy:
+    @pytest.fixture
+    def store(self, monkeypatch: pytest.MonkeyPatch) -> PgEmbeddinglessVectorStore:
+        store = PgEmbeddinglessVectorStore("SpecialDimensions_12")
+        self.removed: list[dict[str, Any]] = []
+        self.swept = 0
+
+        async def fake_remove_metadata(
+            _session: Any, *, dataset_id: uuid.UUID | None, version_ids: list[int] | None
+        ) -> list[int]:
+            self.removed.append({"dataset_id": dataset_id, "version_ids": version_ids})
+            return [1, 2]
+
+        async def fake_sweep(_session: Any) -> None:
+            self.swept += 1
+
+        monkeypatch.setattr(store, "_remove_dataset_metadata", fake_remove_metadata)
+        monkeypatch.setattr(store, "_clear_documents_without_metadata", fake_sweep)
+        return store
+
+    async def test_requires_dataset_id_or_version_ids(
+        self, store: PgEmbeddinglessVectorStore
+    ) -> None:
+        with pytest.raises(ValueError, match="Either dataset_id or version_ids"):
+            await store.remove_documents_by()
+
+    async def test_locks_the_dataset_and_sweeps_after_releasing_it(
+        self, store: PgEmbeddinglessVectorStore, locks: list[uuid.UUID], session: FakeSession
+    ) -> None:
+        await store.remove_documents_by(dataset_id=DATASET_A)
+
+        assert locks == [DATASET_A]
+        assert self.removed == [{"dataset_id": DATASET_A, "version_ids": None}]
+        assert self.swept == 1
+        assert session.commits == 2, "one commit for the delete, one for the sweep"
+
+    async def test_delete_is_scoped_to_the_resolved_dataset(
+        self,
+        store: PgEmbeddinglessVectorStore,
+        locks: list[uuid.UUID],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The version_ids branch used to delete every dataset's rows for those versions."""
+
+        async def fake_resolve(_version_ids: list[int]) -> uuid.UUID:
+            return DATASET_B
+
+        monkeypatch.setattr(store, "_resolve_dataset_id", fake_resolve)
+
+        await store.remove_documents_by(version_ids=[VERSION_ID])
+
+        assert locks == [DATASET_B]
+        assert self.removed == [{"dataset_id": DATASET_B, "version_ids": [VERSION_ID]}]
+
+    async def test_returns_early_when_versions_match_nothing(
+        self,
+        store: PgEmbeddinglessVectorStore,
+        locks: list[uuid.UUID],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def fake_resolve(_version_ids: list[int]) -> None:
+            return None
+
+        monkeypatch.setattr(store, "_resolve_dataset_id", fake_resolve)
+
+        await store.remove_documents_by(version_ids=[VERSION_ID])
+
+        assert locks == [], "nothing to remove means nothing to lock"
+        assert self.removed == []
+        assert self.swept == 0, "an unlocked global sweep must not run for a no-op call"
+
+    async def test_rejects_versions_spanning_several_datasets(
+        self, store: PgEmbeddinglessVectorStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_ids(_session: Any, _version_ids: list[int]) -> list[uuid.UUID]:
+            return [DATASET_A, DATASET_B]
+
+        @asynccontextmanager
+        async def fake_readonly_session() -> AsyncIterator[Any]:
+            yield object()
+
+        monkeypatch.setattr(store, "_get_dataset_ids_by_version_ids", fake_ids)
+        monkeypatch.setattr(module, "get_readonly_session_context_manager", fake_readonly_session)
+
+        with pytest.raises(ValueError, match="single dataset"):
+            await store.remove_documents_by(version_ids=[VERSION_ID])
+
+
+class TestAddDocuments:
+    @pytest.fixture
+    def store(self, monkeypatch: pytest.MonkeyPatch) -> PgVectorStore:
+        class FakeEmbeddings:
+            async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+                return [[0.1, 0.2] for _ in texts]
+
+        class FakeEmbeddingModel:
+            name = "fake"
+            model = FakeEmbeddings()
+
+        store = PgVectorStore("Indicators_1", embedding_model=FakeEmbeddingModel())  # type: ignore
+        store._postgres_settings = PostgresSettings(batch_size=2)
+
+        async def fake_document_model() -> Any:
+            return FakeDocument
+
+        async def fake_metadata_model() -> Any:
+            return FakeMetadata
+
+        async def fake_create_table(_session: Any, _model: Any) -> bool:
+            return False
+
+        monkeypatch.setattr(store, "_get_document_model", fake_document_model)
+        monkeypatch.setattr(store, "_get_metadata_model", fake_metadata_model)
+        monkeypatch.setattr(store, "_create_table_if_not_exist", fake_create_table)
+        return store
+
+    async def test_work_runs_on_the_connection_holding_the_lock(
+        self, store: PgVectorStore, locks: list[uuid.UUID], session: FakeSession
+    ) -> None:
+        await store.add_documents([Document(page_content="a")], DATASET_A, VERSION_ID)
+
+        assert locks == [DATASET_A]
+        assert session.bound_connection is not None, "the session must be bound to the lock conn"
+
+    async def test_documents_and_mappings_land_in_one_commit_per_batch(
+        self, store: PgVectorStore, locks: list[uuid.UUID], session: FakeSession
+    ) -> None:
+        """Committing documents before their mappings left them briefly sweepable."""
+        documents = [Document(page_content=str(i)) for i in range(4)]  # batch_size=2 -> 2 batches
+
+        await store.add_documents(documents, DATASET_A, VERSION_ID)
+
+        assert session.flushes == 2, "one flush per batch, to assign the document ids"
+        assert session.commits == 2, "one commit per batch, publishing documents with mappings"
+        # add_all is called twice per batch: documents, then their mappings.
+        assert [type(batch[0]) for batch in session.added] == [
+            FakeDocument,
+            FakeMetadata,
+            FakeDocument,
+            FakeMetadata,
+        ]
+
+    async def test_mappings_reference_the_flushed_document_ids(
+        self, store: PgVectorStore, locks: list[uuid.UUID], session: FakeSession
+    ) -> None:
+        await store.add_documents([Document(page_content="a")], DATASET_A, VERSION_ID)
+
+        mappings = session.added[1]
+        assert [m.document_id for m in mappings] == [1]
+        assert all(m.dataset_id == DATASET_A and m.version_id == VERSION_ID for m in mappings)


### PR DESCRIPTION
## Applicable issues

- fixes #583

## Description of changes

A PostgreSQL session-level advisory lock belongs to the **connection** that took it, but the lock was taken through an `AsyncSession` bound to the engine. Such a session returns its connection to the pool on every `commit()`, so in `add_documents` the unlock landed on a different backend. `pg_advisory_unlock` returns `false` rather than raising, and the result was discarded, so the failure was silent: the lock stayed held by an idle pooled connection until `pool_recycle` reaped it, and every later operation on that dataset blocked for the full `advisory_lock_timeout` and then failed.

Locking now goes through `advisory_lock_context_manager` in `statgpt/common/models/database.py`, which owns one connection for the whole critical section and hands it to `get_session_context_manager(connection=...)`, so the work commits on the backend that holds the lock. The connection is closed between acquisition attempts, so none is held while waiting for a contended lock. The release path discards the connection if the unlock returns `false` or is interrupted by cancellation, since only a real socket close makes PostgreSQL drop the lock.

Three further defects in the same code are fixed alongside:

- `remove_documents_by` applied no `dataset_id` predicate in the `version_ids` branch, so the delete was not scoped to the dataset whose lock it held.
- `add_documents` committed documents **before** their metadata, leaving them briefly unreferenced and exposed to the orphan sweep; it now commits both together, once per batch.
- The lock-set query left a session `idle in transaction` while waiting for the lock; it now runs in its own short-lived session.

The multi-lock helper is removed rather than repaired: every call site resolves to exactly one dataset, so its sorting and deadlock-avoidance machinery was never exercised. `remove_documents_by` now requires a single dataset and sweeps orphaned documents in a separate transaction after releasing the lock.

`sqlalchemy` is also declared as a direct dependency, which it always was in practice.

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.