### PR TITLE
feat: add configurable scopes to the admin audit log #543

### DIFF
--- a/statgpt/admin/alembic/versions/2026_08_14_1200-f4c2a9b7d3e1_add_scope_to_audit_logs.py
+++ b/statgpt/admin/alembic/versions/2026_08_14_1200-f4c2a9b7d3e1_add_scope_to_audit_logs.py
@@ -1,0 +1,47 @@
+"""Add scope column to audit logs
+
+Revision ID: f4c2a9b7d3e1
+Revises: a4f1d794d575
+Create Date: 2026-08-14 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'f4c2a9b7d3e1'
+down_revision: str | None = 'a4f1d794d575'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    audit_scope = postgresql.ENUM(
+        'config',
+        'ex_im',
+        'reindex',
+        'ds_link',
+        name='auditscope',
+        create_type=False,
+    )
+    audit_scope.create(op.get_bind(), checkfirst=True)
+
+    op.add_column(
+        'audit_logs',
+        sa.Column('scope', audit_scope, nullable=False, server_default='config'),
+    )
+
+    # Backfill historical export/import records. audit_logs rows are immutable
+    # via a trigger, so it must be toggled off for this one-time backfill.
+    op.execute("ALTER TABLE audit_logs DISABLE TRIGGER trg_prevent_audit_log_mutation")
+    op.execute("UPDATE audit_logs SET scope = 'ex_im' WHERE entity_type = 'import_job'")
+    op.execute("ALTER TABLE audit_logs ENABLE TRIGGER trg_prevent_audit_log_mutation")
+
+
+def downgrade() -> None:
+    op.drop_column('audit_logs', 'scope')
+    postgresql.ENUM(name='auditscope').drop(op.get_bind(), checkfirst=True)

--- a/statgpt/admin/audit/decorators.py
+++ b/statgpt/admin/audit/decorators.py
@@ -3,13 +3,14 @@ from functools import wraps
 
 from statgpt.admin.audit.service import AuditService
 from statgpt.common.schemas.auditable import Auditable
-from statgpt.common.schemas.enums import AuditActionType, AuditEntityType
+from statgpt.common.schemas.enums import AuditActionType, AuditEntityType, AuditScope
 
 
 def audit_action(
     *,
     entity_type: AuditEntityType,
     action_type: AuditActionType,
+    scope: AuditScope = AuditScope.CONFIG,
 ):
     """Decorated methods must not call session.commit(); this decorator owns transaction commit/rollback."""
 
@@ -18,19 +19,21 @@ def audit_action(
         async def wrapped(self, *args, **kwargs) -> Auditable:
             if self._session.in_transaction():
                 result: Auditable = await func(self, *args, **kwargs)
-                AuditService(self._session).persist(
+                await AuditService(self._session).persist(
                     entity_type=entity_type,
                     action_type=action_type,
                     data=result,
+                    scope=scope,
                 )
                 return result
 
             async with self._session.begin():
                 result = await func(self, *args, **kwargs)
-                AuditService(self._session).persist(
+                await AuditService(self._session).persist(
                     entity_type=entity_type,
                     action_type=action_type,
                     data=result,
+                    scope=scope,
                 )
                 return result
 

--- a/statgpt/admin/audit/service.py
+++ b/statgpt/admin/audit/service.py
@@ -1,58 +1,136 @@
 from collections.abc import Iterable
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import statgpt.common.models as models
 from statgpt.admin.audit import context as audit_context
+from statgpt.admin.settings.app import APP_SETTINGS
 from statgpt.common.schemas.auditable import Auditable
-from statgpt.common.schemas.enums import AuditActionType, AuditEntityType
+from statgpt.common.schemas.enums import AuditActionType, AuditEntityType, AuditScope
 
 
 class AuditService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    def persist(
+    @staticmethod
+    def _scope_enabled(scope: AuditScope) -> bool:
+        return scope in APP_SETTINGS.enabled_audit_scopes
+
+    async def persist(
         self,
         *,
         entity_type: AuditEntityType,
         action_type: AuditActionType,
         data: Auditable,
+        scope: AuditScope = AuditScope.CONFIG,
     ) -> None:
-        self.persist_batch(
+        await self.persist_batch(
             entity_type=entity_type,
             action_type=action_type,
             items=[data],
+            scope=scope,
         )
 
-    def persist_batch(
+    async def persist_batch(
         self,
         *,
         entity_type: AuditEntityType,
         action_type: AuditActionType,
         items: Iterable[Auditable],
+        scope: AuditScope = AuditScope.CONFIG,
     ) -> None:
+        if not self._scope_enabled(scope):
+            return
+
         auditable_items = list(items)
         if not auditable_items:
             return
 
         context = audit_context.get_audit_context()
-        audit_logs = [
-            self._build_audit_log(
+        audit_logs = []
+        for data in auditable_items:
+            if action_type is AuditActionType.UPDATE and await self._is_noop_update(
+                entity_type, scope, data
+            ):
+                continue
+            audit_logs.append(
+                self._build_audit_log(
+                    entity_type=entity_type,
+                    action_type=action_type,
+                    scope=scope,
+                    data=data,
+                    context=context,
+                )
+            )
+        self._session.add_all(audit_logs)
+
+    async def log_event(
+        self,
+        *,
+        entity_type: AuditEntityType,
+        action_type: AuditActionType,
+        scope: AuditScope,
+        item_id: int,
+        entity_id: str,
+        entity_name: str,
+        state_after: dict | None = None,
+    ) -> None:
+        """Records a single audit entry from explicit fields.
+
+        Used for events (reindexing, dataset linking) that have no dedicated
+        ``Auditable`` domain object.
+        """
+        if not self._scope_enabled(scope):
+            return
+
+        context = audit_context.get_audit_context()
+        self._session.add(
+            models.AuditLog(
                 entity_type=entity_type,
                 action_type=action_type,
-                data=data,
-                context=context,
+                scope=scope,
+                item_id=item_id,
+                entity_id=entity_id,
+                entity_name=entity_name,
+                performed_by=context.performed_by,
+                performed_by_name=context.performed_by_name,
+                state_after=state_after,
+                trace_id=context.trace_id,
             )
-            for data in auditable_items
-        ]
-        self._session.add_all(audit_logs)
+        )
+
+    async def _is_noop_update(
+        self, entity_type: AuditEntityType, scope: AuditScope, data: Auditable
+    ) -> bool:
+        """True when the update leaves the persisted state unchanged.
+
+        Skips empty-diff audit records, e.g. re-importing an unchanged channel
+        config, which would otherwise call the audited ``update`` unconditionally.
+        Only same-scope records are compared: verbose-scope events (reindex,
+        ds_link) store a different ``state_after`` shape and would otherwise mask
+        genuine config no-ops.
+        """
+        query = (
+            select(models.AuditLog.state_after)
+            .where(
+                models.AuditLog.entity_type == entity_type,
+                models.AuditLog.scope == scope,
+                models.AuditLog.item_id == data.get_item_id(),
+            )
+            .order_by(models.AuditLog.id.desc())
+            .limit(1)
+        )
+        previous_state = (await self._session.execute(query)).scalar_one_or_none()
+        return previous_state is not None and previous_state == data.get_state_after()
 
     @staticmethod
     def _build_audit_log(
         *,
         entity_type: AuditEntityType,
         action_type: AuditActionType,
+        scope: AuditScope,
         data: Auditable,
         context: audit_context.AuditContext,
     ) -> models.AuditLog:
@@ -60,6 +138,7 @@ class AuditService:
         return models.AuditLog(
             entity_type=entity_type,
             action_type=action_type,
+            scope=scope,
             item_id=data.get_item_id(),
             entity_id=data.get_entity_id(),
             entity_name=data.get_entity_name(),

--- a/statgpt/admin/routers/audit_log.py
+++ b/statgpt/admin/routers/audit_log.py
@@ -23,6 +23,7 @@ async def get_audit_log_enum_values() -> dict[str, list[str]]:
     return {
         "entity_types": [entity_type.value for entity_type in schemas.AuditEntityType],
         "action_types": [action_type.value for action_type in schemas.AuditActionType],
+        "scopes": [scope.value for scope in schemas.AuditScope],
     }
 
 
@@ -43,6 +44,7 @@ async def get_audit_logs(
     offset: int = 0,
     entity_type: schemas.AuditEntityType | None = None,
     action_type: schemas.AuditActionType | None = None,
+    scope: schemas.AuditScope | None = None,
     item_id: int | None = None,
     entity_id: str | None = None,
     entity_name: str | None = None,
@@ -62,6 +64,7 @@ async def get_audit_logs(
         offset=offset,
         entity_type=entity_type,
         action_type=action_type,
+        scope=scope,
         item_id=item_id,
         entity_id=entity_id,
         entity_name=entity_name,
@@ -74,6 +77,7 @@ async def get_audit_logs(
     total = await service.get_count(
         entity_type=entity_type,
         action_type=action_type,
+        scope=scope,
         item_id=item_id,
         entity_id=entity_id,
         entity_name=entity_name,
@@ -96,6 +100,7 @@ async def get_audit_logs(
 async def export_audit_logs(
     entity_type: schemas.AuditEntityType | None = None,
     action_type: schemas.AuditActionType | None = None,
+    scope: schemas.AuditScope | None = None,
     item_id: int | None = None,
     entity_id: str | None = None,
     entity_name: str | None = None,
@@ -113,6 +118,7 @@ async def export_audit_logs(
     items = await service.get_logs(
         entity_type=entity_type,
         action_type=action_type,
+        scope=scope,
         item_id=item_id,
         entity_id=entity_id,
         entity_name=entity_name,

--- a/statgpt/admin/services/audit_log.py
+++ b/statgpt/admin/services/audit_log.py
@@ -7,10 +7,23 @@ from sqlalchemy.sql.expression import func
 import statgpt.common.models as models
 import statgpt.common.schemas as schemas
 
+# Keys never audited for an entity type but which older records may still contain.
+# Stripping them at read time keeps diffs clean without mutating immutable rows.
+_EXCLUDED_STATE_KEYS: dict[schemas.AuditEntityType, frozenset[str]] = {
+    schemas.AuditEntityType.DATASET: frozenset({"data_source"}),
+}
+
 
 class AdminAuditLogService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
+
+    @staticmethod
+    def _sanitize_state(entity_type: schemas.AuditEntityType, state: dict | None) -> dict | None:
+        excluded = _EXCLUDED_STATE_KEYS.get(entity_type)
+        if not excluded or state is None:
+            return state
+        return {key: value for key, value in state.items() if key not in excluded}
 
     async def get_by_id(self, item_id: int) -> schemas.AuditLogDetails:
         item = await self._session.get(models.AuditLog, item_id)
@@ -18,10 +31,14 @@ class AdminAuditLogService:
             raise ValueError(f"Audit log with id={item_id} not found")
         state_before = None
         if item.item_id is not None:
+            # Same-scope only: reindex/ds_link events share (entity_type, item_id)
+            # with config records but store a different state shape, which would
+            # otherwise corrupt the before/after diff.
             previous_query = (
                 select(models.AuditLog)
                 .where(
                     models.AuditLog.entity_type == item.entity_type,
+                    models.AuditLog.scope == item.scope,
                     models.AuditLog.item_id == item.item_id,
                     models.AuditLog.id < item.id,
                 )
@@ -36,6 +53,7 @@ class AdminAuditLogService:
             id=item.id,
             entity_type=item.entity_type,
             action_type=item.action_type,
+            scope=item.scope,
             item_id=item.item_id,
             entity_id=item.entity_id,
             entity_name=item.entity_name,
@@ -43,8 +61,8 @@ class AdminAuditLogService:
             performed_by_name=item.performed_by_name,
             trace_id=item.trace_id,
             created_at=item.created_at,
-            state_before=state_before,
-            state_after=item.state_after,
+            state_before=self._sanitize_state(item.entity_type, state_before),
+            state_after=self._sanitize_state(item.entity_type, item.state_after),
         )
 
     async def get_logs(
@@ -54,6 +72,7 @@ class AdminAuditLogService:
         offset: int | None = None,
         entity_type: schemas.AuditEntityType | None = None,
         action_type: schemas.AuditActionType | None = None,
+        scope: schemas.AuditScope | None = None,
         item_id: int | None = None,
         entity_id: str | None = None,
         entity_name: str | None = None,
@@ -68,6 +87,7 @@ class AdminAuditLogService:
             query=query,
             entity_type=entity_type,
             action_type=action_type,
+            scope=scope,
             item_id=item_id,
             entity_id=entity_id,
             entity_name=entity_name,
@@ -92,6 +112,7 @@ class AdminAuditLogService:
         *,
         entity_type: schemas.AuditEntityType | None = None,
         action_type: schemas.AuditActionType | None = None,
+        scope: schemas.AuditScope | None = None,
         item_id: int | None = None,
         entity_id: str | None = None,
         entity_name: str | None = None,
@@ -106,6 +127,7 @@ class AdminAuditLogService:
             query=query,
             entity_type=entity_type,
             action_type=action_type,
+            scope=scope,
             item_id=item_id,
             entity_id=entity_id,
             entity_name=entity_name,
@@ -127,6 +149,8 @@ class AdminAuditLogService:
             query = query.where(models.AuditLog.entity_type == filters["entity_type"])
         if filters["action_type"]:
             query = query.where(models.AuditLog.action_type == filters["action_type"])
+        if filters["scope"]:
+            query = query.where(models.AuditLog.scope == filters["scope"])
         if filters["item_id"] is not None:
             query = query.where(models.AuditLog.item_id == filters["item_id"])
         if filters["entity_id"]:

--- a/statgpt/admin/services/dataset.py
+++ b/statgpt/admin/services/dataset.py
@@ -29,6 +29,7 @@ from statgpt.common.hybrid_indexer import Indexer
 from statgpt.common.schemas import (
     AuditActionType,
     AuditEntityType,
+    AuditScope,
     AutoUpdateResult,
     ChannelIndexStatusScope,
     HybridSearchConfig,
@@ -360,19 +361,24 @@ class AdminPortalDataSetService(DataSetService):
                 limit=None, offset=0, channel_id=channel_id
             )
         }
-        items = [
-            models.ChannelDataset(
-                channel_id=channel_id,
-                dataset_id=ds.id,
-            )
-            for ds in datasets
-            if ds.id not in existing_dataset_ids
-        ]
-
-        if not items:
+        new_datasets = [ds for ds in datasets if ds.id not in existing_dataset_ids]
+        if not new_datasets:
             return
 
-        self._session.add_all(items)
+        self._session.add_all(
+            models.ChannelDataset(channel_id=channel_id, dataset_id=ds.id) for ds in new_datasets
+        )
+        audit = AuditService(self._session)
+        for ds in new_datasets:
+            await audit.log_event(
+                entity_type=AuditEntityType.DATASET,
+                action_type=AuditActionType.CREATE,
+                scope=AuditScope.DS_LINK,
+                item_id=ds.id,
+                entity_id=str(ds.id_),
+                entity_name=ds.title,
+                state_after={"channel_id": channel_id, "dataset_id": ds.id},
+            )
         await self._session.commit()
 
     async def _import_datasets_versions(
@@ -813,7 +819,7 @@ class AdminPortalDataSetService(DataSetService):
                 delete(models.DataSet).where(models.DataSet.id.in_([item.id for item in items]))
             )
             await self._session.flush()
-            AuditService(self._session).persist_batch(
+            await AuditService(self._session).persist_batch(
                 entity_type=AuditEntityType.DATASET,
                 action_type=AuditActionType.DELETE,
                 items=deleted,
@@ -1053,6 +1059,19 @@ class AdminPortalDataSetService(DataSetService):
         )
 
         self._session.add(item)
+        await AuditService(self._session).log_event(
+            entity_type=AuditEntityType.DATASET,
+            action_type=AuditActionType.CREATE,
+            scope=AuditScope.DS_LINK,
+            item_id=dataset.id,
+            entity_id=str(dataset.id_),
+            entity_name=dataset.title,
+            state_after={
+                "channel_id": channel.id,
+                "channel_deployment_id": channel.deployment_id,
+                "dataset_id": dataset.id,
+            },
+        )
         await self._session.commit()
 
         return schemas.ChannelDatasetBase.model_validate(item, from_attributes=True)
@@ -1511,6 +1530,16 @@ class AdminPortalDataSetService(DataSetService):
                 ch_ds, StatusEnum.NOT_STARTED, do_commit=False
             )
 
+        await AuditService(self._session).log_event(
+            entity_type=AuditEntityType.CHANNEL,
+            action_type=AuditActionType.UPDATE,
+            scope=AuditScope.REINDEX,
+            item_id=channel.id,
+            entity_id=channel.get_entity_id(),
+            entity_name=channel.title,
+            state_after={"dataset_ids": dataset_ids, "dataset_count": len(dataset_ids)},
+        )
+
         await self._session.commit()
         for ch_ds in channel_datasets:
             await self._session.refresh(ch_ds)
@@ -1588,6 +1617,19 @@ class AdminPortalDataSetService(DataSetService):
         background_tasks.add_task(
             clear_channel_dataset_data_in_background_task,
             channel_dataset_id=channel_dataset.id,
+        )
+        await AuditService(self._session).log_event(
+            entity_type=AuditEntityType.DATASET,
+            action_type=AuditActionType.UPDATE,
+            scope=AuditScope.REINDEX,
+            item_id=dataset.id,
+            entity_id=dataset.get_entity_id(),
+            entity_name=dataset.title,
+            state_after={
+                "channel_id": channel.id,
+                "channel_deployment_id": channel.deployment_id,
+                "version_id": version.id,
+            },
         )
         await self._update_channel_dataset_status(channel_dataset, StatusEnum.NOT_STARTED)
 

--- a/statgpt/admin/services/import_export_jobs.py
+++ b/statgpt/admin/services/import_export_jobs.py
@@ -21,7 +21,7 @@ from statgpt.admin.audit.context import AuditContext, get_audit_context, update_
 from statgpt.admin.audit.decorators import audit_action
 from statgpt.admin.settings.exim import JobsConfig
 from statgpt.common.auth.auth_context import AuthContext
-from statgpt.common.schemas import AuditActionType, AuditEntityType
+from statgpt.common.schemas import AuditActionType, AuditEntityType, AuditScope
 from statgpt.common.settings.dial import dial_settings
 from statgpt.common.utils import (
     AttachmentsStorage,
@@ -177,7 +177,11 @@ class JobsService:
 
         return schemas.Job.model_validate(job, from_attributes=True)
 
-    @audit_action(entity_type=AuditEntityType.IMPORT_JOB, action_type=AuditActionType.CREATE)
+    @audit_action(
+        entity_type=AuditEntityType.IMPORT_JOB,
+        action_type=AuditActionType.CREATE,
+        scope=AuditScope.EX_IM,
+    )
     async def create_import_job(
         self,
         background_tasks: BackgroundTasks,

--- a/statgpt/admin/settings/app.py
+++ b/statgpt/admin/settings/app.py
@@ -1,5 +1,9 @@
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from statgpt.common.schemas import AuditScope
+
+_DEFAULT_AUDIT_SCOPE = f"{AuditScope.CONFIG.value},{AuditScope.EX_IM.value}"
 
 
 class AppSettings(BaseSettings):
@@ -17,6 +21,24 @@ class AppSettings(BaseSettings):
         alias="BETA_MCP_ENABLED",
         description="Flag to enable the beta MCP features",
     )
+    audit_scope: str = Field(
+        default=_DEFAULT_AUDIT_SCOPE,
+        alias="AUDIT_SCOPE",
+        description=(
+            "Comma-separated audit scopes to record. Defaults to 'config,ex_im'; "
+            "add 'reindex' and/or 'ds_link' to enable verbose auditing."
+        ),
+    )
+
+    @property
+    def enabled_audit_scopes(self) -> set[AuditScope]:
+        return {AuditScope(token.strip()) for token in self.audit_scope.split(",") if token.strip()}
+
+    @model_validator(mode="after")
+    def _validate_audit_scope(self) -> "AppSettings":
+        # Fail fast on an invalid AUDIT_SCOPE value instead of at first audit write.
+        _ = self.enabled_audit_scopes
+        return self
 
 
 APP_SETTINGS = AppSettings()

--- a/statgpt/common/models/models.py
+++ b/statgpt/common/models/models.py
@@ -10,6 +10,7 @@ from sqlalchemy.sql import func
 from statgpt.common.schemas import (
     AuditActionType,
     AuditEntityType,
+    AuditScope,
     AutoUpdateResult,
     DiscoveryIndexingStatus,
     DiscoveryValidationStatus,
@@ -386,6 +387,11 @@ class AuditLog(IdMixin, Base):
     )
     action_type: Mapped[AuditActionType] = mapped_column(
         Enum(AuditActionType, values_callable=lambda e: [x.value for x in e]),
+    )
+    scope: Mapped[AuditScope] = mapped_column(
+        Enum(AuditScope, values_callable=lambda e: [x.value for x in e]),
+        default=AuditScope.CONFIG,
+        server_default=AuditScope.CONFIG.value,
     )
 
     item_id: Mapped[int]

--- a/statgpt/common/schemas/__init__.py
+++ b/statgpt/common/schemas/__init__.py
@@ -45,6 +45,7 @@ from .discovery_indexing_job import DiscoveryIndexingJob
 from .enums import (
     AuditActionType,
     AuditEntityType,
+    AuditScope,
     AutoUpdateResult,
     ChannelDatasetUpdateStatus,
     ChannelIndexStatusScope,

--- a/statgpt/common/schemas/audit_log.py
+++ b/statgpt/common/schemas/audit_log.py
@@ -3,13 +3,14 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from .enums import AuditActionType, AuditEntityType
+from .enums import AuditActionType, AuditEntityType, AuditScope
 
 
 class AuditLogListItem(BaseModel):
     id: int
     entity_type: AuditEntityType
     action_type: AuditActionType
+    scope: AuditScope
 
     item_id: int
     entity_id: str

--- a/statgpt/common/schemas/enums.py
+++ b/statgpt/common/schemas/enums.py
@@ -198,6 +198,20 @@ class AuditActionType(StrEnum):
     DELETE = "delete"
 
 
+class AuditScope(StrEnum):
+    """Groups audit records so verbose scopes can be enabled per environment.
+
+    Which scopes are recorded is controlled by the ``AUDIT_SCOPE`` setting, which
+    defaults to ``CONFIG`` and ``EX_IM``; add ``REINDEX`` and/or ``DS_LINK`` to
+    enable verbose auditing.
+    """
+
+    CONFIG = "config"
+    EX_IM = "ex_im"
+    REINDEX = "reindex"
+    DS_LINK = "ds_link"
+
+
 class AutoUpdateResult(StrEnum):
     """Result of an auto-update job execution."""
 


### PR DESCRIPTION
## Applicable issues

- closes #543

## Description of changes

The admin audit log had three rough edges: no-op channel updates produced empty-diff records (a #528 regression), the `data_source` block still showed up in dataset update diffs, and high-value operations (reindexing, dataset↔channel linking) weren't recorded at all. This PR addresses all three by introducing audit **scopes**.

- **Configurable scopes.** Adds an `AuditScope` enum (`config`, `ex_im`, `reindex`, `ds_link`) and a `scope` column on `audit_logs`. Which scopes are recorded is controlled by a new `AUDIT_SCOPE` setting (default `config,ex_im`); the verbose `reindex` and `ds_link` scopes are opt-in per environment. This supersedes the single `DETAILED_AUDIT` boolean proposed in the issue with a more granular, per-scope toggle.
- **New event coverage.** Channel reindexing and dataset↔channel linking are now audited via a new event-based logging path for operations that have no `Auditable` domain object.
- **No-op updates skipped.** Config updates that don't change state (e.g. re-importing an unchanged channel) no longer produce empty-diff records; the latest same-scope state is compared before persisting.
- **Cleaner diffs.** Obsolete keys such as `data_source` are stripped from historical state at read time, so they no longer appear in before/after diffs — without mutating the immutable audit rows.
- **Filtering.** The audit log list/export API gains a `scope` filter.
- **Migration.** Adds the `scope` column and backfills existing import/export records to `ex_im` (temporarily disabling the row-immutability trigger for the one-time backfill).

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.