### PR TITLE
fix: SDMX attribute with no representation aborts the whole dataflow #598

### DIFF
--- a/statgpt/common/data/sdmx/v21/attributes_creator.py
+++ b/statgpt/common/data/sdmx/v21/attributes_creator.py
@@ -8,6 +8,7 @@ from statgpt.common.data.sdmx.v21.attribute import (
     Sdmx21CodeListAttribute,
     Sdmx21StringAttribute,
 )
+from statgpt.common.data.sdmx.v21.representation import resolve_representation
 from statgpt.common.data.sdmx.v21.schemas import StructureMessage21, Urn
 from statgpt.common.data.sdmx.v21.urn_utils import lookup_urn
 
@@ -51,11 +52,7 @@ class Sdmx21AttributesCreator:
 
     def _create_attribute_from_concept(self, attribute: common.DataAttribute) -> Sdmx21Attribute:
         concept = self._get_concept_for(attribute)
-        representation = concept.core_representation
-        if not representation:
-            representation = attribute.local_representation
-            if not representation:
-                raise ValueError(f"Concept {concept} has neither core nor local representation")
+        representation = resolve_representation(attribute, concept)
 
         name = concept.name[self._locale]
         description = concept.description.localizations.get(self._locale)
@@ -66,7 +63,7 @@ class Sdmx21AttributesCreator:
             # so that we see which representations are used for each attribute.
             # But get_dataset() is called often when answering the user query (by chat facade).
             # TODO: either control when to produce this log depending on the context, or remove it.
-            # logger.info(f"Creating code list attribute from core_representation for {attribute=}")
+            # logger.info(f"Creating code list attribute from {representation=} for {attribute=}")
             result_attribute = self._create_code_list_attribute(
                 code_list_ref=representation.enumerated,
                 attribute=attribute,

--- a/statgpt/common/data/sdmx/v21/representation.py
+++ b/statgpt/common/data/sdmx/v21/representation.py
@@ -1,0 +1,54 @@
+"""Resolving the effective SDMX 2.1 representation of a component.
+
+SDMX 2.1 resolves a component's representation in three steps: the component's own
+`LocalRepresentation`, then the `CoreRepresentation` of the concept it identifies, then the
+standard's default of untyped `xs:string`. The last step is normative - `ConceptType` in
+`SDMXStructureConcept.xsd` states that a concept without a `TextFormat` or core representation
+"is assumed to be represented by any set of valid characters (corresponding to the xs:string
+datatype of W3C XML Schema)" - and `AttributeType` explicitly allows a component to declare
+neither representation.
+
+`sdmx1` models the first two steps as optional fields and never supplies the third, so a caller
+that treats a missing representation as an error rejects structures the standard allows. One such
+component used to abort the whole dataflow.
+"""
+
+import logging
+
+from sdmx.model import common
+
+_log = logging.getLogger(__name__)
+
+
+def resolve_representation(
+    component: common.Component, concept: common.Concept
+) -> common.Representation:
+    """Effective representation of `component`, defaulting to untyped string.
+
+    The local representation of the component overrides the core representation of the concept
+    it identifies, per `ComponentType`: the concept is the fallback "if a representation
+    (LocalRepresentation) is not supplied".
+    """
+
+    if component.local_representation is not None:
+        return component.local_representation
+    if concept.core_representation is not None:
+        return concept.core_representation
+
+    _log.debug(
+        f"Neither {component=} nor {concept=} declares a representation."
+        " Defaulting to untyped string, per SDMX 2.1."
+    )
+    return string_representation()
+
+
+def string_representation() -> common.Representation:
+    """A new untyped-string representation.
+
+    Returns a fresh object on every call: `sdmx1` model objects are mutable, so components must
+    not share one.
+    """
+
+    return common.Representation(
+        non_enumerated=[common.Facet(value_type=common.FacetValueType.string)]
+    )

--- a/tests/unit/common/data/sdmx/v21/test_attributes_creator.py
+++ b/tests/unit/common/data/sdmx/v21/test_attributes_creator.py
@@ -1,0 +1,191 @@
+"""Tests for SDMX 2.1 attribute creation: representation resolution and its string default."""
+
+from dataclasses import dataclass, field
+
+from sdmx.model import common
+from sdmx.model.v21 import DataflowDefinition, DataStructureDefinition
+
+from statgpt.common.data.base import AttributeType
+from statgpt.common.data.sdmx.v21.attribute import (
+    Sdmx21Attribute,
+    Sdmx21CodeListAttribute,
+    Sdmx21StringAttribute,
+)
+from statgpt.common.data.sdmx.v21.attributes_creator import Sdmx21AttributesCreator
+from statgpt.common.data.sdmx.v21.schemas import StructureMessage21, Urn
+
+AGENCY = "TEST_AGENCY"
+LOCALE = "en"
+
+CODELIST_ID = "CL_TEST_OBS_STATUS"
+CORE_VERSION = "1.0"
+LOCAL_VERSION = "1.5"
+
+# Two versions of the same codelist that genuinely disagree: the newer one, referenced by the
+# attribute's local representation, carries a code the older one (referenced by the concept's core
+# representation) never had.
+CODE_IN_BOTH = "CODE_A"
+CODE_IN_LOCAL_ONLY = "CODE_B"
+
+
+@dataclass
+class AttributeSpec:
+    """One attribute of the data structure, with the representations declared for it."""
+
+    id: str
+    name: str
+    local: common.Representation | None = None
+    core: common.Representation | None = None
+    codelists: list[common.Codelist] = field(default_factory=list)
+
+
+def _codelist(version: str, code_ids: list[str]) -> common.Codelist:
+    codelist = common.Codelist(id=CODELIST_ID, maintainer=common.Agency(id=AGENCY), version=version)
+    for code_id in code_ids:
+        codelist.append(common.Code(id=code_id, name=f"{code_id} ({version})"))
+    return codelist
+
+
+def _string_representation() -> common.Representation:
+    return common.Representation(
+        non_enumerated=[common.Facet(value_type=common.FacetValueType.string)]
+    )
+
+
+def _coded_attribute_spec() -> AttributeSpec:
+    """An attribute whose concept declares an enumerated core representation, and nothing local."""
+    codelist = _codelist(CORE_VERSION, [CODE_IN_BOTH])
+    return AttributeSpec(
+        id="OBS_STATUS",
+        name="Observation status",
+        core=common.Representation(enumerated=codelist),
+        codelists=[codelist],
+    )
+
+
+def _build_message(specs: list[AttributeSpec]) -> tuple[StructureMessage21, Urn]:
+    agency = common.Agency(id=AGENCY)
+
+    concept_scheme = common.ConceptScheme(id="CS_TEST", maintainer=agency, version="1.0")
+    dsd = DataStructureDefinition(id="DSD_TEST", maintainer=agency, version="1.0")
+
+    for spec in specs:
+        concept = common.Concept(id=spec.id, name=spec.name, parent=concept_scheme)
+        concept.core_representation = spec.core
+        concept_scheme.append(concept)
+        dsd.attributes.append(
+            common.DataAttribute(
+                id=spec.id, concept_identity=concept, local_representation=spec.local
+            )
+        )
+
+    dataflow = DataflowDefinition(
+        id="DSD_TEST@DF_TEST", maintainer=agency, version="1.0", structure=dsd
+    )
+
+    message = StructureMessage21()
+    urn = Urn.for_artifact(dataflow)
+    message.dataflow[urn] = dataflow
+    message.structure[Urn.for_artifact(dsd)] = dsd
+    message.concept_scheme[Urn.for_artifact(concept_scheme)] = concept_scheme
+    message.add_codelists([codelist for spec in specs for codelist in spec.codelists])
+    return message, urn
+
+
+def _create_attributes(specs: list[AttributeSpec]) -> dict[str, Sdmx21Attribute]:
+    message, urn = _build_message(specs)
+    attributes = Sdmx21AttributesCreator(message, urn, LOCALE)._create_attributes()
+    return {attribute.entity_id: attribute for attribute in attributes}
+
+
+def test_attribute_without_representation_defaults_to_string() -> None:
+    """An attribute with no representation on either side resolves to a string attribute.
+
+    Regression test: raising here lost the whole dataflow, because every attribute is built in
+    one comprehension. SDMX 2.1 defines the default representation as untyped `xs:string`, so
+    `VAR` in OECD.SDD.TPS:DSD_SDBSBD_ISIC4@DF_BD_API is a valid string-valued attribute.
+    """
+    spec = AttributeSpec(id="VAR", name="Variable", local=None, core=None)
+
+    attributes = _create_attributes([spec])
+
+    attribute = attributes["VAR"]
+    assert isinstance(attribute, Sdmx21StringAttribute)
+    assert attribute.attribute_type == AttributeType.STRING
+    assert attribute.name == "Variable"
+
+
+def test_local_string_facet_resolves_to_string_attribute() -> None:
+    """An uncoded local representation still resolves to a string attribute.
+
+    This is the `LOCAL_AREA_NAME` shape, where the provider declares
+    `TextFormat textType="String"` explicitly.
+    """
+    spec = AttributeSpec(
+        id="LOCAL_AREA_NAME", name="Local area name", local=_string_representation()
+    )
+
+    attributes = _create_attributes([spec])
+
+    assert isinstance(attributes["LOCAL_AREA_NAME"], Sdmx21StringAttribute)
+
+
+def test_core_representation_used_when_no_local_representation() -> None:
+    """The concept's core representation remains the fallback when the attribute declares none."""
+    attributes = _create_attributes([_coded_attribute_spec()])
+
+    attribute = attributes["OBS_STATUS"]
+    assert isinstance(attribute, Sdmx21CodeListAttribute)
+    assert attribute.attribute_type == AttributeType.CATEGORY
+    assert attribute.code_list.code_list.version == CORE_VERSION
+
+
+def test_local_representation_overrides_core_representation() -> None:
+    """An attribute's local representation wins over the concept's core representation.
+
+    SDMX 2.1 inherits from the concept only when the component declares no local representation.
+    Preferring the core representation resolved the attribute to the older codelist version, so
+    any code added in a later version was missing from it.
+    """
+    local_codelist = _codelist(LOCAL_VERSION, [CODE_IN_BOTH, CODE_IN_LOCAL_ONLY])
+    core_codelist = _codelist(CORE_VERSION, [CODE_IN_BOTH])
+    spec = AttributeSpec(
+        id="OBS_STATUS",
+        name="Observation status",
+        local=common.Representation(enumerated=local_codelist),
+        core=common.Representation(enumerated=core_codelist),
+        codelists=[local_codelist, core_codelist],
+    )
+
+    attributes = _create_attributes([spec])
+
+    attribute = attributes["OBS_STATUS"]
+    assert isinstance(attribute, Sdmx21CodeListAttribute)
+    assert attribute.code_list.code_list.version == LOCAL_VERSION
+    assert CODE_IN_LOCAL_ONLY in attribute.code_list
+
+
+def test_representation_less_attribute_does_not_abort_the_other_attributes() -> None:
+    """A dataflow shaped like DSD_SDBSBD_ISIC4 keeps all four of its attributes."""
+    coded_ids = ["DECIMALS", "OBS_STATUS", "UNIT_MULT"]
+    specs = []
+    for attribute_id in coded_ids:
+        codelist = _codelist(CORE_VERSION, [CODE_IN_BOTH])
+        specs.append(
+            AttributeSpec(
+                id=attribute_id,
+                name=attribute_id.capitalize(),
+                local=common.Representation(enumerated=codelist),
+                core=common.Representation(enumerated=codelist),
+                codelists=[codelist],
+            )
+        )
+    specs.append(AttributeSpec(id="VAR", name="Variable"))
+
+    attributes = _create_attributes(specs)
+
+    assert sorted(attributes) == sorted(coded_ids + ["VAR"])
+    assert all(
+        isinstance(attributes[attribute_id], Sdmx21CodeListAttribute) for attribute_id in coded_ids
+    )
+    assert isinstance(attributes["VAR"], Sdmx21StringAttribute)


### PR DESCRIPTION
## Applicable issues

- closes #598

## Description of changes

An SDMX attribute may declare no `LocalRepresentation`, and its concept no `CoreRepresentation`.
SDMX 2.1 defines the default for that case as untyped `xs:string`, but `Sdmx21AttributesCreator`
raised instead — and because it builds every attribute in one comprehension, a single such
attribute aborted the whole dataflow. `VAR` in `OECD.SDD.TPS:DSD_SDBSBD_ISIC4@DF_BD_API` could
therefore be neither previewed in the Admin Portal nor loaded for indexing or querying.

- Add `statgpt/common/data/sdmx/v21/representation.py`: `resolve_representation()` applies the
  standard's chain — local representation, then the concept's core representation, then untyped
  string.
- `attributes_creator._create_attribute_from_concept` uses it and stops raising. The existing
  `non_enumerated` branch already builds `Sdmx21StringAttribute`, so nothing else changes. The
  helper also fixes the inverted precedence on the attribute side, matching the dimension-side fix
  in #580.
- Add unit tests for the string default, the `LOCAL_AREA_NAME` shape, the core-representation
  fallback, local-over-core precedence, and a full `DSD_SDBSBD_ISIC4`-shaped attribute list.
- Add the design doc, `docs/design/sdmx-attribute-string-default.md`.

Verified against the captured OECD structure message: `DECIMALS`, `OBS_STATUS`, and `UNIT_MULT`
resolve to their codelists unchanged, and `VAR` becomes a `string` attribute named `Variable`.
Attribute lists for the two `*_DDOWN` dataflows are identical before and after.

Dimensions and measures are out of scope. Measures aren't built from the DSD at all. Dimensions
keep their own resolution, because the string default there only trades one fatal error for
another — the `DD_ID` string-dimension case needs its own design.

Datasets that failed to onboard hold no embeddings, so reindex them after deployment.

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.