### PR TITLE
feat: delete discovery datasets from the CLI, withdrawing their documents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ See `statgpt/cli/README.md` for full documentation.
 | `channel reindex` | Reindex dataset embeddings for a channel |
 | `discovery upload` | Upload discovery datasets (Grade C) to a channel |
 | `discovery reindex` | Reindex a channel's discovery datasets |
+| `discovery clear` | Delete a channel's discovery datasets and their published documents |
 | `content init` | Initialize channels, data sources, datasets, glossaries, discovery datasets |
 | `settings` | Show current CLI settings |
 

--- a/statgpt/admin/exception_handlers.py
+++ b/statgpt/admin/exception_handlers.py
@@ -20,6 +20,7 @@ from statgpt.admin.services.exceptions import (
     IndexingJobInProgressError,
 )
 from statgpt.common import schemas
+from statgpt.common.services import GenericRagIngestionError
 
 _log = logging.getLogger(__name__)
 
@@ -82,3 +83,15 @@ def register_exception_handlers(app: FastAPI) -> None:
         """
         _log.info(f"Refused a discovery indexing job: {exc}")
         return JSONResponse(status_code=status.HTTP_409_CONFLICT, content={"detail": str(exc)})
+
+    @app.exception_handler(GenericRagIngestionError)
+    async def _rag_unreachable(_: Request, exc: GenericRagIngestionError) -> JSONResponse:
+        """The RAG channel would not serve a call this request depends on: 502.
+
+        Reachable since deleting a record withdraws its document synchronously. Everywhere
+        else this error is raised inside an indexing job, which records it on the job row and
+        never lets it near a response - so without this it would surface as a bare 500 and a
+        caller could not tell a RAG channel that is down from a bug here.
+        """
+        _log.warning(f"Generic RAG call failed while serving a request: {exc}")
+        return JSONResponse(status_code=status.HTTP_502_BAD_GATEWAY, content={"detail": str(exc)})

--- a/statgpt/admin/services/discovery_dataset.py
+++ b/statgpt/admin/services/discovery_dataset.py
@@ -4,6 +4,7 @@ import io
 import logging
 import os
 import zipfile
+from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 
@@ -16,8 +17,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from statgpt.admin.settings.discovery import DiscoveryUploadSettings
 from statgpt.admin.settings.exim import JobsConfig
 from statgpt.common import models, schemas, utils
-from statgpt.common.services import ChannelService, DiscoveryDatasetService, RecordKey, record_key
+from statgpt.common.services import (
+    ChannelSerializer,
+    ChannelService,
+    DiscoveryDatasetService,
+    GenericRagIngestionClient,
+    RecordKey,
+    record_key,
+)
 
+from .discovery_publisher import withdraw_documents
 from .discovery_upload import COLUMN_FIELDS, FIELD_LABELS, REQUIRED_FIELDS, parse_discovery_file
 from .exceptions import (
     DiscoveryDatasetConflictError,
@@ -402,6 +411,7 @@ class AdminPortalDiscoveryDatasetService(DiscoveryDatasetService):
         item = await self._get_item_or_raise(item_id)
         _log.info(f"Deleting {item}")
 
+        await self._withdraw_documents([item])
         await self._session.delete(item)
         await self._session.commit()
 
@@ -473,13 +483,57 @@ class AdminPortalDiscoveryDatasetService(DiscoveryDatasetService):
         else:
             raise RuntimeError("Either item_ids or channel_id must be provided.")
 
-        query = (
-            delete(models.DiscoveryDataset).where(where_clause).returning(models.DiscoveryDataset)
-        )
-        deleted = (await self._session.execute(query)).scalars().all()
+        # Read the rows before deleting them rather than using `DELETE ... RETURNING`: their
+        # documents have to be withdrawn while the records that name them still exist, and the
+        # response has to be built while the instances are still readable.
+        query = select(models.DiscoveryDataset).where(where_clause)
+        doomed = list((await self._session.execute(query)).scalars().all())
+        if not doomed:
+            return []
+
+        # Serialized up front: the commit below expires the instances, and reading an expired
+        # attribute in an async session raises instead of lazy-loading.
+        deleted = [self._serialize(item) for item in doomed]
+
+        await self._withdraw_documents(doomed)
+        await self._session.execute(delete(models.DiscoveryDataset).where(where_clause))
         await self._session.commit()
         _log.info(f"Deleted {len(deleted)} discovery datasets.")
-        return [self._serialize(item) for item in deleted]
+        return deleted
+
+    async def _withdraw_documents(self, records: Sequence[models.DiscoveryDataset]) -> None:
+        """Remove the RAG documents of records that are about to be deleted.
+
+        The documents go first and the rows second, for the reason `DiscoveryPublisher._withdraw`
+        gives: a crash in between leaves a record with no document behind it, which the next
+        indexing run repairs, while the opposite order strands a live document that nothing
+        points at any more and only an orphan sweep would ever find.
+
+        A failure is not swallowed. Deleting the record while its document survives is exactly
+        what this exists to prevent, so the caller is left to fail with the rows intact.
+        """
+        by_channel: dict[int, list[models.DiscoveryDataset]] = defaultdict(list)
+        for record in records:
+            by_channel[record.channel_id].append(record)
+
+        channels = ChannelService(self._session)
+        for channel_id, group in by_channel.items():
+            channel = await channels.get_model_by_id(channel_id)
+            config = ChannelSerializer.db_to_schema(channel).details.discovery_rag
+            if config is None:
+                # No publish target, so nothing was ever published. Refusing the delete here
+                # would block it over a document that cannot exist.
+                continue
+
+            keys = {record_key(record.agency, record.dataset_id) for record in group}
+            async with GenericRagIngestionClient.for_application(
+                config.get_application_id()
+            ) as client:
+                withdrawn = await withdraw_documents(client, channel.deployment_id, keys)
+            _log.info(
+                f"Withdrew {withdrawn} discovery document(s) of channel"
+                f" {channel.deployment_id} for {len(group)} record(s) being deleted."
+            )
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ upsert ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/statgpt/admin/services/discovery_publisher.py
+++ b/statgpt/admin/services/discovery_publisher.py
@@ -11,7 +11,7 @@ rather than of an algorithm here.
 import asyncio
 import hashlib
 import logging
-from collections.abc import Iterable, Sequence
+from collections.abc import Collection, Iterable, Sequence
 from dataclasses import dataclass, field
 from time import monotonic
 from typing import NamedTuple
@@ -31,6 +31,8 @@ from .discovery_validation import DiscoveryRecord
 from .exceptions import DiscoveryMetadataSchemaError
 
 _log = logging.getLogger(__name__)
+
+_SETTINGS = DiscoveryPublishSettings()
 
 
 class _RenderedField(NamedTuple):
@@ -192,6 +194,72 @@ def document_key(document: schemas.GenericRagDocument) -> RecordKey | None:
     return key if all(key) else None
 
 
+def is_channel_document(
+    document: schemas.GenericRagDocument, channel: str, grade: schemas.DiscoveryGrade
+) -> bool:
+    """Whether this document was published by this grade, for this channel.
+
+    The channel is identified by its deployment id rather than its row id, so a document stays
+    recognizable as this channel's after the channel is moved to another environment, where the
+    row id would differ.
+    """
+    metadata = document.metadata
+    return metadata.get("grade") == grade and metadata.get("statgpt_channel") == channel
+
+
+async def withdraw_documents(
+    client: GenericRagIngestionClient,
+    channel: str,
+    keys: Collection[RecordKey],
+    *,
+    grade: schemas.DiscoveryGrade = schemas.DiscoveryGrade.C,
+    concurrency: int | None = None,
+) -> int:
+    """Delete this channel's documents for `keys`, returning how many went.
+
+    What a record's deletion needs, as opposed to what an indexing run needs. It reconciles
+    nothing: a key not in `keys` is left alone, whatever state it is in, so removing one record
+    cannot disturb another one's document.
+
+    Two differences from the reconciliation the publisher does, both following from that:
+
+    Every document claiming one of the keys goes, not one per key. `_load_documents` keeps the
+    highest id of a duplicated key and treats the rest as orphans for the run to sweep; here
+    there is no run to follow, and a leftover duplicate would keep serving a record that was
+    deleted - which is the whole point of withdrawing.
+
+    A failure propagates. `_delete_orphan` swallows one because an orphan belongs to no record
+    and the next run retries it; here the caller is about to drop the row that is the last
+    thing pointing at the document, so it has to learn that the document is still there.
+    """
+    if not keys:
+        return 0
+
+    documents = [
+        document
+        for document in await client.list_documents()
+        if is_channel_document(document, channel, grade) and document_key(document) in keys
+    ]
+    try:
+        await async_utils.gather_with_concurrency(
+            concurrency if concurrency is not None else _SETTINGS.concurrency,
+            *(client.delete_document(document.id) for document in documents),
+        )
+    except BaseExceptionGroup as group:
+        # The group is an artifact of the task group inside `gather_with_concurrency`, and it
+        # matches neither an `except GenericRagIngestionError` nor an exception handler
+        # registered on it. The remaining leaves are the same outage counted once per document.
+        raise _first_leaf(group) from group
+    return len(documents)
+
+
+def _first_leaf(exc: BaseException) -> BaseException:
+    """The first real exception inside a possibly nested exception group."""
+    while isinstance(exc, BaseExceptionGroup):
+        exc = exc.exceptions[0]
+    return exc
+
+
 @dataclass
 class PublishCounts:
     """What a publish stage did. Reported on the job row."""
@@ -243,8 +311,6 @@ class DiscoveryPublisher:
     error - and leaves persisting them to the caller.
     """
 
-    _SETTINGS = DiscoveryPublishSettings()
-
     def __init__(
         self,
         client: GenericRagIngestionClient,
@@ -266,9 +332,9 @@ class DiscoveryPublisher:
         self._channel = channel
         self._grade = grade
         self._force = force
-        self._concurrency = concurrency if concurrency is not None else self._SETTINGS.concurrency
+        self._concurrency = concurrency if concurrency is not None else _SETTINGS.concurrency
         self._settle_timeout = (
-            self._SETTINGS.settle_timeout_seconds
+            _SETTINGS.settle_timeout_seconds
             if settle_timeout_seconds is None
             else settle_timeout_seconds
         )
@@ -353,17 +419,8 @@ class DiscoveryPublisher:
         return by_key, unclaimed
 
     def _is_ours(self, document: schemas.GenericRagDocument) -> bool:
-        """Whether this document was published by this grade, for this channel.
-
-        The channel is identified by its deployment id rather than its row id, so a document
-        stays recognizable as this channel's after the channel is moved to another
-        environment, where the row id would differ.
-        """
-        metadata = document.metadata
-        return (
-            metadata.get("grade") == self._grade
-            and metadata.get("statgpt_channel") == self._channel
-        )
+        """Whether this document was published by this grade, for this channel."""
+        return is_channel_document(document, self._channel, self._grade)
 
     async def _apply_safely(
         self, record: models.DiscoveryDataset, document: schemas.GenericRagDocument | None

--- a/statgpt/cli/README.md
+++ b/statgpt/cli/README.md
@@ -84,6 +84,7 @@ This is useful for troubleshooting and reporting bugs.
 | `channel deduplicate` | Deduplicate embeddings for a channel   |
 | `discovery upload`    | Upload discovery datasets to a channel |
 | `discovery reindex`   | Reindex a channel's discovery datasets |
+| `discovery clear`     | Delete a channel's discovery datasets  |
 | `content init`        | Initialize content from config files   |
 | `settings`            | Show current CLI settings and sources  |
 
@@ -156,7 +157,9 @@ statgpt> discovery upload -c my-channel --file records.xlsx
 | `-f, --file`    | Path to the `.xlsx` or `.csv` file (prompts if omitted)                       |
 | `--mode`        | `upsert` (default) keeps records absent from the file; `replace` deletes them |
 
-Uploading does not publish anything: run `discovery reindex` afterwards. A file whose cells
+Uploading does not publish anything: run `discovery reindex` afterwards. That goes for what
+`--mode replace` deletes too - its documents are withdrawn by the next indexing run, not by
+the upload. Only an explicit `discovery clear` withdraws documents itself. A file whose cells
 cannot be read is refused in full - nothing is saved - and every offending row is listed with
 its cell reference, with a non-zero exit code. See [Batch Summaries and Exit
 Codes](#batch-summaries-and-exit-codes).
@@ -178,6 +181,26 @@ statgpt> discovery reindex -c my-channel
 
 Requires a `discoveryRag` block in the channel configuration, and refuses to start while
 another job for the channel is running.
+
+### discovery clear
+
+Deletes every discovery record of a channel, and the documents they published to the Generic
+RAG application. Asks for confirmation, naming the channel and how many records would go.
+
+```
+statgpt> discovery clear -c my-channel
+statgpt> discovery clear -c my-channel -y        # scripted, no prompt
+```
+
+| Option          | Description                                    |
+|-----------------|------------------------------------------------|
+| `-c, --channel` | Channel deployment ID (interactive if omitted) |
+| `-y, --yes`     | Skip the confirmation prompt                   |
+
+No reindex is needed afterwards: the documents are withdrawn as part of the delete. If the RAG
+application cannot be reached the command fails and nothing is deleted, so a record never
+outlives its document. A channel with no `discoveryRag` block simply has its records deleted -
+it never published anything.
 
 ### content init
 

--- a/statgpt/cli/commands/discovery.py
+++ b/statgpt/cli/commands/discovery.py
@@ -153,6 +153,38 @@ async def reindex_handler(channel: str | None = None, force: bool = False) -> No
         print_success("Discovery indexing completed")
 
 
+async def clear_handler(channel: str | None = None, yes: bool = False) -> None:
+    """Delete every discovery dataset of a channel, and its published documents."""
+    async with get_admin_client() as client:
+        selected_channel = await select_channel(client, channel)
+        if not selected_channel:
+            return
+
+        stats = await client.get_discovery_stats(selected_channel.id)
+        if not stats.total:
+            print_info(f"{selected_channel.deployment_id} holds no discovery datasets.")
+            return
+
+        if not yes and not confirm_interactive(
+            f"Delete all {stats.total} discovery dataset(s) of"
+            f" {selected_channel.deployment_id} and their published documents?",
+            default=False,
+            error_message=(
+                "Deleting a channel's discovery datasets requires confirmation.\n"
+                "  Use -y/--yes to skip it.\n"
+                "  Usage: statgpt discovery clear -c <channel> -y"
+            ),
+        ):
+            print_info("Aborted.")
+            return
+
+        # Not instant: the records' documents are withdrawn from the RAG channel first.
+        with spinner_status(f"Deleting discovery datasets of {selected_channel.title}..."):
+            deleted = await client.clear_discovery_datasets(selected_channel.id)
+
+        print_success(f"Deleted {len(deleted)} record(s) and their published documents")
+
+
 upload_command = Command(
     name="upload",
     description="Upload a discovery datasets workbook (.xlsx) or CSV to a channel",
@@ -202,6 +234,26 @@ reindex_command = Command(
 )
 
 
+clear_command = Command(
+    name="clear",
+    description="Delete all discovery datasets of a channel and their published documents",
+    handler=clear_handler,
+    args=[
+        CommandArg(
+            name="channel",
+            short_name="c",
+            description="Channel deployment ID",
+        ),
+        CommandArg(
+            name="yes",
+            short_name="y",
+            description="Skip confirmation prompt",
+            is_flag=True,
+        ),
+    ],
+)
+
+
 # Command group
 discovery_group = CommandGroup(
     name="discovery",
@@ -209,3 +261,4 @@ discovery_group = CommandGroup(
 )
 discovery_group.add_command(upload_command)
 discovery_group.add_command(reindex_command)
+discovery_group.add_command(clear_command)

--- a/statgpt/cli/shared/admin_client.py
+++ b/statgpt/cli/shared/admin_client.py
@@ -21,6 +21,7 @@ from statgpt.common.schemas import (
     DataSource,
     DataSourceType,
     DeduplicationJob,
+    DiscoveryDataset,
     DiscoveryDatasetStats,
     DiscoveryIndexingJob,
     DiscoveryPayloadErrorDetail,
@@ -45,6 +46,7 @@ _channel_datasets_adapter = TypeAdapter(list[ChannelDatasetExpanded])
 _data_sources_adapter = TypeAdapter(list[DataSource])
 _data_source_types_adapter = TypeAdapter(list[DataSourceType])
 _glossary_terms_adapter = TypeAdapter(list[GlossaryTerm])
+_discovery_datasets_adapter = TypeAdapter(list[DiscoveryDataset])
 
 
 class AdminAPIError(Exception):
@@ -384,6 +386,18 @@ class AdminClient:
             raise _payload_error(resp)
         self._raise_for_status(resp)
         return DiscoveryUploadSummary.model_validate(resp.json())
+
+    async def clear_discovery_datasets(self, channel_id: int) -> list[DiscoveryDataset]:
+        """Delete every discovery dataset of a channel, and its published document.
+
+        The API answers with the deleted records themselves as a bare list, not the
+        `{"data": [...]}` envelope the paginated `get_*` endpoints use.
+        """
+        resp = await self._client.delete(
+            self._url(f"/channels/{channel_id}/discovery-datasets/bulk")
+        )
+        self._raise_for_status(resp)
+        return _discovery_datasets_adapter.validate_python(resp.json())
 
     async def trigger_discovery_indexing(
         self, channel_id: int, force: bool = False

--- a/tests/unit/admin/services/test_discovery_delete.py
+++ b/tests/unit/admin/services/test_discovery_delete.py
@@ -1,0 +1,239 @@
+"""Deleting a discovery record withdraws the document it published.
+
+The reconciliation itself is `withdraw_documents`, covered in `test_discovery_publisher`. What
+is checked here is the orchestration around it: that it runs before the rows go, that records
+are grouped by the channel whose RAG application holds their documents, and that a channel with
+nowhere to publish to is not stopped from deleting its records.
+"""
+
+import datetime
+from collections.abc import Sequence
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from statgpt.admin.services import discovery_dataset as service_module
+from statgpt.admin.services.discovery_dataset import AdminPortalDiscoveryDatasetService
+from statgpt.admin.services.discovery_upload import COLUMN_FIELDS
+from statgpt.common import models
+from statgpt.common.schemas import DiscoveryIndexingStatus, DiscoveryValidationStatus
+from statgpt.common.services import GenericRagIngestionError, record_key
+
+_APPLICATION = "discovery-rag-app"
+_TIMESTAMP = datetime.datetime(2026, 8, 26, tzinfo=datetime.timezone.utc)
+
+
+def _stored(
+    item_id: int = 1,
+    channel_id: int = 1,
+    agency: str = "Bank Indonesia (BI)",
+    dataset_id: str = "TABEL1_1",
+) -> models.DiscoveryDataset:
+    """A stand-in for a stored row, carrying the columns the service reads."""
+    values: dict[str, object] = {name: "" for name in COLUMN_FIELDS}
+    values.update(
+        id=item_id,
+        channel_id=channel_id,
+        agency=agency,
+        dataset_id=dataset_id,
+        validation_status=DiscoveryValidationStatus.VALID,
+        validation_issues=None,
+        validated_at=None,
+        indexing_status=DiscoveryIndexingStatus.INDEXED,
+        indexed_at=None,
+        index_error=None,
+        created_at=_TIMESTAMP,
+        updated_at=_TIMESTAMP,
+    )
+    return cast(models.DiscoveryDataset, SimpleNamespace(**values))
+
+
+@pytest.fixture
+def calls() -> list[str]:
+    """The order the steps ran in, which is what most of these tests are about."""
+    return []
+
+
+@pytest.fixture
+def rag_client() -> AsyncMock:
+    client = AsyncMock()
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = False
+    return client
+
+
+@pytest.fixture
+def withdrawn() -> list[tuple[str, set[tuple[str, str]]]]:
+    """One entry per `withdraw_documents` call: (channel deployment id, record keys)."""
+    return []
+
+
+@pytest.fixture(autouse=True)
+def _rag(
+    monkeypatch: pytest.MonkeyPatch,
+    calls: list[str],
+    rag_client: AsyncMock,
+    withdrawn: list[tuple[str, set[tuple[str, str]]]],
+) -> None:
+    """Stand in for everything between the service and the RAG channel."""
+
+    def channel_service(_session: Any) -> Any:
+        return SimpleNamespace(
+            get_model_by_id=AsyncMock(
+                side_effect=lambda channel_id: SimpleNamespace(
+                    id=channel_id, deployment_id=f"channel-{channel_id}"
+                )
+            )
+        )
+
+    def db_to_schema(channel: Any) -> Any:
+        # Channel 2 stands for one with no publish target configured.
+        config = (
+            None
+            if channel.id == 2
+            else SimpleNamespace(get_application_id=lambda: f"{_APPLICATION}-{channel.id}")
+        )
+        return SimpleNamespace(details=SimpleNamespace(discovery_rag=config))
+
+    async def withdraw(client: Any, channel: str, keys: Any, **_: Any) -> int:
+        calls.append(f"withdraw:{channel}")
+        withdrawn.append((channel, set(keys)))
+        return len(keys)
+
+    monkeypatch.setattr(service_module, "ChannelService", channel_service)
+    monkeypatch.setattr(
+        service_module, "ChannelSerializer", SimpleNamespace(db_to_schema=db_to_schema)
+    )
+    monkeypatch.setattr(
+        service_module.GenericRagIngestionClient,
+        "for_application",
+        classmethod(lambda cls, application_id: rag_client),
+    )
+    monkeypatch.setattr(service_module, "withdraw_documents", withdraw)
+
+
+def _service(
+    calls: list[str], stored: Sequence[models.DiscoveryDataset]
+) -> AdminPortalDiscoveryDatasetService:
+    """A service whose session hands back `stored` for the select and records what ran."""
+    service = AdminPortalDiscoveryDatasetService(session=MagicMock())
+
+    async def execute(statement: Any) -> Any:
+        operation = "select" if statement.is_select else "delete"
+        calls.append(operation)
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = list(stored)
+        return result
+
+    service._session.execute = AsyncMock(side_effect=execute)  # type: ignore[method-assign]
+    service._session.commit = AsyncMock(side_effect=lambda: calls.append("commit"))  # type: ignore[method-assign]
+    service._session.delete = AsyncMock(side_effect=lambda _: calls.append("delete"))  # type: ignore[method-assign]
+    return service
+
+
+async def test_documents_are_withdrawn_before_the_rows_are_deleted(calls: list[str]) -> None:
+    """A crash in between must leave a record with no document, never the reverse.
+
+    A record with no document is what the next indexing run republishes; a document with no
+    record is invisible to everything except an orphan sweep, and goes on being retrievable.
+    """
+    service = _service(calls, [_stored()])
+
+    await service.delete_records_bulk(channel_id=1)
+
+    assert calls == ["select", "withdraw:channel-1", "delete", "commit"]
+
+
+async def test_deleted_records_are_returned_after_the_commit_expired_them(
+    calls: list[str],
+) -> None:
+    """The response is built while the instances are still readable.
+
+    A commit expires them, and reading an expired attribute in an async session raises
+    instead of lazy-loading - so a response assembled afterwards would blow up.
+    """
+    service = _service(calls, [_stored(item_id=7, dataset_id="TABEL7")])
+
+    deleted = await service.delete_records_bulk(channel_id=1)
+
+    assert [(item.id, item.dataset_id) for item in deleted] == [(7, "TABEL7")]
+
+
+async def test_records_are_withdrawn_from_the_channel_that_published_them(
+    calls: list[str], withdrawn: list[tuple[str, set[tuple[str, str]]]]
+) -> None:
+    """Ids are global, so a bulk delete by id can span channels."""
+    service = _service(
+        calls,
+        [
+            _stored(item_id=1, channel_id=1, dataset_id="TABEL1"),
+            _stored(item_id=2, channel_id=3, dataset_id="TABEL2"),
+            _stored(item_id=3, channel_id=1, dataset_id="TABEL3"),
+        ],
+    )
+
+    await service.delete_records_bulk(item_ids=[1, 2, 3])
+
+    assert dict(withdrawn) == {
+        "channel-1": {
+            record_key("Bank Indonesia (BI)", "TABEL1"),
+            record_key("Bank Indonesia (BI)", "TABEL3"),
+        },
+        "channel-3": {record_key("Bank Indonesia (BI)", "TABEL2")},
+    }
+
+
+async def test_a_channel_with_no_publish_target_still_deletes_its_records(
+    calls: list[str], rag_client: AsyncMock
+) -> None:
+    """Nothing was ever published, so refusing over a document that cannot exist is wrong."""
+    service = _service(calls, [_stored(channel_id=2)])
+
+    deleted = await service.delete_records_bulk(channel_id=2)
+
+    assert len(deleted) == 1
+    assert calls == ["select", "delete", "commit"]
+    rag_client.__aenter__.assert_not_awaited()
+
+
+async def test_a_failed_withdrawal_leaves_the_rows_in_place(
+    calls: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deleting the record while its document survives is what this exists to prevent."""
+
+    async def withdraw(*_: Any, **__: Any) -> int:
+        raise GenericRagIngestionError("document deletion", "boom", 503)
+
+    monkeypatch.setattr(service_module, "withdraw_documents", withdraw)
+    service = _service(calls, [_stored()])
+
+    with pytest.raises(GenericRagIngestionError):
+        await service.delete_records_bulk(channel_id=1)
+
+    assert calls == ["select"]
+
+
+async def test_a_channel_with_no_records_costs_no_round_trip(
+    calls: list[str], rag_client: AsyncMock
+) -> None:
+    service = _service(calls, [])
+
+    assert await service.delete_records_bulk(channel_id=1) == []
+    assert calls == ["select"]
+    rag_client.__aenter__.assert_not_awaited()
+
+
+async def test_deleting_one_record_withdraws_its_document(
+    calls: list[str], withdrawn: list[tuple[str, set[tuple[str, str]]]]
+) -> None:
+    """The single-record route goes through the same step as the bulk ones."""
+    item = _stored(item_id=5, dataset_id="TABEL5")
+    service = _service(calls, [item])
+    service.get_record_model_by_id = AsyncMock(return_value=item)  # type: ignore[method-assign]
+
+    await service.delete(5)
+
+    assert calls == ["withdraw:channel-1", "delete", "commit"]
+    assert withdrawn == [("channel-1", {record_key("Bank Indonesia (BI)", "TABEL5")})]

--- a/tests/unit/admin/services/test_discovery_publisher.py
+++ b/tests/unit/admin/services/test_discovery_publisher.py
@@ -15,6 +15,7 @@ from statgpt.admin.services.discovery_publisher import (
     document_filename,
     document_key,
     render_document_body,
+    withdraw_documents,
 )
 from statgpt.admin.services.discovery_upload import COLUMN_FIELDS
 from statgpt.admin.services.exceptions import DiscoveryMetadataSchemaError
@@ -27,7 +28,7 @@ from statgpt.common.schemas import (
     GenericRagDocument,
     GenericRagMetadataSchema,
 )
-from statgpt.common.services import GenericRagIngestionClient
+from statgpt.common.services import GenericRagIngestionClient, record_key
 from statgpt.common.services.generic_rag.ingestion import GenericRagIngestionError
 
 _CHANNEL = "statgpt-gtdc"
@@ -770,3 +771,52 @@ async def test_one_records_failure_does_not_cancel_the_others() -> None:
         True,
         True,
     ]
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ withdraw_documents ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+_KEY = record_key("Bank Indonesia (BI)", "TABEL1_1")
+
+
+async def test_withdraw_deletes_only_the_documents_claiming_the_given_keys() -> None:
+    """A withdrawal reconciles nothing: another record's document is not its business."""
+    wanted = _document(document_id=10)
+    other_record = _document(document_id=11, dataset_id="TABEL2_1")
+    other_channel = _document(document_id=12, channel="statgpt-other")
+    other_grade = _document(document_id=13, grade=DiscoveryGrade.B)
+    keyless = _document(document_id=14)
+    keyless.metadata.pop("dataset_id")
+    client = _client([wanted, other_record, other_channel, other_grade, keyless])
+
+    withdrawn = await withdraw_documents(client, _CHANNEL, {_KEY})
+
+    assert withdrawn == 1
+    assert [call.args[0] for call in client.delete_document.await_args_list] == [10]
+
+
+async def test_withdraw_deletes_every_document_claiming_one_key() -> None:
+    """A duplicated key leaves the record retrievable unless both documents go.
+
+    The publisher keeps the highest id and sweeps the rest as orphans on the next run. Here
+    there is no next run to rely on - the record is being deleted.
+    """
+    client = _client([_document(document_id=10), _document(document_id=20)])
+
+    withdrawn = await withdraw_documents(client, _CHANNEL, {_KEY})
+
+    assert withdrawn == 2
+    assert sorted(call.args[0] for call in client.delete_document.await_args_list) == [10, 20]
+
+
+async def test_withdraw_propagates_a_failed_deletion() -> None:
+    """The caller is about to drop the last row pointing at the document."""
+    client = _client([_document(document_id=10)])
+    client.delete_document.side_effect = GenericRagIngestionError("document deletion", "boom", 503)
+
+    with pytest.raises(GenericRagIngestionError):
+        await withdraw_documents(client, _CHANNEL, {_KEY})
+
+
+async def test_withdraw_without_keys_does_not_call_the_channel() -> None:
+    assert await withdraw_documents(_client([_document()]), _CHANNEL, set()) == 0

--- a/tests/unit/cli/commands/test_discovery_clear.py
+++ b/tests/unit/cli/commands/test_discovery_clear.py
@@ -1,0 +1,152 @@
+"""Tests for `discovery clear`.
+
+Emptying a channel is the one discovery command that cannot be undone, so what matters is
+that it does not run without being asked to, and that it does not ask when there is nothing
+to delete.
+"""
+
+import datetime
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+
+from statgpt.cli.commands import discovery as discovery_module
+from statgpt.cli.commands.discovery import clear_handler
+from statgpt.cli.settings import cli_runtime
+from statgpt.cli.shared.prompts import NonInteractiveError
+from statgpt.common.schemas import Channel, DiscoveryDatasetStats
+
+_NOW = datetime.datetime(2026, 1, 1)
+_CHANNEL_ID = 7
+_DEPLOYMENT_ID = "my-channel"
+
+
+def _channel() -> Channel:
+    return Channel(
+        id=_CHANNEL_ID,
+        created_at=_NOW,
+        updated_at=_NOW,
+        title="My Channel",
+        description="",
+        deployment_id=_DEPLOYMENT_ID,
+        llm_model="gpt-4o",
+        details={  # type: ignore[arg-type]
+            "supremeAgent": {"name": "bot", "domain": "stats", "terminologyDomain": "stats"}
+        },
+    )
+
+
+class _StubAdminClient:
+    """Answers the two reads the command makes, and records the delete."""
+
+    def __init__(self, total: int) -> None:
+        self._total = total
+        self.cleared: list[int] = []
+
+    async def health_check(self) -> bool:
+        return True
+
+    async def get_channels(self) -> list[Channel]:
+        return [_channel()]
+
+    async def get_discovery_stats(self, channel_id: int) -> DiscoveryDatasetStats:
+        return DiscoveryDatasetStats(total=self._total)
+
+    async def clear_discovery_datasets(self, channel_id: int) -> list[Any]:
+        self.cleared.append(channel_id)
+        return [object()] * self._total
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> _StubAdminClient:
+    """The command's admin client, defaulting to a channel that holds three records."""
+    stub = _StubAdminClient(total=3)
+
+    @asynccontextmanager
+    async def get_admin_client(*_: Any, **__: Any):
+        yield stub
+
+    monkeypatch.setattr(discovery_module, "get_admin_client", get_admin_client)
+    return stub
+
+
+@pytest.fixture
+def confirmations(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Every prompt shown, answered yes. Replaced per-test where a no is wanted."""
+    prompts: list[str] = []
+
+    def confirm(prompt: str, **_: Any) -> bool:
+        prompts.append(prompt)
+        return True
+
+    monkeypatch.setattr(discovery_module, "confirm_interactive", confirm)
+    return prompts
+
+
+async def test_a_confirmed_clear_deletes_the_channels_records(
+    client: _StubAdminClient, confirmations: list[str]
+) -> None:
+    await clear_handler(channel=_DEPLOYMENT_ID)
+
+    assert client.cleared == [_CHANNEL_ID]
+    assert len(confirmations) == 1
+
+
+async def test_the_prompt_names_the_channel_and_what_would_go(
+    client: _StubAdminClient, confirmations: list[str]
+) -> None:
+    """Confirming a deletion is only meaningful if it says how much is being deleted."""
+    await clear_handler(channel=_DEPLOYMENT_ID)
+
+    assert "3" in confirmations[0]
+    assert _DEPLOYMENT_ID in confirmations[0]
+    assert "documents" in confirmations[0]
+
+
+async def test_a_declined_confirmation_deletes_nothing(
+    client: _StubAdminClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(discovery_module, "confirm_interactive", lambda *_, **__: False)
+
+    await clear_handler(channel=_DEPLOYMENT_ID)
+
+    assert client.cleared == []
+
+
+async def test_yes_skips_the_prompt(client: _StubAdminClient, confirmations: list[str]) -> None:
+    await clear_handler(channel=_DEPLOYMENT_ID, yes=True)
+
+    assert client.cleared == [_CHANNEL_ID]
+    assert confirmations == []
+
+
+async def test_an_empty_channel_is_not_worth_a_prompt(
+    client: _StubAdminClient, confirmations: list[str]
+) -> None:
+    """Nothing to delete, so there is nothing to confirm and nothing to call."""
+    client._total = 0
+
+    await clear_handler(channel=_DEPLOYMENT_ID)
+
+    assert client.cleared == []
+    assert confirmations == []
+
+
+async def test_an_unknown_channel_deletes_nothing(client: _StubAdminClient) -> None:
+    await clear_handler(channel="no-such-channel")
+
+    assert client.cleared == []
+
+
+async def test_non_interactive_without_yes_says_which_flag_to_pass(
+    client: _StubAdminClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The prompt cannot be shown, so the escape hatch has to be named."""
+    monkeypatch.setattr(cli_runtime, "non_interactive", True)
+
+    with pytest.raises(NonInteractiveError) as exc_info:
+        await clear_handler(channel=_DEPLOYMENT_ID)
+
+    assert "-y/--yes" in str(exc_info.value)
+    assert client.cleared == []

--- a/tests/unit/cli/shared/test_admin_client_discovery.py
+++ b/tests/unit/cli/shared/test_admin_client_discovery.py
@@ -138,3 +138,38 @@ async def test_a_conflict_reports_the_reason_the_api_gave() -> None:
 
     assert "indexing job 3 is already running" in str(excinfo.value)
     assert "Response body" not in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_clear_deletes_the_channels_records_and_parses_the_bare_list() -> None:
+    """The endpoint answers with the deleted records themselves, not a `data` envelope."""
+    record = {
+        "id": 1,
+        "channelId": _CHANNEL_ID,
+        "agency": "Bank Indonesia (BI)",
+        "datasetId": "TABEL1_1",
+        "validationStatus": "VALID",
+        "indexingStatus": "INDEXED",
+        "createdAt": "2026-08-26T00:00:00Z",
+        "updatedAt": "2026-08-26T00:00:00Z",
+    }
+    client, requests = _client(lambda request: httpx.Response(200, json=[record]))
+
+    deleted = await client.clear_discovery_datasets(_CHANNEL_ID)
+
+    assert requests[0].method == "DELETE"
+    assert requests[0].url.path == "/admin/api/v1/channels/7/discovery-datasets/bulk"
+    assert [item.dataset_id for item in deleted] == ["TABEL1_1"]
+
+
+@pytest.mark.asyncio
+async def test_clear_reports_a_rag_channel_that_would_not_serve_the_withdrawal() -> None:
+    """Deleting withdraws documents, so an unreachable RAG channel fails the call."""
+    client, _ = _client(
+        lambda request: httpx.Response(502, json={"detail": "Generic RAG document deletion failed"})
+    )
+
+    with pytest.raises(AdminAPIError) as exc_info:
+        await client.clear_discovery_datasets(_CHANNEL_ID)
+
+    assert exc_info.value.status_code == 502


### PR DESCRIPTION
## Applicable issues

- None

## Description of changes

PR #622 gave the CLI `discovery upload` and `discovery reindex`, but no way to empty a channel's
Grade C records. The admin API already had the endpoint — `DELETE /channels/{channel_id}/discovery-datasets/bulk` —
and nothing called it.

While wiring it up, a second problem surfaced: deleting a discovery record did not withdraw the
document it had published to the channel's Generic RAG application. Only an indexing run did, as
part of its orphan sweep. So a deleted record stayed retrievable until someone remembered to
reindex, and the agent went on referring users to a dataset the administrator had removed.

**Deletion now withdraws the document.** Every explicit delete route — the single record, the bulk
delete by ids, and the channel-scoped clear — removes the deleted records' documents before it
drops the rows. The ordering is deliberate and follows the rule `DiscoveryPublisher._withdraw`
already states: a crash in between leaves a record with no document, which the next indexing run
repairs, whereas the reverse order strands a live document nothing points at any more.

A failed withdrawal fails the request with the rows intact — deleting a record while its document
survives is exactly what this exists to prevent. A channel with no `discoveryRag` block deletes its
records with no RAG call, since it never published anything. Replace-mode upload is unchanged: its
contract is "uploading does not publish", and its deletions still wait for the next indexing run.

**New command.** `discovery clear -c <channel>` reads the record count first, skips the prompt when
the channel is empty, names the channel and the count when it asks, and takes `-y/--yes` for
scripted use. No reindex hint afterwards — removal is no longer deferred.

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.