### PR TITLE
chore: carry only the description in a discovery RAG document

### DIFF
--- a/statgpt/admin/services/discovery_publisher.py
+++ b/statgpt/admin/services/discovery_publisher.py
@@ -6,6 +6,11 @@ the records say it should hold. Run by an indexing job, after validation.
 Nothing here derives, paraphrases or summarizes: the document carries the submitted metadata
 verbatim, so how discoverable a dataset is stays a property of the source's own metadata
 rather than of an algorithm here.
+
+The split between the document's body and its metadata is decided by how the application
+indexes them: its indexes are document-level and span the metadata fields alongside the
+content, so every field is searchable from where it is carried. The body is therefore the
+description alone, and repeating a field in it would only index the same text twice.
 """
 
 import asyncio
@@ -14,7 +19,6 @@ import logging
 from collections.abc import Collection, Iterable, Sequence
 from dataclasses import dataclass, field
 from time import monotonic
-from typing import NamedTuple
 
 from statgpt.admin.settings.discovery import DiscoveryPublishSettings
 from statgpt.common import models, schemas
@@ -34,32 +38,6 @@ _log = logging.getLogger(__name__)
 
 _SETTINGS = DiscoveryPublishSettings()
 
-
-class _RenderedField(NamedTuple):
-    """One `DiscoveryRecord` field and the heading it is rendered under."""
-
-    label: str
-    attribute: str
-
-
-_SUMMARY_FIELDS: tuple[_RenderedField, ...] = (
-    _RenderedField("Agency / organization", "agency"),
-    _RenderedField("Dataset ID", "dataset_id"),
-    _RenderedField("Reference area / country", "reference_area"),
-    _RenderedField("Regional coverage", "regional_coverage"),
-    _RenderedField("Excluded regional values", "excluded_regional_values"),
-    _RenderedField("Time coverage", "time_coverage"),
-    _RenderedField("Frequency coverage", "frequency_coverage"),
-    _RenderedField("Dataset URL", "url"),
-)
-"""Fields rendered as the document's leading bullet list, in workbook order."""
-
-_SECTION_FIELDS: tuple[_RenderedField, ...] = (
-    _RenderedField("Description", "description"),
-    _RenderedField("Indicators coverage", "indicators_coverage"),
-    _RenderedField("Relevant indicators not present in the dataset", "missing_indicators"),
-)
-"""Fields rendered as their own section, being prose or long ';'-separated lists."""
 
 _MAX_FILENAME_STEM = 100
 _FALLBACK_FILENAME_STEM = "discovery-dataset"
@@ -85,26 +63,17 @@ _INDEXING_FAILED = (
 
 
 def render_document_body(record: DiscoveryRecord) -> str:
-    """Render a record as the markdown document the RAG channel indexes.
+    """Render a record as the document the RAG channel indexes: its description.
 
-    Every workbook field goes in, including the ones that also travel as metadata: metadata
-    is what search filters on, the body is what it retrieves over. Leaving `name` or
-    `indicators_coverage` out of the body would hide from search exactly what a user's
-    question matches on.
+    The one field that is prose, and the only one the body carries. Everything else travels
+    as metadata, which the application's document-level indexes cover in its own right, so
+    rendering it here as well would index the same text twice and dilute what a question
+    matches against.
 
-    An empty field is omitted rather than rendered as an empty label, so a sparse record
-    does not fill the index with headings.
+    A record is only published once it validates, and validation requires a description, so
+    this is never empty for a document that reaches the channel.
     """
-    lines = [f"# {record.name or record.dataset_id}", ""]
-    lines.extend(
-        f"- **{rendered.label}:** {value}"
-        for rendered in _SUMMARY_FIELDS
-        if (value := getattr(record, rendered.attribute))
-    )
-    for rendered in _SECTION_FIELDS:
-        if value := getattr(record, rendered.attribute):
-            lines.extend(["", f"## {rendered.label}", "", value])
-    return "\n".join(lines) + "\n"
+    return record.description
 
 
 def document_filename(record: DiscoveryRecord, channel: str, grade: schemas.DiscoveryGrade) -> str:
@@ -127,7 +96,7 @@ def document_filename(record: DiscoveryRecord, channel: str, grade: schemas.Disc
     ).hexdigest()[:_FILENAME_DIGEST_CHARS]
     label = escape_invalid_filename_chars(f"{record.agency} - {record.dataset_id}")
     stem = label[:_MAX_FILENAME_STEM].strip() or _FALLBACK_FILENAME_STEM
-    return f"{stem} [{digest}].md"
+    return f"{stem} [{digest}].txt"
 
 
 @dataclass(frozen=True)
@@ -144,14 +113,14 @@ def render_document(
 ) -> DocumentFile:
     """Render a record as the file the RAG channel ingests.
 
-    The one place the document's format is decided. The channel parses what it is given with
-    `unstructured`, whose `by_title` chunking follows the markdown headings below, so the
-    record arrives as the sections it was written as.
+    The one place the document's format is decided. Plain text, because the body is one
+    field of prose: there is no structure left in it for a parser to recover, and the
+    application is configured with no parser at all.
     """
     return DocumentFile(
         filename=document_filename(record, channel, grade),
         content=render_document_body(record).encode("utf-8"),
-        mime_type=MediaTypes.MARKDOWN,
+        mime_type=MediaTypes.PLAIN_TEXT,
     )
 
 
@@ -160,8 +129,8 @@ def build_metadata(
 ) -> schemas.DiscoveryDocumentMetadata:
     """Build the document metadata: every workbook field except the description.
 
-    The description is the one field left out - it is prose, it is in the body, and it is
-    nothing search would filter on.
+    The description is the one field left out, because it is the body. Everything else is
+    carried here and nowhere else, and the application's indexes reach it here.
     """
     return schemas.DiscoveryDocumentMetadata(
         grade=grade,

--- a/statgpt/admin/services/discovery_validation.py
+++ b/statgpt/admin/services/discovery_validation.py
@@ -131,7 +131,22 @@ def _check_url(record: DiscoveryRecord) -> Iterable[DiscoveryValidationIssue]:
         )
 
 
+def _check_description(record: DiscoveryRecord) -> Iterable[DiscoveryValidationIssue]:
+    """Column G must say something, because it is the whole of the published document.
+
+    Every other field travels as document metadata; the description is the document's
+    content. A record without one is published as an empty document, which retrieval can
+    return but nothing in it can be read - so it is not fit to be indexed.
+    """
+    if not record.description:
+        yield DiscoveryValidationIssue(
+            field="description",
+            message="A description is required: it is the content of the published document.",
+        )
+
+
 DEFAULT_CHECKS: tuple[DiscoveryCheck, ...] = (
+    DiscoveryCheck(name="description", run=_check_description),
     DiscoveryCheck(name="frequency_coverage", run=_check_frequency_coverage),
     DiscoveryCheck(name="url", run=_check_url),
 )
@@ -141,6 +156,9 @@ Deliberately minimal. There is no severity axis, so a check must only emit an is
 the record genuinely should not be indexed - an advisory nitpick has nowhere to live and
 would silently make records unindexable. `reference_area` is therefore not checked against
 ISO codes: the template explicitly allows group labels such as 'Euro area' or 'World'.
+
+An absent description clears that bar rather than being a nitpick: the published document
+has nothing else in it.
 """
 
 

--- a/statgpt/common/schemas/discovery_document.py
+++ b/statgpt/common/schemas/discovery_document.py
@@ -10,21 +10,13 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 
-def _flags(*, filterable: bool = False, retrievable: bool = False) -> dict[str, Any]:
-    """Build the `json_schema_extra` marking what the RAG channel may do with a field.
+def _filterable() -> dict[str, Any]:
+    """The `json_schema_extra` letting a retrieval request pre-filter documents by a field.
 
     A fresh dict per field: Pydantic keeps whatever it is given on the `FieldInfo`, and a
     shared one would be the same object on every field that carries it.
-
-    `filterable` lets a retrieval request pre-filter documents by the field; `retrievable`
-    returns it alongside a retrieved chunk.
     """
-    extra: dict[str, Any] = {}
-    if filterable:
-        extra["enable_filtering"] = True
-    if retrievable:
-        extra["enable_in_mcp_retrieve_chunks"] = True
-    return extra
+    return {"enable_filtering": True}
 
 
 class DiscoveryDocumentMetadata(BaseModel):
@@ -45,7 +37,7 @@ class DiscoveryDocumentMetadata(BaseModel):
 
     model_config = ConfigDict(use_attribute_docstrings=True)
 
-    grade: str = Field(json_schema_extra=_flags(filterable=True))
+    grade: str = Field(json_schema_extra=_filterable())
     """Which discovery grade produced the record - see `DiscoveryGrade`.
 
     Typed as `str` rather than as the enum on purpose: this model renders the JSON-schema an
@@ -53,7 +45,7 @@ class DiscoveryDocumentMetadata(BaseModel):
     into a `$defs` block, which is a needlessly brittle thing to ask a deployment to carry.
     """
 
-    statgpt_channel: str = Field(json_schema_extra=_flags(filterable=True))
+    statgpt_channel: str = Field(json_schema_extra=_filterable())
     """Deployment id of the StatGPT channel the record belongs to.
 
     Scopes reconciliation: several channels, and both grades, can share one RAG channel, so a
@@ -62,19 +54,17 @@ class DiscoveryDocumentMetadata(BaseModel):
     environments.
     """
 
-    agency: str = Field(json_schema_extra=_flags(filterable=True, retrievable=True))
+    agency: str = Field(json_schema_extra=_filterable())
     """Publisher. A search pre-filter key."""
 
-    reference_area: str = Field(
-        default="", json_schema_extra=_flags(filterable=True, retrievable=True)
-    )
+    reference_area: str = Field(default="", json_schema_extra=_filterable())
     """Countries covered. A search pre-filter key."""
 
-    frequency_coverage: str = Field(default="", json_schema_extra=_flags(filterable=True))
+    frequency_coverage: str = Field(default="", json_schema_extra=_filterable())
     """The frequencies the dataset publishes at."""
 
-    dataset_id: str = Field(default="", json_schema_extra=_flags(retrievable=True))
-    name: str = Field(default="", json_schema_extra=_flags(retrievable=True))
+    dataset_id: str = ""
+    name: str = ""
     url: str = ""
     regional_coverage: str = ""
     excluded_regional_values: str = ""

--- a/tests/unit/admin/services/test_discovery_publisher.py
+++ b/tests/unit/admin/services/test_discovery_publisher.py
@@ -14,6 +14,7 @@ from statgpt.admin.services.discovery_publisher import (
     build_metadata,
     document_filename,
     document_key,
+    render_document,
     render_document_body,
     withdraw_documents,
 )
@@ -130,27 +131,26 @@ def _updated_ids(client: AsyncMock) -> list[int]:
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ the document ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-def test_the_body_carries_every_field_including_those_sent_as_metadata() -> None:
-    """Metadata is what search filters on; the body is what it retrieves over."""
+def test_the_body_is_the_description() -> None:
+    assert render_document_body(_record()) == "Money and Banking table."
+
+
+def test_the_body_carries_no_field_that_travels_as_metadata() -> None:
+    """The application's indexes span the metadata, so the body must not repeat it."""
     body = render_document_body(_record())
 
-    assert body.startswith("# I.1. Broad Money and its Affecting Factors\n")
-    assert "- **Agency / organization:** Bank Indonesia (BI)" in body
-    assert "- **Dataset URL:** https://www.bi.go.id/SEKI/tabel/TABEL1_1.xls" in body
-    assert "## Description\n\nMoney and Banking table." in body
-    assert "## Indicators coverage\n\nbroad money (M2) (Rp billions)" in body
-    assert body.endswith("\n")
+    assert "I.1. Broad Money and its Affecting Factors" not in body
+    assert "Bank Indonesia (BI)" not in body
+    assert "https://www.bi.go.id/SEKI/tabel/TABEL1_1.xls" not in body
+    assert "broad money (M2) (Rp billions)" not in body
 
 
-def test_the_body_omits_empty_fields() -> None:
-    body = render_document_body(_record(missing_indicators="", regional_coverage=""))
+def test_the_document_is_uploaded_as_plain_text() -> None:
+    document = render_document(_record(), _CHANNEL, DiscoveryGrade.C)
 
-    assert "Relevant indicators not present" not in body
-    assert "Regional coverage" not in body
-
-
-def test_the_body_falls_back_to_the_dataset_id_when_unnamed() -> None:
-    assert render_document_body(_record(name="")).startswith("# TABEL1_1\n")
+    assert document.mime_type == "text/plain"
+    assert document.filename.endswith(".txt")
+    assert document.content == b"Money and Banking table."
 
 
 def _filename(record, channel: str = _CHANNEL) -> str:
@@ -165,14 +165,14 @@ def test_the_filename_escapes_path_characters() -> None:
     name = _filename(_record(agency="A/B", dataset_id="C:D"))
 
     assert "/" not in name
-    assert name.endswith(".md")
+    assert name.endswith(".txt")
 
 
 def test_the_readable_part_of_the_filename_is_capped() -> None:
     name = _filename(_record(agency="A" * 200))
 
     assert name.startswith("A" * 100 + " [")
-    assert name.endswith(".md")
+    assert name.endswith(".txt")
 
 
 def test_the_filename_is_stable_for_one_record() -> None:
@@ -185,7 +185,7 @@ def test_respelling_a_record_only_changes_the_readable_label() -> None:
     original = _filename(_record())
 
     assert respelled != original
-    assert respelled[-16:] == original[-16:]  # ' [<digest>].md'
+    assert respelled[-17:] == original[-17:]  # ' [<digest>].txt'
 
 
 # The service derives a document's storage path from its name alone, so any two records that
@@ -310,7 +310,7 @@ async def test_an_edited_record_is_refreshed_in_place() -> None:
 
 async def test_a_record_whose_label_changed_is_rebuilt_under_the_new_name() -> None:
     """An update cannot rename, so the document would keep the old label for good."""
-    client = _client([_document(document_id=10, display_name="Bank Indonesia (BI) - OLD.md")])
+    client = _client([_document(document_id=10, display_name="Bank Indonesia (BI) - OLD.txt")])
     record = _record(indexing_status=DiscoveryIndexingStatus.OUTDATED)
 
     counts = await _publisher(client).publish([record])
@@ -493,7 +493,7 @@ async def test_one_failing_record_does_not_stop_the_others() -> None:
 
 
 async def test_a_failed_upload_after_a_successful_delete_leaves_nothing_indexed() -> None:
-    client = _client([_document(document_id=10, display_name="renamed.md")])
+    client = _client([_document(document_id=10, display_name="renamed.txt")])
     record = _record(indexing_status=DiscoveryIndexingStatus.OUTDATED)
     client.upload_document.side_effect = GenericRagIngestionError("document upload", "boom", 503)
 

--- a/tests/unit/admin/services/test_discovery_validation.py
+++ b/tests/unit/admin/services/test_discovery_validation.py
@@ -14,6 +14,7 @@ def _record(**overrides: str) -> DiscoveryDatasetBase:
     values: dict[str, str] = {
         "agency": "Bank Indonesia (BI)",
         "dataset_id": "TABEL1_1",
+        "description": "Money and Banking table.",
         "frequency_coverage": "Monthly",
         "url": "https://www.bi.go.id/SEKI/tabel/TABEL1_1.xls",
     }
@@ -77,6 +78,14 @@ def test_a_value_that_is_not_a_web_address_is_reported(url: str) -> None:
 
 def test_an_empty_url_is_not_an_issue() -> None:
     assert DiscoveryValidator().validate(_record(url="")) == []
+
+
+def test_a_record_without_a_description_is_reported() -> None:
+    """The description is the published document's only content."""
+    issues = DiscoveryValidator().validate(_record(description=""))
+
+    assert len(issues) == 1
+    assert issues[0].field == "description"
 
 
 def test_group_reference_areas_are_not_flagged() -> None:


### PR DESCRIPTION
## Applicable issues

- related to #547

## Description of changes

Three decisions of the Grade C publish stage, reconsidered together because they are one decision: what the RAG application indexes determines what the document has to carry.

### The application's indexes become `type: "document"`.

A `chunk` index indexed the parsed body, which is why the body had to render all twelve workbook fields — a field left out of it was a field search could not match on. A document index takes an explicit `fields` list and reads the metadata directly, so `$.metadata.name`, `$.metadata.agency` and the rest are searchable where they are already carried. `grade` and `statgpt_channel` are left out: they scope ownership rather than describe a dataset, and every document of a channel carries the same value.

### The body is the description alone.

As plain text (`.txt`, `text/plain`). It follows: with the metadata indexed in its own right, a field rendered into the body as well is the same text indexed twice. `parsers` becomes `[]` — one field of prose has no structure for `unstructured` to recover, and `by_title` chunking has nothing to follow.

### A description is now required.

It is the whole of the document's content, so a record without one would be published as a document nothing can read. `_check_description` joins the check registry; such a record reads INVALID and the next run withdraws its document.

### `enable_in_mcp_retrieve_chunks` goes.

It asked the channel to return a metadata field alongside a retrieved chunk over its MCP retrieval API, which nothing here uses — the read path is chat completions through `GenericRagAgentFactory`. `DiscoveryDocumentMetadata` keeps one flag, so `_flags(filterable=, retrievable=)` collapses to `_filterable()`, and `dataset_id` / `name` become plain defaulted fields. StatGPT's own MCP server is a different feature and is untouched.

### The application configuration is not in this repository.

`dial/core/config/config.json` is gitignored and a deployment's copy lives in the helm chart. The metadata schema is still generated from the model with `scripts/print_discovery_metadata_schema.py`; the `indexes` block below has to be applied by hand.

<details>

<summary>The <code>applicationProperties</code> the Generic RAG application needs</summary>

```jsonc
{
  "metadata_schema": { /* python scripts/print_discovery_metadata_schema.py */ },
  "parsers": [],
  "indexes": {
    "keyword": {
      "type": "document",
      "display_name": "Keyword search",
      "fields": [
        "$.metadata.agency",
        "$.metadata.reference_area",
        "$.metadata.frequency_coverage",
        "$.metadata.dataset_id",
        "$.metadata.name",
        "$.metadata.url",
        "$.metadata.regional_coverage",
        "$.metadata.excluded_regional_values",
        "$.metadata.time_coverage",
        "$.metadata.indicators_coverage",
        "$.metadata.missing_indicators",
        "$.content"
      ],
      "indexer": { "type": "text_normalizer", "language": "english" },
      "storage": { "backend": "elastic" }
    },
    "text-embedding-3-large": {
      "type": "document",
      "display_name": "Semantic search",
      "fields": [ /* the same list */ ],
      "indexer": { "type": "text_embeddings", "deployment_name": "text-embedding-3-large" }
    }
  },
  "retriever": { "type": "classic", "document_selector": { "type": "explicit" } },
  "generation": { "type": "default", "llm": { "deployment_name": "..." }, "metadata_instructions": {} }
}
```

</details>

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
