### PR TITLE
feat: return Data Query eval attachments in direct tool calls #630

### DIFF
--- a/statgpt/app/chains/data_query/data_query_artifacts_displayer.py
+++ b/statgpt/app/chains/data_query/data_query_artifacts_displayer.py
@@ -5,6 +5,9 @@ import string
 import pandas as pd
 import plotly.graph_objects as go
 
+from statgpt.app.chains.data_query.eval_attachments_displayer import (
+    DataQueryEvalAttachmentsDisplayer,
+)
 from statgpt.app.schemas.dial_app_configuration import StatGPTConfiguration
 from statgpt.app.schemas.query import AppJsonQueryWithMetadata
 from statgpt.app.schemas.tool_artifact import DataQueryArtifact
@@ -46,14 +49,19 @@ class DataQueryArtifactDisplayer:
         self._chat_config = chat_config
         self._auth_context = auth_context
         self._max_cells = max_cells
+        self._eval_displayer = DataQueryEvalAttachmentsDisplayer(
+            choice=choice,
+            auth_context=auth_context,
+            enabled=chat_config.enable_debug_attachments,
+        )
 
     async def display(self, data_query_artifacts: dict[str, DataQueryArtifact]) -> None:
         data_query_artifacts_list = list(data_query_artifacts.values())
         responses = self._merge_data_responses(data_query_artifacts_list)
-        tasks = [self._display_data_responses(responses)]
-        if self._chat_config.enable_debug_attachments:
-            tasks.append(self._display_eval_attachments(data_query_artifacts))
-        await asyncio.gather(*tasks)
+        await asyncio.gather(
+            self._display_data_responses(responses),
+            self._eval_displayer.display(data_query_artifacts),
+        )
 
     async def get_system_message_content(
         self, data_query_artifacts: list[DataQueryArtifact]
@@ -66,48 +74,6 @@ class DataQueryArtifactDisplayer:
         datasets_content_filtered = list(filter(None, datasets_content))
 
         return "\n\n".join(datasets_content_filtered)
-
-    async def _display_eval_attachments(
-        self, data_query_artifacts: dict[str, DataQueryArtifact]
-    ) -> None:
-        async with attachments_storage_factory(self._auth_context.api_key) as attachments_storage:
-            tasks = []
-            for tool_call_id, artifact in data_query_artifacts.items():
-                tasks.append(
-                    self._display_eval_attachment(tool_call_id, artifact, attachments_storage)
-                )
-            await asyncio.gather(*tasks)
-
-    async def _display_eval_attachment(
-        self,
-        tool_call_id: str,
-        artifact: DataQueryArtifact,
-        attachments_storage: AttachmentsStorage,
-    ) -> None:
-        eval_attachment_content = artifact.eval_attachment.model_dump(mode="json")
-        response = await self._attach_json_file(
-            attachments_storage=attachments_storage,
-            data=eval_attachment_content,
-            filename=f"data_query_eval_attachment_{tool_call_id}.json",
-            title=f"Data Query Eval data: {tool_call_id}",
-            indent=2,
-        )
-        if response is not None:
-            self._choice.add_attachment(**response)
-
-        # The discovery lookup runs beside the query, so it reports in a file of its own.
-        discovery = artifact.discovery_datasets_eval_attachment
-        if discovery is None:
-            return
-        discovery_response = await self._attach_json_file(
-            attachments_storage=attachments_storage,
-            data=discovery.model_dump(mode="json"),
-            filename=f"discovery_datasets_eval_attachment_{tool_call_id}.json",
-            title=f"Discovery Datasets Eval data: {tool_call_id}",
-            indent=2,
-        )
-        if discovery_response is not None:
-            self._choice.add_attachment(**discovery_response)
 
     def _get_system_message_content(self, response: DataResponse) -> str | None:
         if response.status.parsing_status == DataParsingStatus.FAILED:
@@ -294,19 +260,6 @@ class DataQueryArtifactDisplayer:
         content = AppJsonQueryWithMetadata.from_common(query).model_dump_json(by_alias=True)
         title = data_response.enrich_attachment_name(self._config.json_query.name)
         return dict(type=MediaTypes.JSON, title=title, data=content)
-
-    @catch_and_log_async(logger)
-    async def _attach_json_file(
-        self,
-        attachments_storage: AttachmentsStorage,
-        data: dict,
-        filename: str,
-        title: str,
-        indent: int | None = None,
-    ) -> dict[str, str]:
-        json_content = json.dumps(data, ensure_ascii=False, indent=indent)
-        response = await attachments_storage.put_json(filename, json_content)
-        return dict(type=MediaTypes.JSON, title=title, url=response.url)
 
     @catch_and_log_async(logger)
     async def _attach_plotly(

--- a/statgpt/app/chains/data_query/eval_attachments_displayer.py
+++ b/statgpt/app/chains/data_query/eval_attachments_displayer.py
@@ -1,0 +1,84 @@
+import asyncio
+import json
+
+from statgpt.app.schemas.tool_artifact import DataQueryArtifact
+from statgpt.app.utils.dial_stages import ChoiceI
+from statgpt.common.auth.auth_context import AuthContext
+from statgpt.common.config import logger
+from statgpt.common.utils import AttachmentsStorage, MediaTypes, attachments_storage_factory
+from statgpt.common.utils.async_utils import catch_and_log_async
+
+
+class DataQueryEvalAttachmentsDisplayer:
+    """Attaches the Data Query eval (debug) files to the choice.
+
+    Kept apart from `DataQueryArtifactDisplayer` because it needs nothing from the channel's
+    attachments config: the direct tool calls path returns these files without any of the data
+    attachments, and need not have the data query tool configured at all.
+    """
+
+    def __init__(self, choice: ChoiceI, auth_context: AuthContext, enabled: bool):
+        self._choice = choice
+        self._auth_context = auth_context
+        self._enabled = enabled
+
+    @catch_and_log_async(logger)
+    async def display(self, artifacts: dict[str, DataQueryArtifact]) -> None:
+        """Attach one eval file per tool call, plus a discovery file where the lookup ran.
+
+        Debug-only output must never cost the user their answer, so the whole method is
+        wrapped: a failure to reach the attachments storage is logged and dropped.
+        """
+        if not self._enabled or not artifacts:
+            return
+
+        async with attachments_storage_factory(self._auth_context.api_key) as attachments_storage:
+            tasks = [
+                self._display_one(tool_call_id, artifact, attachments_storage)
+                for tool_call_id, artifact in artifacts.items()
+            ]
+            await asyncio.gather(*tasks)
+
+    async def _display_one(
+        self,
+        tool_call_id: str,
+        artifact: DataQueryArtifact,
+        attachments_storage: AttachmentsStorage,
+    ) -> None:
+        eval_attachment_content = artifact.eval_attachment.model_dump(mode="json")
+        response = await self._attach_json_file(
+            attachments_storage=attachments_storage,
+            data=eval_attachment_content,
+            filename=f"data_query_eval_attachment_{tool_call_id}.json",
+            title=f"Data Query Eval data: {tool_call_id}",
+            indent=2,
+        )
+        if response is not None:
+            self._choice.add_attachment(**response)
+
+        # The discovery lookup runs beside the query, so it reports in a file of its own.
+        discovery = artifact.discovery_datasets_eval_attachment
+        if discovery is None:
+            return
+        discovery_response = await self._attach_json_file(
+            attachments_storage=attachments_storage,
+            data=discovery.model_dump(mode="json"),
+            filename=f"discovery_datasets_eval_attachment_{tool_call_id}.json",
+            title=f"Discovery Datasets Eval data: {tool_call_id}",
+            indent=2,
+        )
+        if discovery_response is not None:
+            self._choice.add_attachment(**discovery_response)
+
+    @catch_and_log_async(logger)
+    async def _attach_json_file(
+        self,
+        attachments_storage: AttachmentsStorage,
+        data: dict,
+        filename: str,
+        title: str,
+        indent: int | None = None,
+    ) -> dict[str, str]:
+        json_content = json.dumps(data, ensure_ascii=False, indent=indent)
+        response = await attachments_storage.put_json(filename, json_content)
+        return dict(type=MediaTypes.JSON, title=title, url=response.url)

--- a/statgpt/app/chains/main.py
+++ b/statgpt/app/chains/main.py
@@ -3,10 +3,14 @@ import asyncio
 from aidial_sdk.exceptions import InvalidRequestError
 from langchain_core.runnables import Runnable, RunnableLambda
 
+from statgpt.app.chains.data_query.eval_attachments_displayer import (
+    DataQueryEvalAttachmentsDisplayer,
+)
 from statgpt.app.chains.out_of_scope_checker import OutOfScopeChecker
 from statgpt.app.chains.parameters import ChainParameters
 from statgpt.app.chains.supreme_agent import SupremeAgentExecutor, ToolCaller
 from statgpt.app.config import StateVarsConfig
+from statgpt.app.schemas.tool_artifact import DataQueryArtifact
 from statgpt.app.settings.dial_app import dial_app_settings
 from statgpt.app.utils.message_history import (
     InvalidToolCallError,
@@ -71,8 +75,23 @@ class MainChainFactory:
                 for tool_call in tool_calls_parsed
             )
         )
+        data_query_artifacts: dict[str, DataQueryArtifact] = {}
         for tool_msg in tool_messages:
             history.add_tool_message(tool_msg)
+
+            artifact = tool_msg.artifact
+            if artifact and isinstance(artifact, DataQueryArtifact):
+                data_query_artifacts[tool_msg.tool_call_id] = artifact
+
+        if data_query_artifacts:
+            # Eval attachments only: a direct caller renders the data itself from the tool
+            # message, so the data attachments (table, plotly, CSV, python) would be noise.
+            eval_displayer = DataQueryEvalAttachmentsDisplayer(
+                choice=ChainParameters.get_choice(inputs),
+                auth_context=ChainParameters.get_auth_context(inputs),
+                enabled=ChainParameters.get_configuration(inputs).enable_debug_attachments,
+            )
+            await eval_displayer.display(data_query_artifacts)
 
         return inputs
 

--- a/tests/unit/app/chains/test_eval_attachments_displayer.py
+++ b/tests/unit/app/chains/test_eval_attachments_displayer.py
@@ -1,0 +1,190 @@
+"""Tests for the Data Query eval attachments displayer.
+
+These files are debug-only output, so the displayer has two obligations beyond attaching them:
+touch nothing when debug attachments are off, and never let a storage failure cost the user
+their answer.
+"""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from statgpt.app.chains.data_query import eval_attachments_displayer as module
+from statgpt.app.chains.data_query.eval_attachments_displayer import (
+    DataQueryEvalAttachmentsDisplayer,
+)
+from statgpt.app.schemas.discovery_datasets import DiscoveryDatasetsEvalAttachment
+from statgpt.app.schemas.query_builder import DataQueryEvalAttachment, QueryBuilderAgentState
+from statgpt.app.schemas.tool_artifact import DataQueryArtifact
+from statgpt.common.utils import MediaTypes
+
+
+def _artifact(*, with_discovery: bool = False) -> DataQueryArtifact:
+    return DataQueryArtifact(
+        state=QueryBuilderAgentState(),
+        data_responses={},
+        eval_attachment=DataQueryEvalAttachment(),
+        discovery_datasets_eval_attachment=(
+            DiscoveryDatasetsEvalAttachment(query="gdp") if with_discovery else None
+        ),
+    )
+
+
+class _Choice:
+    """Records the attachments the displayer adds, in the order it adds them."""
+
+    def __init__(self) -> None:
+        self.attachments: list[dict[str, Any]] = []
+
+    def add_attachment(self, **kwargs: Any) -> None:
+        self.attachments.append(kwargs)
+
+
+class _Storage:
+    """Stands in for the DIAL attachments storage, reporting what was uploaded."""
+
+    def __init__(self, *, fail_for: str | None = None) -> None:
+        self._fail_for = fail_for
+        self.uploaded: list[str] = []
+
+    async def put_json(self, name: str, content: str) -> SimpleNamespace:
+        if self._fail_for is not None and self._fail_for in name:
+            raise RuntimeError("upload exploded")
+        self.uploaded.append(name)
+        # The real storage appends a uuid and the extension, hence the shape of the url.
+        return SimpleNamespace(url=f"files/bucket/{name}-uuid.json")
+
+
+class _Factory:
+    """Stands in for `attachments_storage_factory`, reporting whether it was ever entered."""
+
+    def __init__(self, storage: _Storage | None = None, *, error: Exception | None = None) -> None:
+        self.storage = storage if storage is not None else _Storage()
+        self._error = error
+        self.entered = False
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        @asynccontextmanager
+        async def factory(api_key: str):
+            self.entered = True
+            if self._error is not None:
+                raise self._error
+            yield self.storage
+
+        monkeypatch.setattr(module, "attachments_storage_factory", factory)
+
+
+def _displayer(choice: _Choice, *, enabled: bool = True) -> DataQueryEvalAttachmentsDisplayer:
+    auth_context = SimpleNamespace(api_key="key")
+    return DataQueryEvalAttachmentsDisplayer(
+        choice=choice,  # type: ignore[arg-type]
+        auth_context=auth_context,  # type: ignore[arg-type]
+        enabled=enabled,
+    )
+
+
+def _filenames(choice: _Choice) -> set[str]:
+    # Attachments are gathered per tool call, so only the set is meaningful.
+    return {attachment["title"] for attachment in choice.attachments}
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ the gate ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+async def test_debug_attachments_off_never_opens_a_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gate sits ahead of the storage, so a normal turn pays nothing for this."""
+    factory = _Factory()
+    factory.install(monkeypatch)
+    choice = _Choice()
+
+    await _displayer(choice, enabled=False).display({"call-1": _artifact()})
+
+    assert factory.entered is False
+    assert choice.attachments == []
+
+
+async def test_nothing_to_report_never_opens_a_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    factory = _Factory()
+    factory.install(monkeypatch)
+    choice = _Choice()
+
+    await _displayer(choice).display({})
+
+    assert factory.entered is False
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ what is attached ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+async def test_each_tool_call_gets_its_own_eval_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A turn with several data queries must be judgeable per call, not in aggregate."""
+    factory = _Factory()
+    factory.install(monkeypatch)
+    choice = _Choice()
+
+    await _displayer(choice).display(
+        {"call-1": _artifact(with_discovery=True), "call-2": _artifact()}
+    )
+
+    assert _filenames(choice) == {
+        "Data Query Eval data: call-1",
+        "Discovery Datasets Eval data: call-1",
+        "Data Query Eval data: call-2",
+    }
+    assert sorted(factory.storage.uploaded) == [
+        "data_query_eval_attachment_call-1.json",
+        "data_query_eval_attachment_call-2.json",
+        "discovery_datasets_eval_attachment_call-1.json",
+    ]
+    for attachment in choice.attachments:
+        assert attachment["type"] == MediaTypes.JSON
+        assert attachment["url"].startswith("files/bucket/")
+
+
+async def test_a_call_without_a_discovery_lookup_reports_the_query_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`None` means the channel has no discovery lookup - there is nothing to report."""
+    factory = _Factory()
+    factory.install(monkeypatch)
+    choice = _Choice()
+
+    await _displayer(choice).display({"call-1": _artifact()})
+
+    assert factory.storage.uploaded == ["data_query_eval_attachment_call-1.json"]
+    assert _filenames(choice) == {"Data Query Eval data: call-1"}
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ failures ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+async def test_a_failed_upload_does_not_cost_the_other_call_its_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    factory = _Factory(_Storage(fail_for="call-1"))
+    factory.install(monkeypatch)
+    choice = _Choice()
+
+    await _displayer(choice).display({"call-1": _artifact(), "call-2": _artifact()})
+
+    assert _filenames(choice) == {"Data Query Eval data: call-2"}
+
+
+async def test_an_unreachable_storage_does_not_break_the_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Debug-only output must never fail the answer the user is waiting on."""
+    factory = _Factory(error=RuntimeError("no bucket"))
+    factory.install(monkeypatch)
+    choice = _Choice()
+
+    await _displayer(choice).display({"call-1": _artifact()})
+
+    assert factory.entered is True
+    assert choice.attachments == []

--- a/tests/unit/app/chains/test_main_direct_tool_calls.py
+++ b/tests/unit/app/chains/test_main_direct_tool_calls.py
@@ -6,10 +6,16 @@ from unittest.mock import Mock
 
 from langchain_core.messages import ToolMessage
 
+from statgpt.app.chains import main as main_module
 from statgpt.app.chains.main import MainChainFactory
 from statgpt.app.config import StateVarsConfig
 from statgpt.app.config.chain_parameters import ChainParametersConfig
+from statgpt.app.schemas.dial_app_configuration import StatGPTConfiguration
+from statgpt.app.schemas.query_builder import DataQueryEvalAttachment, QueryBuilderAgentState
+from statgpt.app.schemas.tool_artifact import DataQueryArtifact, ToolArtifact
+from statgpt.app.schemas.tool_states import ToolMessageState
 from statgpt.app.settings.dial_app import dial_app_settings
+from statgpt.common.schemas import ToolTypes
 
 
 def _dial_tool_call(id_: str, name: str) -> SimpleNamespace:
@@ -64,5 +70,66 @@ async def test_dispatches_concurrently_and_preserves_order(monkeypatch):
     state = inputs[ChainParametersConfig.STATE]
     assert [tc["id"] for tc in state[StateVarsConfig.DIRECT_TOOL_CALLS]] == ["call-1", "call-2"]
     # results are appended to history in the original tool-call order
+    added_ids = [call.args[0].tool_call_id for call in history.add_tool_message.call_args_list]
+    assert added_ids == ["call-1", "call-2"]
+
+
+class _EvalDisplayer:
+    """Stands in for `DataQueryEvalAttachmentsDisplayer`, recording how it was built and used."""
+
+    built_with: dict = {}
+    displayed: dict = {}
+
+    def __init__(self, choice, auth_context, enabled) -> None:
+        type(self).built_with = dict(choice=choice, auth_context=auth_context, enabled=enabled)
+
+    async def display(self, artifacts) -> None:
+        type(self).displayed = artifacts
+
+
+async def test_only_data_query_calls_get_eval_attachments(monkeypatch):
+    """The eval attachments are what an offline evaluation scores the retrieval with, so a
+    direct caller must get one per data query call - and nothing for the other tools."""
+    monkeypatch.setattr(dial_app_settings, "enable_direct_tool_calls", True)
+
+    data_query_artifact = DataQueryArtifact(
+        state=QueryBuilderAgentState(),
+        data_responses={},
+        eval_attachment=DataQueryEvalAttachment(),
+    )
+    artifacts = {
+        "call-1": data_query_artifact,
+        "call-2": ToolArtifact(state=ToolMessageState(type=ToolTypes.WEB_SEARCH)),
+    }
+
+    async def call_tool(tool_call, inputs, show_stage=True, prefix=''):
+        return ToolMessage(
+            content="result",
+            tool_call_id=tool_call["id"],
+            artifact=artifacts[tool_call["id"]],
+        )
+
+    monkeypatch.setattr(
+        "statgpt.app.chains.main.ToolCaller",
+        SimpleNamespace(from_config=lambda config: SimpleNamespace(call_tool=call_tool)),
+    )
+    monkeypatch.setattr(main_module, "DataQueryEvalAttachmentsDisplayer", _EvalDisplayer)
+
+    choice = object()
+    auth_context = object()
+    inputs, history = _inputs_with_tool_calls(
+        [_dial_tool_call("call-1", "data_query"), _dial_tool_call("call-2", "web_search")]
+    )
+    inputs[ChainParametersConfig.CHOICE] = choice
+    inputs[ChainParametersConfig.AUTH_CONTEXT] = auth_context
+    inputs[ChainParametersConfig.CONFIGURATION] = StatGPTConfiguration(
+        enable_debug_attachments=True
+    )
+
+    await MainChainFactory(channel_config=Mock())._direct_tool_calls_chain(inputs)
+
+    assert _EvalDisplayer.displayed == {"call-1": data_query_artifact}
+    assert _EvalDisplayer.built_with == dict(choice=choice, auth_context=auth_context, enabled=True)
+    # the existing contract holds: every tool result still reaches history, in order
     added_ids = [call.args[0].tool_call_id for call in history.add_tool_message.call_args_list]
     assert added_ids == ["call-1", "call-2"]


### PR DESCRIPTION
## Applicable issues

- closes #630

## Description of changes

The Data Query eval attachments — `data_query_eval_attachment_<tool_call_id>.json` and `discovery_datasets_eval_attachment_<tool_call_id>.json`, the retrieval trail an offline evaluation scores — were uploaded only from `DataQueryArtifactDisplayer.display()`, whose sole caller is the Supreme Agent. The direct tool calls path never constructed that displayer, so it returned no attachments at all and an eval harness targeting the tool directly could score the answer but not the retrieval behind it.

- Extracted the eval-attachment emission into a `DataQueryEvalAttachmentsDisplayer` that takes only the choice, the auth context, and the gate — none of the channel's data-attachments config, which the direct path has no reason to resolve and cannot assume is present, since it dispatches any tool. `DataQueryArtifactDisplayer` now composes it and keeps its constructor signature, so the Supreme Agent path is untouched.
- `MainChainFactory._direct_tool_calls_chain` collects `DataQueryArtifact`s from the dispatched tool messages the way the agent path already does, and emits the eval files only: a direct caller renders the data itself from the tool message, so the data attachments (custom table, plotly, CSV, python code, JSON query) would be noise.
- The `enable_debug_attachments` gate moved inside the new displayer, ahead of the attachments storage, so a normal turn no longer opens a DIAL client for it. The entry point is wrapped in `catch_and_log_async`: previously a failure reaching the attachments storage propagated and would fail the turn, taking the data attachments with it.
- Added unit tests for the extracted displayer, which was previously uncovered, and one for the direct path asserting only data query calls get eval attachments.

`discovery_datasets_block` needed no change — the direct path is already `InvocationSource.AGENT`, so the block is folded into the tool response string.

## Checklist

- [X] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
