### PR TITLE
feat: expose _meta.ui.prefersBorder on MCP-App widget resources #636

### DIFF
--- a/statgpt/app/README.md
+++ b/statgpt/app/README.md
@@ -65,6 +65,7 @@ Two pieces of configuration are required:
   - `html_url` — internal endpoint the backend fetches the HTML from (required). Supports `$env:{VAR}`.
   - `cache_ttl_seconds` — TTL for the in-process HTML cache (default `60`).
   - `mime_type` — MIME type reported for the content (default `text/html;profile=mcp-app`, the MCP Apps UI HTML type).
+  - `prefers_border` — whether the widget prefers a visible border when rendered inline; exposed to the host as `_meta.ui.prefersBorder` (default `true`). In borderless mode the host removes padding, so the widget must honor safe-area insets itself.
 - Per tool, `mcp_app_resource_uri` — binds the tool to a `uri` declared in `mcp.resources` (added to the tool's `_meta.ui.resourceUri`). Must reference a declared resource.
 
 ```yaml

--- a/statgpt/app/mcp/widget_resource.py
+++ b/statgpt/app/mcp/widget_resource.py
@@ -66,7 +66,10 @@ class WidgetResource(Resource):
             mime_type=config.mime_type,
             meta={
                 "ui": app_config_to_meta_dict(
-                    AppConfig(csp=ResourceCSP(resource_domains=[config.get_origin()]))
+                    AppConfig(
+                        csp=ResourceCSP(resource_domains=[config.get_origin()]),
+                        prefers_border=config.prefers_border,
+                    )
                 )
             },
             html_url=config.get_html_url(),

--- a/statgpt/common/schemas/channel.py
+++ b/statgpt/common/schemas/channel.py
@@ -191,6 +191,14 @@ class ProxiedResourceConfig(McpResourceConfig):
             " type 'text/html;profile=mcp-app' (ext-apps 2026-01-26)."
         ),
     )
+    prefers_border: bool = Field(
+        default=True,
+        description=(
+            "Whether the widget prefers a visible border when rendered inline; exposed to the"
+            " host as `_meta.ui.prefersBorder`. In borderless mode the host removes padding, so"
+            " the widget must honor safe-area insets itself. Defaults to bordered."
+        ),
+    )
 
     def get_origin(self) -> str:
         return config_utils.replace_env(self.origin_raw).rstrip("/")

--- a/tests/unit/app/mcp/test_widget_resource.py
+++ b/tests/unit/app/mcp/test_widget_resource.py
@@ -49,8 +49,22 @@ class TestFromConfig:
             _config(origin="https://widget.example/", mime_type=MediaTypes.HTML_MCP_APP)
         )
         assert resource.mime_type == MediaTypes.HTML_MCP_APP
-        assert resource.meta == {"ui": {"csp": {"resourceDomains": ["https://widget.example"]}}}
+        assert resource.meta == {
+            "ui": {
+                "csp": {"resourceDomains": ["https://widget.example"]},
+                "prefersBorder": True,
+            }
+        }
         assert str(resource.uri) == _URI
+
+    def test_prefers_border_can_be_disabled(self):
+        resource = WidgetResource.from_config(_config(prefers_border=False))
+        assert resource.meta == {
+            "ui": {
+                "csp": {"resourceDomains": ["https://widget.example"]},
+                "prefersBorder": False,
+            }
+        }
 
 
 class TestRead:


### PR DESCRIPTION
## Applicable issues

- closes #636

## Description of changes

MCP-App widget resources now declare `_meta.ui.prefersBorder` explicitly, controlling whether the host renders the widget bordered or borderless inline. This satisfies the MCP marketplace publishing checklist requirement to set the field explicitly rather than relying on the host default (which borders on mobile but not desktop).

- Add a per-resource `prefers_border` field to `ProxiedResourceConfig`, defaulting to `true` so widgets render bordered by default while any channel can override it per resource.
- `WidgetResource.from_config` passes `prefers_border` into `AppConfig` alongside the existing CSP, so it is serialized into the resource's `_meta.ui.prefersBorder` by FastMCP.
- Document the option in the app README and cover the default (`true`) and override (`false`) paths in the widget resource unit tests.

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
