### PR TITLE
chore: patch libuuid/util-linux HIGH CVEs in chat and admin images

### DIFF
--- a/docker/admin.Dockerfile
+++ b/docker/admin.Dockerfile
@@ -37,8 +37,9 @@ FROM python:3.11-alpine AS server
 # Security patches (consolidated into single layer)
 # CVE-2023-52425 (libexpat), CVE-2025-6965 (sqlite-libs), libcrypto3/libssl3
 # CVE-2026-40200 (musl)
+# CVE-2026-53612/53613/53614/76642/78408/78409/78410 (libuuid/util-linux)
 RUN apk update && apk upgrade --no-cache \
-    libcrypto3 libssl3 libexpat sqlite-libs zlib musl musl-utils \
+    libcrypto3 libssl3 libexpat sqlite-libs zlib musl musl-utils libuuid \
   && apk add --no-cache ca-certificates \
   && update-ca-certificates \
   && rm -rf /var/cache/apk/*

--- a/docker/admin.Dockerfile
+++ b/docker/admin.Dockerfile
@@ -39,7 +39,8 @@ FROM python:3.11-alpine AS server
 # CVE-2026-40200 (musl)
 # CVE-2026-53612/53613/53614/76642/78408/78409/78410 (libuuid/util-linux)
 RUN apk update && apk upgrade --no-cache \
-    libcrypto3 libssl3 libexpat sqlite-libs zlib musl musl-utils libuuid \
+    libcrypto3 libssl3 libexpat sqlite-libs zlib musl musl-utils \
+  && apk add --no-cache --upgrade "libuuid>=2.42.3-r1" \
   && apk add --no-cache ca-certificates \
   && update-ca-certificates \
   && rm -rf /var/cache/apk/*

--- a/docker/chat.Dockerfile
+++ b/docker/chat.Dockerfile
@@ -36,8 +36,9 @@ FROM python:3.11-alpine AS server
 # Security patches (consolidated into single layer)
 # CVE-2023-52425 (libexpat), CVE-2025-6965 (sqlite-libs), libcrypto3/libssl3
 # CVE-2026-40200 (musl)
+# CVE-2026-53612/53613/53614/76642/78408/78409/78410 (libuuid/util-linux)
 RUN apk update && apk upgrade --no-cache \
-    libcrypto3 libssl3 libexpat sqlite-libs zlib musl musl-utils \
+    libcrypto3 libssl3 libexpat sqlite-libs zlib musl musl-utils libuuid \
   && apk add --no-cache ca-certificates \
   && update-ca-certificates \
   && rm -rf /var/cache/apk/*

--- a/docker/chat.Dockerfile
+++ b/docker/chat.Dockerfile
@@ -38,7 +38,8 @@ FROM python:3.11-alpine AS server
 # CVE-2026-40200 (musl)
 # CVE-2026-53612/53613/53614/76642/78408/78409/78410 (libuuid/util-linux)
 RUN apk update && apk upgrade --no-cache \
-    libcrypto3 libssl3 libexpat sqlite-libs zlib musl musl-utils libuuid \
+    libcrypto3 libssl3 libexpat sqlite-libs zlib musl musl-utils \
+  && apk add --no-cache --upgrade "libuuid>=2.42.3-r1" \
   && apk add --no-cache ca-certificates \
   && update-ca-certificates \
   && rm -rf /var/cache/apk/*


### PR DESCRIPTION
## Summary
- The image scan flagged HIGH-severity `libuuid` (util-linux) CVEs in both runtime images: installed `2.42.1-r0`, fixed in `2.42.3-r1`.
- Explicitly installs the patched package with a version constraint (`apk add --upgrade "libuuid>=2.42.3-r1"`) in `docker/chat.Dockerfile` and `docker/admin.Dockerfile`, so the fixed util-linux `libuuid` is guaranteed rather than depending on the general `apk upgrade` set picking it up.
- Resolves: CVE-2026-53612, CVE-2026-53613, CVE-2026-53614, CVE-2026-76642, CVE-2026-78408, CVE-2026-78409, CVE-2026-78410.

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.