### PR TITLE
feat(file_rag): forward a current date override to the prefilter builder and Generic RAG

### DIFF
--- a/statgpt/app/chains/file_rags/dial_rag/dial_rag.py
+++ b/statgpt/app/chains/file_rags/dial_rag/dial_rag.py
@@ -1,3 +1,4 @@
+import datetime
 import time
 from typing import Any
 
@@ -32,6 +33,7 @@ class DialRagAgentFactory(BaseRAGFactory):
     FIELD_ATTACHMENTS = 'attachments'
     FIELD_METADATA = 'metadata'
     FIELD_PRE_FILTER_DECODER_OF_LATEST = 'prefilter_decoder_of_latest'
+    FIELD_CURRENT_DATE = 'current_date'
 
     def _init_dial_rag_client(self, auth_context: AuthContext):
         nondefault_dial_rag_pgvector_endpoint = dial_rag_settings.pgvector_url
@@ -76,7 +78,7 @@ class DialRagAgentFactory(BaseRAGFactory):
         )
 
     async def _run_prefilter_nonsafe(
-        self, auth_context: AuthContext, query: str
+        self, auth_context: AuthContext, query: str, reference_date: datetime.date | None
     ) -> tuple[PreFilterResponse, DialRagMetadata]:
         try:
             metadata_loader = DialRagMetadataLoader.create_for_local_or_remote(
@@ -101,13 +103,19 @@ class DialRagAgentFactory(BaseRAGFactory):
             llm=llm, metadata=metadata, pub_type_to_decoder_mapping=decoder_of_latest_mapping
         )
 
-        pre_filter_response = await pre_filter_builder.build_filter_from_query(query=query)
+        pre_filter_response = await pre_filter_builder.build_filter_from_query(
+            query=query, reference_date=reference_date
+        )
         logger.info(f'Built publication filter: {pre_filter_response!r}')
 
         return pre_filter_response, metadata
 
     async def _run_prefilter(
-        self, auth_context: AuthContext, query: str, target: Stage
+        self,
+        auth_context: AuthContext,
+        query: str,
+        target: Stage,
+        reference_date: datetime.date | None,
     ) -> tuple[PreFilterResponse, DialRagMetadata | None]:
 
         def _format_exception_w_cause(exc: Exception) -> str:
@@ -115,7 +123,7 @@ class DialRagAgentFactory(BaseRAGFactory):
 
         try:
             pre_filter_response, metadata = await self._run_prefilter_nonsafe(
-                auth_context=auth_context, query=query
+                auth_context=auth_context, query=query, reference_date=reference_date
             )
         except RAGMetadataError as e:
             logger.exception(e)
@@ -157,8 +165,19 @@ class DialRagAgentFactory(BaseRAGFactory):
                 reference_type=attachment.get('reference_type'),
             )
 
-    def _build_extra_body(self, pre_filter_response: PreFilterResponse) -> dict | None:
-        """Build the `extra_body` (RAG configuration) sent with the chat completion request."""
+    def _build_extra_body(
+        self, pre_filter_response: PreFilterResponse, current_date: datetime.date | None
+    ) -> dict | None:
+        """Build the `extra_body` (RAG configuration) sent with the chat completion request.
+
+        `current_date` is the "today" override; DIAL RAG has no way to accept it, so it only
+        affects the prefilter built by statgpt. Generic RAG forwards it to answer generation.
+        """
+        if current_date is not None:
+            logger.warning(
+                f'{type(self).__name__}: RAG does not accept a current date override - '
+                f'ignoring current_date={current_date} for the RAG call'
+            )
         rag_filter = pre_filter_response.rag_filter
         if rag_filter is None:
             return None
@@ -173,6 +192,10 @@ class DialRagAgentFactory(BaseRAGFactory):
         query = ChainParameters.get_query(inputs)
 
         target_prefilter = ChainParameters.get_target_prefilter(inputs)
+        current_date = ChainParameters.get_target_current_date(inputs)
+        if current_date is not None:
+            logger.info(f'received current date override: {current_date}')
+
         if target_prefilter is not None:
             logger.info(
                 'received target prefilter - will ignore building prefilter from user query. '
@@ -186,7 +209,7 @@ class DialRagAgentFactory(BaseRAGFactory):
         else:
             logger.info(f'building prefilter from user query: "{query}"')
             pre_filter_response, metadata = await self._run_prefilter(
-                auth_context=auth_context, query=query, target=target
+                auth_context=auth_context, query=query, target=target, reference_date=current_date
             )
 
         inputs[self.FIELD_PRE_FILTER] = pre_filter_response
@@ -194,6 +217,7 @@ class DialRagAgentFactory(BaseRAGFactory):
         inputs[self.FIELD_PRE_FILTER_DECODER_OF_LATEST] = (
             self._tool_config.details.decoder_of_latest
         )
+        inputs[self.FIELD_CURRENT_DATE] = current_date
 
         state = ChainParameters.get_state(inputs)
         skip = state.get(StateVarsConfig.CMD_RAG_PREFILTER_ONLY, False)
@@ -209,11 +233,9 @@ class DialRagAgentFactory(BaseRAGFactory):
 
         # call dial RAG
 
-        prefilter_dict = None if (f := pre_filter_response.rag_filter) is None else f.as_dial_dict()
-        inputs_to_log = {'query': query, 'prefilter': prefilter_dict}
-        logger.info(f'calling DIAL RAG with following inputs: {inputs_to_log}')
-
-        configuration_params = self._build_extra_body(pre_filter_response)
+        configuration_params = self._build_extra_body(pre_filter_response, current_date)
+        inputs_to_log = {'query': query, 'extra_body': configuration_params}
+        logger.info(f'calling RAG with following inputs: {inputs_to_log}')
 
         dial_rag_client = self._init_dial_rag_client(auth_context)
         deployment_name = self._tool_config.details.get_deployment_id()

--- a/statgpt/app/chains/file_rags/dial_rag/prefilter.py
+++ b/statgpt/app/chains/file_rags/dial_rag/prefilter.py
@@ -68,13 +68,33 @@ class PreFilterBuilder:
         )
         self._metadata = metadata
 
-    async def build_filter_from_query(self, query: str) -> PreFilterResponse:
-        llm_filters = await self._call_llm(query=query)
-        dial_rag_filters = self._convert_llm_output_to_dial_rag_filter(llm_filters)
+    async def build_filter_from_query(
+        self, query: str, reference_date: date | None = None
+    ) -> PreFilterResponse:
+        """
+        Build the publications prefilter from the user query.
+
+        `reference_date` replaces "today" everywhere the builder needs it: in the LLM prompt,
+        when dropping hallucinated future dates, and when decoding "latest" into a time range.
+        None means the wall clock. Used by the RAG eval to reproduce a past date.
+        """
+        llm_filters = await self._call_llm(query=query, reference_date=reference_date)
+        dial_rag_filters = self._convert_llm_output_to_dial_rag_filter(
+            llm_filters, reference_date=reference_date
+        )
         return PreFilterResponse(llm_output=llm_filters, rag_filter=dial_rag_filters)
 
-    async def _call_llm(self, query: str) -> RagFilterLLMOutput:
-        pre_filter_chain = self._create_prefilter_chain()
+    @staticmethod
+    def _prompt_date_partials(reference_date: date | None) -> dict[str, str]:
+        today = reference_date or date.today()
+        return {
+            "current_date_long": utils.format_date_long(today),
+            "current_date_yyyymmdd": today.strftime("%Y-%m-%d"),
+            "current_year": today.strftime("%Y"),
+        }
+
+    async def _call_llm(self, query: str, reference_date: date | None) -> RagFilterLLMOutput:
+        pre_filter_chain = self._create_prefilter_chain(reference_date=reference_date)
         outputs = await pre_filter_chain.ainvoke({"query": query})
         return RagFilterLLMOutput(
             time_period=outputs["time_period"],
@@ -83,16 +103,12 @@ class PreFilterBuilder:
             last_n_publications=outputs["last_n_publications"].last_n_publications,
         )
 
-    def _create_prefilter_chain(self) -> RunnableSerializable:
+    def _create_prefilter_chain(self, reference_date: date | None) -> RunnableSerializable:
         date_chain = SingleFilterChainBuilder.create_chain(
             llm=self._llm,
             system_prompt=rag_prefilter_default_prompts.date_system_prompt,
             output_type=TimePeriodFilter,
-            partials={
-                "current_date_long": utils.get_today_date_long(),
-                "current_date_yyyymmdd": utils.get_ts_now_str(ts_format="%Y-%m-%d"),
-                "current_year": utils.get_ts_now_str(ts_format="%Y"),
-            },
+            partials=self._prompt_date_partials(reference_date),
         )
         latest_chain = SingleFilterChainBuilder.create_chain(
             llm=self._llm,
@@ -126,7 +142,7 @@ class PreFilterBuilder:
         self, llm_output: RagFilterLLMOutput, reference_date: date | None = None
     ) -> RagFilterDial | None:
         # fix hallucinations before creating the filter
-        time_period_llm = llm_output.time_period.fix_llm_hallucinations()
+        time_period_llm = llm_output.time_period.fix_llm_hallucinations(today=reference_date)
 
         start_date = time_period_llm.parse_date(time_period_llm.start)
         end_date = time_period_llm.parse_date(time_period_llm.end)

--- a/statgpt/app/chains/file_rags/file_rag_tool.py
+++ b/statgpt/app/chains/file_rags/file_rag_tool.py
@@ -1,3 +1,4 @@
+import datetime
 import typing as t
 
 from langchain_core.runnables import Runnable
@@ -41,6 +42,13 @@ The query to search an answer for.
         'since RagFilterDial is not JSON-serializable, '
         'it must be passed as a JSON serialized string. ',
     )
+    target_current_date: t.Annotated[str | None, InjectedToolArg] = Field(
+        default=None,
+        description='YYYY-MM-DD date to use as "today" instead of the wall clock: '
+        'when building the prefilter (prompt, relative dates, "latest") '
+        'and, for RAG versions supporting it, in the RAG answer generation. '
+        'used in RAG eval to reproduce answers as of the test case cutoff date.',
+    )
 
 
 class FileRagTool(StatGptTool[FileRagToolConfig], tool_type=ToolTypes.FILE_RAG):
@@ -54,7 +62,11 @@ class FileRagTool(StatGptTool[FileRagToolConfig], tool_type=ToolTypes.FILE_RAG):
         return FileRagArgs
 
     async def _arun(
-        self, inputs: dict, query: str, target_prefilter_json: str | None = None
+        self,
+        inputs: dict,
+        query: str,
+        target_prefilter_json: str | None = None,
+        target_current_date: str | None = None,
     ) -> tuple[str, BaseFileRagArtifact]:
         version = self._tool_config.details.version
         implementation = _RAG_IMPLEMENTATIONS[version](self._tool_config, self._channel_config)
@@ -69,6 +81,9 @@ class FileRagTool(StatGptTool[FileRagToolConfig], tool_type=ToolTypes.FILE_RAG):
         )
         inputs[ChainParametersConfig.QUERY] = query
         inputs[ChainParametersConfig.TARGET_PREFILTER] = target_prefilter
+        inputs[ChainParametersConfig.TARGET_CURRENT_DATE] = (
+            datetime.date.fromisoformat(target_current_date) if target_current_date else None
+        )
         res: dict = await chain.ainvoke(inputs)
         logger.info(f"FileRagTool result: {res!r}")
 

--- a/statgpt/app/chains/file_rags/generic_rag/generic_rag.py
+++ b/statgpt/app/chains/file_rags/generic_rag/generic_rag.py
@@ -1,7 +1,12 @@
+import datetime
+
 from statgpt.app.chains.file_rags.dial_rag import DialRagAgentFactory
 from statgpt.app.schemas import DialRagArtifact, DialRagState
 from statgpt.app.schemas.file_rags.dial_rag import PreFilterResponse
-from statgpt.app.schemas.file_rags.generic_rag import GenericRagConfiguration
+from statgpt.app.schemas.file_rags.generic_rag import (
+    GenericGenerationConfig,
+    GenericRagConfiguration,
+)
 from statgpt.common.schemas import RAGVersion
 
 
@@ -10,14 +15,22 @@ class GenericRagAgentFactory(DialRagAgentFactory):
 
     Reuses the entire DIAL RAG flow (client, prefilter, metadata loading, streaming,
     attachment formatting). Only the RAG configuration payload differs: the Generic RAG
-    application expects the prefilter nested under `retriever.document_selector`.
+    application expects the prefilter nested under `retriever.document_selector`, and
+    accepts a current date override for answer generation under `generation.current_date`.
     """
 
-    def _build_extra_body(self, pre_filter_response: PreFilterResponse) -> dict | None:
+    def _build_extra_body(
+        self, pre_filter_response: PreFilterResponse, current_date: datetime.date | None
+    ) -> dict | None:
         rag_filter = pre_filter_response.rag_filter
-        if rag_filter is None or (not rag_filter.filters and rag_filter.top_n is None):
+        if rag_filter is not None and (rag_filter.filters or rag_filter.top_n is not None):
+            config = GenericRagConfiguration.from_rag_filter_dial(rag_filter)
+        else:
+            config = GenericRagConfiguration()
+        if current_date is not None:
+            config.generation = GenericGenerationConfig(current_date=current_date)
+        if config.is_empty():
             return None
-        config = GenericRagConfiguration.from_rag_filter_dial(rag_filter)
         return {
             "custom_fields": {"configuration": config.model_dump(mode="json", exclude_none=True)}
         }

--- a/statgpt/app/chains/parameters.py
+++ b/statgpt/app/chains/parameters.py
@@ -1,5 +1,5 @@
 import typing as t
-from datetime import datetime
+from datetime import date, datetime
 
 from aidial_sdk.chat_completion import Request, Stage
 
@@ -51,6 +51,11 @@ class ChainParameters:
     @staticmethod
     def get_target_prefilter(data: dict) -> RagFilterDial | None:
         return data[ChainParametersConfig.TARGET_PREFILTER]
+
+    @staticmethod
+    def get_target_current_date(data: dict) -> date | None:
+        """Current date override for the RAG tool (used in RAG eval). None means "today"."""
+        return data.get(ChainParametersConfig.TARGET_CURRENT_DATE)
 
     @staticmethod
     def get_auth_context(data: dict) -> AuthContext:

--- a/statgpt/app/config/chain_parameters.py
+++ b/statgpt/app/config/chain_parameters.py
@@ -22,6 +22,7 @@ class ChainParametersConfig:
     INVOCATION_SOURCE = "invocation_source"
 
     TARGET_PREFILTER = "target_prefilter"
+    TARGET_CURRENT_DATE = "target_current_date"
     DATASETS_DICT = "datasets_dict"
     DATASET_DIMENSION_QUERIES = "dataset_dimension_queries"
     DATASET_QUERIES_FORMATTED_STR = "dataset_queries_formatted_str"

--- a/statgpt/app/schemas/file_rags/dial_rag.py
+++ b/statgpt/app/schemas/file_rags/dial_rag.py
@@ -44,11 +44,12 @@ class TimePeriodFilter(SingleFilterLLMOutput):
         except ValueError:
             return None
 
-    def fix_llm_hallucinations(self) -> TimePeriodFilter:
+    def fix_llm_hallucinations(self, today: datetime.date | None = None) -> TimePeriodFilter:
         """
         LLM might occasionally set end or start date after today. Here we fix it.
+        `today` may be overridden (e.g. by the RAG eval, to reproduce a past date).
         """
-        today = datetime.date.today()
+        today = today or datetime.date.today()
         parsed_start_date = self.parse_date(self.start)
         parsed_end_date = self.parse_date(self.end)
         if parsed_start_date and parsed_start_date > today:
@@ -318,9 +319,18 @@ class PreFilterResponse(BaseModel):
 
 
 class DialRagState(BaseRagState):
+    """
+    Tool state shared by all FILE_RAG implementations (DIAL RAG and Generic RAG).
+    statgpt-eval validates FILE_RAG tool responses against this model, so new fields must be optional.
+    """
+
     version: RAGVersion = RAGVersion.DIAL
     pre_filter: PreFilterResponse | None = None
     metadata: DialRagMetadata | None = None
+    current_date: datetime.date | None = Field(
+        default=None,
+        description="Current date override used instead of the wall clock (RAG eval). None means 'today'.",
+    )
     prefilter_decoder_of_latest: dict[str, str] = Field(
         default_factory=dict,
         description="Mapping the publication type to a function that generates a time range "

--- a/statgpt/app/schemas/file_rags/generic_rag.py
+++ b/statgpt/app/schemas/file_rags/generic_rag.py
@@ -44,14 +44,30 @@ class GenericRetrieverConfig(BaseModel):
     document_selector: GenericExplicitDocumentSelector
 
 
+class GenericGenerationConfig(BaseModel):
+    """Overrides for the Generic RAG answer generation config."""
+
+    current_date: datetime.date | None = Field(
+        default=None,
+        description="Date the answer generation treats as 'today' instead of the wall clock. "
+        "Used in RAG eval to reproduce answers as of a cutoff date.",
+    )
+
+
 class GenericRagConfiguration(BaseModel):
     """Partial `custom_fields.configuration` payload sent to the Generic RAG application.
 
     Only the fields we need to override are set; everything else (retriever type,
-    answer generation, top_k) is merged from the application's server-side defaults.
+    answer generation LLM, top_k) is merged from the application's server-side defaults.
+    NOTE: the application silently ignores unknown top-level keys, so the nesting here
+    must match its `RequestConfig` exactly.
     """
 
-    retriever: GenericRetrieverConfig
+    retriever: GenericRetrieverConfig | None = None
+    generation: GenericGenerationConfig | None = None
+
+    def is_empty(self) -> bool:
+        return self.retriever is None and self.generation is None
 
     @classmethod
     def from_rag_filter_dial(cls, rag_filter: RagFilterDial) -> Self:

--- a/tests/unit/app/chains/file_rags/test_current_date_override.py
+++ b/tests/unit/app/chains/file_rags/test_current_date_override.py
@@ -1,0 +1,179 @@
+"""
+The RAG eval replays questions as of a cutoff date. `target_current_date` must replace
+"today" everywhere the FILE_RAG tool uses it: in the prefilter it builds, and in the
+configuration it sends to a RAG that accepts the override (Generic RAG).
+Generic RAG silently drops unknown configuration keys, so the payload shape is asserted exactly.
+"""
+
+import datetime
+
+import pytest
+
+from statgpt.app.chains.file_rags.dial_rag import DialRagAgentFactory
+from statgpt.app.chains.file_rags.dial_rag.prefilter import (
+    DialRagPrefilterBuilder,
+    PreFilterBuilder,
+)
+from statgpt.app.chains.file_rags.file_rag_tool import _RAG_IMPLEMENTATIONS, FileRagArgs
+from statgpt.app.chains.file_rags.generic_rag import GenericRagAgentFactory
+from statgpt.app.schemas.file_rags.dial_rag import (
+    DialRagMetadata,
+    DialRagState,
+    PreFilterResponse,
+    RagFilterDial,
+    RagFilterDialSingle,
+    TimePeriodFilter,
+    TimePeriodFilterDial,
+    TopNDocuments,
+)
+from statgpt.common.schemas import FileRagTool as FileRagToolConfig
+from statgpt.common.schemas import RAGVersion
+from statgpt.common.schemas.tool_details import FileRagDetails
+
+CUTOFF = datetime.date(2025, 3, 15)
+
+
+def _factory(version: RAGVersion) -> DialRagAgentFactory:
+    tool_config = FileRagToolConfig(
+        name="File_RAG", description="publications", details=FileRagDetails(version=version)
+    )
+    return _RAG_IMPLEMENTATIONS[version](tool_config, channel_config=None)  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def prefilter() -> PreFilterResponse:
+    return PreFilterResponse(
+        rag_filter=RagFilterDial(
+            filters=[
+                RagFilterDialSingle(
+                    publication_date=TimePeriodFilterDial(
+                        start=datetime.date(2024, 1, 1), end=CUTOFF
+                    ),
+                    publication_type=None,
+                ),
+                RagFilterDialSingle(publication_date=None, publication_type="sigma"),
+            ],
+            top_n=TopNDocuments(limit=3),
+        )
+    )
+
+
+EXPECTED_FILTERS = [
+    {"publication_date": {"start": "2024-01-01", "end": "2025-03-15"}},
+    {"publication_type": "sigma"},
+]
+EXPECTED_TOP_N = {"sort_by": ["publication_date"], "order": "desc", "limit": 3}
+
+
+def test_registry_covers_every_rag_version():
+    assert _RAG_IMPLEMENTATIONS[RAGVersion.DIAL] is DialRagAgentFactory
+    assert _RAG_IMPLEMENTATIONS[RAGVersion.GENERIC] is GenericRagAgentFactory
+    assert set(_RAG_IMPLEMENTATIONS) == set(RAGVersion)
+
+
+def test_dial_rag_sends_flat_prefilter_and_ignores_current_date(prefilter):
+    factory = _factory(RAGVersion.DIAL)
+    expected = {
+        "custom_fields": {"configuration": {"filters": EXPECTED_FILTERS, "top_n": EXPECTED_TOP_N}}
+    }
+
+    assert factory._build_extra_body(prefilter, None) == expected
+    assert factory._build_extra_body(prefilter, CUTOFF) == expected
+    assert factory._build_extra_body(PreFilterResponse(), CUTOFF) is None
+
+
+def test_generic_rag_nests_prefilter_and_forwards_current_date(prefilter):
+    factory = _factory(RAGVersion.GENERIC)
+    selector = {"type": "explicit", "filters": EXPECTED_FILTERS, "top_n": EXPECTED_TOP_N}
+
+    assert factory._build_extra_body(prefilter, None) == {
+        "custom_fields": {"configuration": {"retriever": {"document_selector": selector}}}
+    }
+    assert factory._build_extra_body(prefilter, CUTOFF) == {
+        "custom_fields": {
+            "configuration": {
+                "retriever": {"document_selector": selector},
+                "generation": {"current_date": "2025-03-15"},
+            }
+        }
+    }
+
+
+def test_generic_rag_sends_current_date_without_prefilter():
+    factory = _factory(RAGVersion.GENERIC)
+
+    assert factory._build_extra_body(PreFilterResponse(), CUTOFF) == {
+        "custom_fields": {"configuration": {"generation": {"current_date": "2025-03-15"}}}
+    }
+    assert factory._build_extra_body(PreFilterResponse(rag_filter=RagFilterDial()), CUTOFF) == {
+        "custom_fields": {"configuration": {"generation": {"current_date": "2025-03-15"}}}
+    }
+    assert factory._build_extra_body(PreFilterResponse(), None) is None
+
+
+def test_tool_state_carries_current_date_and_stays_backward_compatible():
+    inputs = {"pre_filter": None, "metadata": None, "current_date": CUTOFF, "unrelated": object()}
+
+    state = DialRagState(**{**inputs, "version": RAGVersion.GENERIC})
+
+    assert state.version == RAGVersion.GENERIC
+    assert state.current_date == CUTOFF
+    assert DialRagState().current_date is None
+
+
+def test_current_date_is_injected_not_exposed_to_llm():
+    props = FileRagArgs.get_public_schema()["properties"]
+
+    assert "query" in props
+    assert "target_current_date" not in props
+    assert "target_prefilter_json" not in props
+
+
+# --- the prefilter statgpt builds itself must use the same "today"
+
+
+def test_prompt_date_partials_use_reference_date():
+    assert PreFilterBuilder._prompt_date_partials(CUTOFF) == {
+        "current_date_long": "15 March 2025",
+        "current_date_yyyymmdd": "2025-03-15",
+        "current_year": "2025",
+    }
+    assert PreFilterBuilder._prompt_date_partials(None)["current_date_yyyymmdd"] == (
+        datetime.date.today().isoformat()
+    )
+
+
+def test_fix_llm_hallucinations_respects_reference_date():
+    # end date after the (mocked) today is dropped; against the wall clock it would be kept
+    period = TimePeriodFilter(start="2024-01-01", end="2025-06-30")
+    assert period.fix_llm_hallucinations(today=CUTOFF) == TimePeriodFilter(
+        start="2024-01-01", end=""
+    )
+    assert period.fix_llm_hallucinations() == period
+
+    # start date after the mocked today invalidates the whole filter
+    future = TimePeriodFilter(start="2025-04-01", end="2025-06-30")
+    assert future.fix_llm_hallucinations(today=CUTOFF).is_empty()
+
+
+def test_latest_is_decoded_relative_to_reference_date():
+    builder = DialRagPrefilterBuilder(
+        metadata=DialRagMetadata(publication_types={"sigma"}),
+        pub_type_to_decoder_mapping={"sigma": "-1y"},
+    )
+
+    rag_filter = builder.create_prefilter(
+        publication_types=["sigma"],
+        start_date=None,
+        end_date=None,
+        is_latest=True,
+        last_n_publications=None,
+        reference_date=CUTOFF,
+    )
+
+    assert rag_filter is not None
+    (single,) = rag_filter.filters
+    assert single.publication_type == "sigma"
+    assert single.publication_date is not None
+    assert single.publication_date.start == datetime.date(2024, 3, 15)
+    assert single.publication_date.end is None

--- a/tests/unit/app/chains/file_rags/test_current_date_override.py
+++ b/tests/unit/app/chains/file_rags/test_current_date_override.py
@@ -51,7 +51,7 @@ def prefilter() -> PreFilterResponse:
                     ),
                     publication_type=None,
                 ),
-                RagFilterDialSingle(publication_date=None, publication_type="sigma"),
+                RagFilterDialSingle(publication_date=None, publication_type="report"),
             ],
             top_n=TopNDocuments(limit=3),
         )
@@ -60,7 +60,7 @@ def prefilter() -> PreFilterResponse:
 
 EXPECTED_FILTERS = [
     {"publication_date": {"start": "2024-01-01", "end": "2025-03-15"}},
-    {"publication_type": "sigma"},
+    {"publication_type": "report"},
 ]
 EXPECTED_TOP_N = {"sort_by": ["publication_date"], "order": "desc", "limit": 3}
 
@@ -158,12 +158,12 @@ def test_fix_llm_hallucinations_respects_reference_date():
 
 def test_latest_is_decoded_relative_to_reference_date():
     builder = DialRagPrefilterBuilder(
-        metadata=DialRagMetadata(publication_types={"sigma"}),
-        pub_type_to_decoder_mapping={"sigma": "-1y"},
+        metadata=DialRagMetadata(publication_types={"report"}),
+        pub_type_to_decoder_mapping={"report": "-1y"},
     )
 
     rag_filter = builder.create_prefilter(
-        publication_types=["sigma"],
+        publication_types=["report"],
         start_date=None,
         end_date=None,
         is_latest=True,
@@ -173,7 +173,7 @@ def test_latest_is_decoded_relative_to_reference_date():
 
     assert rag_filter is not None
     (single,) = rag_filter.filters
-    assert single.publication_type == "sigma"
+    assert single.publication_type == "report"
     assert single.publication_date is not None
     assert single.publication_date.start == datetime.date(2024, 3, 15)
     assert single.publication_date.end is None


### PR DESCRIPTION
## Applicable issues

- related to #491 — builds on the Generic RAG tool added there (#537)
- related to epam/ai-dial-generic-rag-backend#52 — the Generic RAG side of the same override, implemented in epam/ai-dial-generic-rag-backend#80

## Description of changes

The RAG eval replays questions as of a cutoff date carried by each test case. The FILE_RAG tool only knew the wall clock, in two places:

- **The prefilter statgpt builds.** "Last year" and "latest" were resolved against today, and an end date after today was dropped as a hallucination even when it was valid relative to the cutoff.
- **Generic RAG answer generation.** The prompt carried `<current_date>` = today while the retrieved documents stopped at the cutoff, so answers drifted as real time passed and eval runs were not reproducible. Generic RAG now accepts the date per request as `custom_fields.configuration.generation.current_date` (epam/ai-dial-generic-rag-backend#80); this PR is the statgpt side.

What changes:

- **Tool argument.** `FileRagArgs.target_current_date` (YYYY-MM-DD, `InjectedToolArg`, not shown to the LLM, same mechanism as `target_prefilter_json`), parsed to a `date` and passed down as the chain parameter `TARGET_CURRENT_DATE`.
- **Prefilter builder.** `PreFilterBuilder.build_filter_from_query(query, reference_date)` uses the date everywhere the builder used "today": the date prompt partials (`current_date_long`, `current_date_yyyymmdd`, `current_year`), `TimePeriodFilter.fix_llm_hallucinations(today=...)`, and the existing `reference_date` of `DialRagPrefilterBuilder.create_prefilter` that decodes "latest". `None` keeps the wall clock, so behaviour without the argument is unchanged.
- **Request payload.** `DialRagAgentFactory._build_extra_body(pre_filter_response, current_date)`: DIAL RAG has no field for the date, logs and ignores it for the RAG call. `GenericRagAgentFactory` forwards it as `generation.current_date`, also when there is no prefilter to send. `GenericRagConfiguration` gains an optional `generation` block and `retriever` becomes optional accordingly.
- **Tool state.** `DialRagState.current_date` (optional) records what was forwarded. Additive only: the eval validates FILE_RAG tool state against this model and keeps parsing old and new responses.

Verification:

- `make lint` is clean for the touched files; the remaining mypy output is `fastmcp` missing stubs in MCP modules, unrelated.
- Nine new tests in `tests/unit/app/chains/file_rags/test_current_date_override.py` plus the existing `tests/unit/app/schemas/test_file_rags.py` pass. The rest of the unit suite passes except pre-existing failures unrelated to this change: `test_oidc_auth_settings.py` (reacts to `OIDC_*` shell variables) and `test_sample_config_validates.py` ("seed is not supported for GPT-5 models").
- Probed a local Generic RAG instance with the `current_date` change applied. The `[DEBUG] Request configuration` stage echoes `"generation": {"current_date": "2025-03-15"}` when sent and has no such key otherwise; the nested prefilter narrows the document selection while the flat DIAL shape is ignored.

<details>

<summary>Follow-ups outside this repository</summary>

- The eval has to pass `target_current_date` from the test case at both FILE_RAG tool-call sites (RAG eval and prefilter eval), and its prefilter checker has to grade against that date instead of the response start time. Requires bumping the eval's installed `statgpt-backend` to include this change.
- The `generation.current_date` field reaches dev once epam/ai-dial-generic-rag-backend#80 is merged and the image rebuilt; until then Generic RAG silently ignores it, exactly as it ignored the flat prefilter shape.

</details>

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
