### PR TITLE
feat: make the data explorer link configurable per output surface #634

### DIFF
--- a/configurations/clients/sample/tools.yaml
+++ b/configurations/clients/sample/tools.yaml
@@ -126,6 +126,14 @@ tools:
           enabledStr: "False"
         markdownTable:
           enabledStr: "True"
+      # When each surface carries the "View data in explorer" deep link back to the source
+      # registry. One of: always | only_when_no_data | never. All default to `always`.
+      # Set a surface to `only_when_no_data` to keep the link on the paths where StatGPT could
+      # not deliver (no rows, or the query failed) and drop it from successful answers.
+      explorerLink:
+        stage: always
+        agent: always
+        mcp: always
       stagesConfig:
         debugOnly: true
         toolCallName: "Searching for data: {query}"

--- a/statgpt/app/chains/data_query/query_builder/query/execute_query.py
+++ b/statgpt/app/chains/data_query/query_builder/query/execute_query.py
@@ -19,8 +19,8 @@ from statgpt.app.utils.formatters import DatasetQueryFormatter, DatasetQueryForm
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.data.base import DataResponse, DataSetQuery
 from statgpt.common.schemas import StagesConfig
-from statgpt.common.schemas.data_query_tool import DataQueryMessages
-from statgpt.common.schemas.enums import DataParsingStatus, DataRequestStatus
+from statgpt.common.schemas.data_query_tool import DataQueryExplorerLink, DataQueryMessages
+from statgpt.common.schemas.enums import DataParsingStatus, DataRequestStatus, ExplorerLinkPolicy
 from statgpt.common.schemas.tool_details import StageDescriptor
 
 from .summarize_query import SummarizeQueriesChain
@@ -32,11 +32,13 @@ class ExecuteQueryChain:
         stages_config: StagesConfig,
         stage: StageDescriptor,
         messages: DataQueryMessages,
+        explorer_link: DataQueryExplorerLink,
         summarize_queries_chain: SummarizeQueriesChain,
     ):
         self._stages_config = stages_config
         self._stage = stage
         self._messages = messages
+        self._explorer_link = explorer_link
         self._summarize_queries_chain = summarize_queries_chain
 
     async def summarize_dataset_queries(self, inputs: dict) -> dict:
@@ -50,24 +52,38 @@ class ExecuteQueryChain:
 
         target = ChainParameters.get_target(inputs)
 
-        query_formatter = DatasetQueryFormatter(
-            config=DatasetQueryFormatterConfig(
-                locale=chain_state.data_service.channel_config.locale,
-                include_missing_dimensions=False,
-                include_default_queries=True,
-                include_auto_selects=True,
-            ),
-            auth_context=auth_context,
+        async def render(policy: ExplorerLinkPolicy) -> str:
+            query_formatter = DatasetQueryFormatter(
+                config=DatasetQueryFormatterConfig(
+                    locale=chain_state.data_service.channel_config.locale,
+                    include_missing_dimensions=False,
+                    include_default_queries=True,
+                    include_auto_selects=True,
+                    explorer_link=policy,
+                ),
+                auth_context=auth_context,
+            )
+            formatted_queries = await query_formatter.format_queries(
+                dataset_queries=dataset_queries,
+                datasets_dict=datasets_dict,
+                data_responses=data_responses,
+            )
+            return "The following queries were executed:\n\n" + formatted_queries
+
+        # The stage is read by the user and the response by the model, so each surface gets its
+        # own explorer link policy - and its own rendering when the two differ. The second pass
+        # is pure string building, and is skipped anyway when both surfaces agree.
+        stage_policy = self._explorer_link.stage
+        response_policy = self._explorer_link.for_source(
+            ChainParameters.get_invocation_source(inputs)
         )
 
-        formatted_queries = await query_formatter.format_queries(
-            dataset_queries=dataset_queries,
-            datasets_dict=datasets_dict,
-            data_responses=data_responses,
+        stage_content = await render(stage_policy)
+        response_content = (  # reuse already rendered content if the policy is the same
+            stage_content if response_policy is stage_policy else await render(response_policy)
         )
 
-        response_content = "The following queries were executed:\n\n" + formatted_queries
-        target.append_content(response_content)
+        target.append_content(stage_content)
         # append message to be shown to agent only (not to user) if it's configured.
         # the wording differs per audience: the agent shows the data in DIAL attachments,
         # an MCP client shows it in the UI widget.

--- a/statgpt/app/chains/data_query/query_builder/query/finalize_query.py
+++ b/statgpt/app/chains/data_query/query_builder/query/finalize_query.py
@@ -60,6 +60,7 @@ class FinalizeQueryChainFactory:
             stages_config=self._config.stages_config,
             stage=self._config.pipeline_stage_names.executing_data_query,
             messages=messages,
+            explorer_link=self._config.explorer_link,
             summarize_queries_chain=self._summarize_queries_chain,
         )
         self._no_data_chain = NoDataChain(messages=messages)

--- a/statgpt/app/utils/formatters/dataset_query.py
+++ b/statgpt/app/utils/formatters/dataset_query.py
@@ -18,7 +18,12 @@ from statgpt.common.data.base import (
 )
 from statgpt.common.data.base.enums import InvalidDataSetQueryReasonType
 from statgpt.common.data.base.query import InvalidDataSetQueryReason
-from statgpt.common.schemas.enums import DataParsingStatus, DataRequestStatus, LocaleEnum
+from statgpt.common.schemas.enums import (
+    DataParsingStatus,
+    DataRequestStatus,
+    ExplorerLinkPolicy,
+    LocaleEnum,
+)
 
 from .base import BaseFormatter
 from .dataset_base import DatasetFormatterConfig
@@ -41,6 +46,10 @@ class DatasetQueryFormatterConfig(BaseModel):
     )
     include_query_uuid: bool = Field(
         False, description="Whether to include the query UUID in the output"
+    )
+    explorer_link: ExplorerLinkPolicy = Field(
+        ExplorerLinkPolicy.always,
+        description="When to render the data explorer deep link under the execution result",
     )
 
 
@@ -84,11 +93,23 @@ class DatasetQueryFormatter(BaseFormatter):
             header += f' {dial_app_settings.official_dataset_label}'
         return header
 
+    def _include_explorer_link(self, has_data: bool) -> bool:
+        """Whether this response's explorer deep link should be rendered."""
+        match self._config.explorer_link:
+            case ExplorerLinkPolicy.always:
+                return True
+            case ExplorerLinkPolicy.only_when_no_data:
+                return not has_data
+            case ExplorerLinkPolicy.never:
+                return False
+
     def _format_execution_result(self, data_response: DataResponse) -> list[str]:
         """Format execution result section."""
         lines = []
 
-        if not data_response.visual_dataframe.empty:
+        has_data = not data_response.visual_dataframe.empty
+
+        if has_data:
             lines.append(
                 f'✅ **{self._("Execution result")}**: {self._("Data received, contains {count} series.").format(count=data_response.get_display_series_count())}'
             )
@@ -120,7 +141,7 @@ class DatasetQueryFormatter(BaseFormatter):
                 f'💡 **{self._("Advice")}:** {self._("Most likely, the query is generally correct, but there is no data for the specified time period.")} {self._("You may want to try selecting a different time period.")} {self._("Another option is to try to find relevant data in other datasets or using other tools.")}'
             )
 
-        if data_response.url_query:
+        if data_response.url_query and self._include_explorer_link(has_data):
             lines.append("")
             lines.append(f'[🔍 {self._("View data in explorer")}]({data_response.url_query})')
 

--- a/statgpt/common/schemas/__init__.py
+++ b/statgpt/common/schemas/__init__.py
@@ -27,7 +27,12 @@ from .channel_dataset import (
     StructureChange,
 )
 from .composite import ChannelDatasetUpdateResult, DataSetUpdateResponse
-from .data_query_tool import DataQueryDetails, DataQueryMcpResources, HybridSearchConfig
+from .data_query_tool import (
+    DataQueryDetails,
+    DataQueryExplorerLink,
+    DataQueryMcpResources,
+    HybridSearchConfig,
+)
 from .data_source import DataSource, DataSourceBase, DataSourceType, DataSourceUpdate, Provider
 from .dataset import DataSet, DataSetBase, DataSetDescriptor, DataSetUpdateRequest, DeletedDataSet
 from .discovery_dataset import (
@@ -68,6 +73,7 @@ from .enums import (
     DiscoveryGrade,
     DiscoveryIndexingStatus,
     DiscoveryValidationStatus,
+    ExplorerLinkPolicy,
     ExportScope,
     IndexerVersion,
     IndicatorSelectionVersion,

--- a/statgpt/common/schemas/data_query_tool.py
+++ b/statgpt/common/schemas/data_query_tool.py
@@ -15,6 +15,7 @@ from statgpt.common.config.utils import replace_env
 
 from .base import BaseYamlModel, SystemUserPrompt
 from .enums import (
+    ExplorerLinkPolicy,
     IndexerVersion,
     IndicatorSelectionVersion,
     InvocationSource,
@@ -246,6 +247,33 @@ class DataQueryMcpResources(BaseYamlModel):
             " is what instructs the model to reproduce the table for the user."
         ),
     )
+
+
+class DataQueryExplorerLink(BaseYamlModel):
+    """When each surface of the data query response carries the data explorer deep link.
+
+    The three surfaces are configured separately because they have different audiences: the
+    stage is read by the user, who may well want to go and look at the source, while the tool
+    response is read by the model, which tends to copy any link it is given into its answer.
+    The defaults reproduce the behavior that predates this config - the link everywhere.
+    """
+
+    stage: ExplorerLinkPolicy = Field(
+        default=ExplorerLinkPolicy.always,
+        description="Policy for the user-facing DIAL stage. Not used on the MCP path, which has no stages.",
+    )
+    agent: ExplorerLinkPolicy = Field(
+        default=ExplorerLinkPolicy.always,
+        description="Policy for the tool response the Supreme Agent reads.",
+    )
+    mcp: ExplorerLinkPolicy = Field(
+        default=ExplorerLinkPolicy.always,
+        description="Policy for the tool response returned to an MCP client.",
+    )
+
+    def for_source(self, source: InvocationSource) -> ExplorerLinkPolicy:
+        """The policy for the tool response, given the flow the call belongs to."""
+        return self.mcp if source is InvocationSource.MCP else self.agent
 
 
 class DataQueryLLMModels(BaseYamlModel):
@@ -507,6 +535,10 @@ class DataQueryDetails(BaseToolDetails):
     messages: DataQueryMessages = Field(default_factory=DataQueryMessages)  # type: ignore
     attachments: DataQueryAttachments = Field(default_factory=DataQueryAttachments)  # type: ignore
     mcp_resources: DataQueryMcpResources = Field(default_factory=DataQueryMcpResources)
+    explorer_link: DataQueryExplorerLink = Field(
+        default_factory=DataQueryExplorerLink,
+        description="When the data explorer deep link is rendered, per output surface.",
+    )
     pipeline_stage_names: DataQueryStageNames = Field(default_factory=DataQueryStageNames)
     allow_auto_update: bool = Field(
         default=False,

--- a/statgpt/common/schemas/enums.py
+++ b/statgpt/common/schemas/enums.py
@@ -117,6 +117,24 @@ class TimePeriodStrategy(StrEnum):
     AFTER = "AFTER"
 
 
+class ExplorerLinkPolicy(StrEnum):
+    """When a data query response should carry the data explorer deep link.
+
+    The link points the user back to the source registry. That is worth offering when
+    StatGPT could not deliver the data itself, and noise when it just did - hence the
+    middle option rather than a plain on/off.
+    """
+
+    always = "always"
+    """Render the link whenever the response carries one."""
+
+    only_when_no_data = "only_when_no_data"
+    """Render the link only when the query returned no rows, or failed to run or parse."""
+
+    never = "never"
+    """Never render the link."""
+
+
 class SpecialDimensionsProcessorType(StrEnum):
     LHCL = "large_hierarchical_codelist"
 

--- a/tests/unit/app/chains/test_explorer_link_surfaces.py
+++ b/tests/unit/app/chains/test_explorer_link_surfaces.py
@@ -1,0 +1,137 @@
+"""The stage and the tool response each carry the explorer link on their own terms."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pandas as pd
+
+from statgpt.app.chains.data_query.parameters import DataQueryParameters
+from statgpt.app.chains.data_query.query_builder.query.execute_query import ExecuteQueryChain
+from statgpt.app.config import ChainParametersConfig
+from statgpt.app.services.chat_facade import ChannelServiceFacade, VersionedDataSet
+from statgpt.common.auth.auth_context import AuthContext
+from statgpt.common.data.base import DataSet, DataSetQuery
+from statgpt.common.data.base.dataset import DataResponseStatus
+from statgpt.common.schemas import ChannelConfig
+from statgpt.common.schemas.data_query_tool import DataQueryExplorerLink, DataQueryMessages
+from statgpt.common.schemas.enums import (
+    DataParsingStatus,
+    DataRequestStatus,
+    ExplorerLinkPolicy,
+    InvocationSource,
+    LocaleEnum,
+)
+
+_URL = "https://explorer.example/view?q=1"
+_DATASET_ID = "ds1"
+
+
+class _FakeTarget:
+    def __init__(self) -> None:
+        self.content = ""
+
+    def append_content(self, content: str) -> None:
+        self.content += content
+
+
+class _FakeDataResponse:
+    """The slice of `DataResponse` the query formatter reads."""
+
+    def __init__(self, has_data: bool) -> None:
+        self.status = DataResponseStatus(
+            request_status=DataRequestStatus.SUCCESS, parsing_status=DataParsingStatus.SUCCESS
+        )
+        self.visual_dataframe = pd.DataFrame({"value": [1]}) if has_data else pd.DataFrame()
+        self.url_query = _URL
+        self.time_period = None
+        self.is_empty = not has_data
+
+    def get_display_series_count(self) -> int:
+        return 1
+
+
+def _versioned_dataset() -> VersionedDataSet:
+    data = Mock(spec=DataSet)
+    data.entity_id = _DATASET_ID
+    data.source_id = _DATASET_ID
+    data.name = "Test dataset"
+    data.config = SimpleNamespace(is_official=False, citation=None)
+    data.dimensions.return_value = []
+    data.indicator_dimensions.return_value = []
+    return VersionedDataSet(version=Mock(), data=data)
+
+
+def _chain(explorer_link: DataQueryExplorerLink) -> ExecuteQueryChain:
+    chain = ExecuteQueryChain.__new__(ExecuteQueryChain)
+    chain._messages = DataQueryMessages()  # type: ignore[attr-defined]
+    chain._explorer_link = explorer_link  # type: ignore[attr-defined]
+    return chain
+
+
+def _inputs(source: InvocationSource, has_data: bool = True) -> dict:
+    data_service = Mock(spec=ChannelServiceFacade)
+    data_service.channel_config = Mock(spec=ChannelConfig)
+    data_service.channel_config.locale = LocaleEnum.EN
+
+    return {
+        "auth_context": Mock(spec=AuthContext),
+        "choice": Mock(),
+        "target": _FakeTarget(),
+        "state": {},
+        "data_service": data_service,
+        "datasets_dict": {_DATASET_ID: _versioned_dataset()},
+        "dataset_queries": {_DATASET_ID: DataSetQuery(dimensions_queries=[])},
+        ChainParametersConfig.DATA_RESPONSES: {_DATASET_ID: _FakeDataResponse(has_data)},
+        ChainParametersConfig.CONFIGURATION: SimpleNamespace(
+            get_current_timestamp=lambda: "2026-01-01T00:00:00+00:00"
+        ),
+        ChainParametersConfig.INVOCATION_SOURCE: source,
+        DataQueryParameters.STATE: {},
+    }
+
+
+async def _run(explorer_link: DataQueryExplorerLink, source: InvocationSource, **kwargs: Any):
+    inputs = _inputs(source, **kwargs)
+    result = await _chain(explorer_link).summarize_dataset_queries(inputs)
+    return inputs["target"].content, result[DataQueryParameters.RESPONSE_FIELD]
+
+
+async def test_default_config_links_on_both_surfaces():
+    """The out-of-the-box behavior must be unchanged."""
+    stage, response = await _run(DataQueryExplorerLink(), InvocationSource.AGENT)
+    assert _URL in stage
+    assert _URL in response
+
+
+async def test_stage_keeps_the_link_while_the_agent_response_drops_it():
+    stage, response = await _run(
+        DataQueryExplorerLink(
+            stage=ExplorerLinkPolicy.always, agent=ExplorerLinkPolicy.only_when_no_data
+        ),
+        InvocationSource.AGENT,
+    )
+    assert _URL in stage
+    assert _URL not in response
+
+
+async def test_only_when_no_data_still_links_where_nothing_was_delivered():
+    stage, response = await _run(
+        DataQueryExplorerLink(
+            stage=ExplorerLinkPolicy.always, agent=ExplorerLinkPolicy.only_when_no_data
+        ),
+        InvocationSource.AGENT,
+        has_data=False,
+    )
+    assert _URL in stage
+    assert _URL in response
+
+
+async def test_mcp_policy_applies_only_on_the_mcp_path():
+    config = DataQueryExplorerLink(agent=ExplorerLinkPolicy.always, mcp=ExplorerLinkPolicy.never)
+
+    _, agent_response = await _run(config, InvocationSource.AGENT)
+    _, mcp_response = await _run(config, InvocationSource.MCP)
+
+    assert _URL in agent_response
+    assert _URL not in mcp_response

--- a/tests/unit/app/utils/formatters/test_explorer_link.py
+++ b/tests/unit/app/utils/formatters/test_explorer_link.py
@@ -1,0 +1,107 @@
+import pandas as pd
+import pytest
+
+from statgpt.app.utils.formatters import DatasetQueryFormatter, DatasetQueryFormatterConfig
+from statgpt.common.data.base.dataset import DataResponseStatus
+from statgpt.common.schemas.enums import DataParsingStatus, DataRequestStatus, ExplorerLinkPolicy
+
+_URL = "https://explorer.example/view?q=1"
+
+_SUCCESS = DataResponseStatus(
+    request_status=DataRequestStatus.SUCCESS, parsing_status=DataParsingStatus.SUCCESS
+)
+_REQUEST_FAILED = DataResponseStatus(
+    request_status=DataRequestStatus.FAILED, parsing_status=DataParsingStatus.NA
+)
+_PARSING_FAILED = DataResponseStatus(
+    request_status=DataRequestStatus.SUCCESS, parsing_status=DataParsingStatus.FAILED
+)
+_EMPTY = DataResponseStatus(
+    request_status=DataRequestStatus.SUCCESS, parsing_status=DataParsingStatus.SUCCESS
+)
+
+# Every outcome `_format_execution_result` branches on, and whether it delivered rows.
+_OUTCOMES = {
+    "data_received": (_SUCCESS, True),
+    "request_failed": (_REQUEST_FAILED, False),
+    "parsing_failed": (_PARSING_FAILED, False),
+    "no_rows": (_EMPTY, False),
+}
+_NO_DATA_OUTCOMES = [name for name, (_, has_data) in _OUTCOMES.items() if not has_data]
+
+
+class _FakeDataResponse:
+    """The slice of `DataResponse` that `_format_execution_result` reads."""
+
+    def __init__(self, status: DataResponseStatus, has_data: bool, url: str | None = _URL):
+        self.status = status
+        self.visual_dataframe = pd.DataFrame({"value": [1]}) if has_data else pd.DataFrame()
+        self.url_query = url
+
+    def get_display_series_count(self) -> int:
+        return 1
+
+
+def _render(policy: ExplorerLinkPolicy, outcome: str, url: str | None = _URL) -> str:
+    status, has_data = _OUTCOMES[outcome]
+    formatter = DatasetQueryFormatter(
+        config=DatasetQueryFormatterConfig(explorer_link=policy), auth_context=None
+    )
+    lines = formatter._format_execution_result(_FakeDataResponse(status, has_data, url))
+    return "\n".join(lines)
+
+
+def _has_link(rendered: str) -> bool:
+    return _URL in rendered
+
+
+class TestAlways:
+    """The default: today's behavior, a link on every outcome."""
+
+    @pytest.mark.parametrize("outcome", list(_OUTCOMES))
+    def test_link_rendered(self, outcome: str):
+        assert _has_link(_render(ExplorerLinkPolicy.always, outcome))
+
+    def test_is_the_config_default(self):
+        assert DatasetQueryFormatterConfig().explorer_link is ExplorerLinkPolicy.always
+
+
+class TestOnlyWhenNoData:
+    """Link out only where StatGPT could not deliver."""
+
+    def test_no_link_on_success(self):
+        """The point of the setting: a delivered answer must stand on its own."""
+        assert not _has_link(_render(ExplorerLinkPolicy.only_when_no_data, "data_received"))
+
+    @pytest.mark.parametrize("outcome", _NO_DATA_OUTCOMES)
+    def test_link_kept_where_nothing_was_delivered(self, outcome: str):
+        assert _has_link(_render(ExplorerLinkPolicy.only_when_no_data, outcome))
+
+
+class TestNever:
+    @pytest.mark.parametrize("outcome", list(_OUTCOMES))
+    def test_no_link_rendered(self, outcome: str):
+        assert not _has_link(_render(ExplorerLinkPolicy.never, outcome))
+
+
+@pytest.mark.parametrize("policy", list(ExplorerLinkPolicy))
+@pytest.mark.parametrize("outcome", list(_OUTCOMES))
+def test_nothing_rendered_when_the_response_carries_no_url(
+    policy: ExplorerLinkPolicy, outcome: str
+):
+    assert "](" not in _render(policy, outcome, url=None)
+
+
+@pytest.mark.parametrize("policy", list(ExplorerLinkPolicy))
+@pytest.mark.parametrize(
+    "outcome,marker",
+    [
+        ("data_received", "Data received"),
+        ("request_failed", "The request to the data source failed."),
+        ("parsing_failed", "parsing the response failed"),
+        ("no_rows", "does not contain any data"),
+    ],
+)
+def test_the_policy_gates_only_the_link(policy: ExplorerLinkPolicy, outcome: str, marker: str):
+    """Which outcome branch is reported must not depend on the link policy."""
+    assert marker in _render(policy, outcome)

--- a/tests/unit/common/schemas/test_explorer_link_config.py
+++ b/tests/unit/common/schemas/test_explorer_link_config.py
@@ -1,0 +1,59 @@
+import pytest
+
+from statgpt.common.schemas.data_query_tool import DataQueryDetails, DataQueryExplorerLink
+from statgpt.common.schemas.enums import ExplorerLinkPolicy, InvocationSource
+
+_SURFACES = ["stage", "agent", "mcp"]
+
+
+class TestDefaults:
+    """Every surface defaults to `always`, reproducing the behavior before the config existed."""
+
+    @pytest.mark.parametrize("surface", _SURFACES)
+    def test_explorer_link_defaults_to_always(self, surface: str):
+        assert getattr(DataQueryExplorerLink(), surface) is ExplorerLinkPolicy.always
+
+    @pytest.mark.parametrize("surface", _SURFACES)
+    def test_details_without_the_block_defaults_to_always(self, surface: str):
+        """A stored channel config that predates the field must keep linking as it does today."""
+        details = DataQueryDetails()
+        assert getattr(details.explorer_link, surface) is ExplorerLinkPolicy.always
+
+
+class TestForSource:
+    """The tool response policy follows the flow the call belongs to."""
+
+    def test_agent_source_reads_the_agent_policy(self):
+        config = DataQueryExplorerLink(
+            agent=ExplorerLinkPolicy.only_when_no_data, mcp=ExplorerLinkPolicy.never
+        )
+        assert config.for_source(InvocationSource.AGENT) is ExplorerLinkPolicy.only_when_no_data
+
+    def test_mcp_source_reads_the_mcp_policy(self):
+        config = DataQueryExplorerLink(
+            agent=ExplorerLinkPolicy.only_when_no_data, mcp=ExplorerLinkPolicy.never
+        )
+        assert config.for_source(InvocationSource.MCP) is ExplorerLinkPolicy.never
+
+    def test_stage_policy_is_not_a_tool_response_policy(self):
+        """The stage setting must never leak into what the model reads."""
+        config = DataQueryExplorerLink(
+            stage=ExplorerLinkPolicy.always, agent=ExplorerLinkPolicy.never
+        )
+        assert config.for_source(InvocationSource.AGENT) is ExplorerLinkPolicy.never
+
+
+class TestYamlParsing:
+    def test_camel_case_block_parses(self):
+        details = DataQueryDetails.model_validate(
+            {"explorerLink": {"stage": "always", "agent": "only_when_no_data", "mcp": "never"}}
+        )
+        assert details.explorer_link.stage is ExplorerLinkPolicy.always
+        assert details.explorer_link.agent is ExplorerLinkPolicy.only_when_no_data
+        assert details.explorer_link.mcp is ExplorerLinkPolicy.never
+
+    def test_partial_block_leaves_the_rest_on_the_default(self):
+        details = DataQueryDetails.model_validate({"explorerLink": {"agent": "never"}})
+        assert details.explorer_link.agent is ExplorerLinkPolicy.never
+        assert details.explorer_link.stage is ExplorerLinkPolicy.always
+        assert details.explorer_link.mcp is ExplorerLinkPolicy.always


### PR DESCRIPTION
## Applicable issues

- closes #634

## Description of changes

When a data query succeeded, the response still carried a `[🔍 View data in explorer]` deep link back to the source registry — sending the user out of the platform to fetch numbers StatGPT had just delivered. The link was emitted unconditionally, so success was treated exactly like failure. Worse, the same string becomes the tool response the Supreme Agent reasons over, so the agent tended to lift the link into its own final message; suppressing it by prompt was never going to be reliable against markdown already sitting in the model's context.

The only lever available was `viewInDataExplorer` on the data source, which removes the link everywhere — including the no-data and failure paths, where linking out is genuinely the most useful thing the response can do.

**A policy per output surface.** A new `explorerLink` block on the data query tool's `details` sets, independently for each surface, when the link is rendered:

```yaml
      explorerLink:
        stage: always              # the user-facing DIAL stage
        agent: only_when_no_data   # the tool response the Supreme Agent reads
        mcp: never                 # the tool response returned to an MCP client
```

Each takes `always`, `only_when_no_data` or `never`. All three default to `always`, so stored channel configs keep today's behavior and no migration is needed. The agent/MCP split reuses the existing `InvocationSource` mechanism that already picks the `*McpOnly` message variants.

**Rendering the two audiences apart.** `ExecuteQueryChain` built one string and sent it both to the stage and to the tool response, so the two could not differ. It now resolves the stage policy and the tool-response policy separately and renders once per distinct policy — which stays a single pass in the default config, and in any config where both surfaces agree. The second pass is pure string building: the one `await` inside `format_queries` just parses a configured citation date.

`only_when_no_data` is evaluated per `DataResponse` rather than per run, so in a multi-dataset fan-out the dataset that returned rows loses its link while an empty one keeps it.

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.