### PR TITLE
feat: relay custom_content.annotations so inline citations render #659

### DIFF
--- a/statgpt/app/application/channel_completion.py
+++ b/statgpt/app/application/channel_completion.py
@@ -138,6 +138,9 @@ class ChannelCompletion(ChatCompletion):
                 ParamsConfig.START_OF_REQUEST: start_time,
                 ParamsConfig.CONFIGURATION: configuration,
                 ParamsConfig.INVOCATION_SOURCE: InvocationSource.AGENT,
+                # Empty index space: every annotation relayed during this response is numbered
+                # in it, whichever tool relays it.
+                ParamsConfig.ANNOTATION_INDEXES: {},
             }
 
             callbacks: list = []

--- a/statgpt/app/application/channel_completion.py
+++ b/statgpt/app/application/channel_completion.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 from collections.abc import Iterable
 from datetime import datetime
@@ -138,9 +139,9 @@ class ChannelCompletion(ChatCompletion):
                 ParamsConfig.START_OF_REQUEST: start_time,
                 ParamsConfig.CONFIGURATION: configuration,
                 ParamsConfig.INVOCATION_SOURCE: InvocationSource.AGENT,
-                # Empty index space: every annotation relayed during this response is numbered
-                # in it, whichever tool relays it.
-                ParamsConfig.ANNOTATION_INDEXES: {},
+                # Fresh index space: every annotation relayed during this response takes its
+                # index from this counter, whichever tool relays it.
+                ParamsConfig.ANNOTATION_INDEX_SPACE: itertools.count(),
             }
 
             callbacks: list = []

--- a/statgpt/app/chains/deep_research/deep_research_tool.py
+++ b/statgpt/app/chains/deep_research/deep_research_tool.py
@@ -208,7 +208,7 @@ class DeepResearchRunner:
                     stream_content=False,
                     show_debug_stages=show_debug_stages,
                     stages_config=details.stages_config,
-                    annotation_indexes=ChainParameters.get_annotation_indexes(inputs),
+                    annotation_index_space=ChainParameters.get_annotation_index_space(inputs),
                 )
                 with dial_streamer:
                     stream = await client.chat.completions.create(**create_kwargs)

--- a/statgpt/app/chains/deep_research/deep_research_tool.py
+++ b/statgpt/app/chains/deep_research/deep_research_tool.py
@@ -186,6 +186,10 @@ class DeepResearchRunner:
             state.get(StateVarsConfig.SHOW_DEBUG_STAGES, False) or details.always_show_stages
         )
 
+        # Keep `stream=True`. In a blocking response the DIAL SDK merges the chunks into one
+        # message and strips the `index` field from every annotation. The streamer below needs
+        # that field to renumber the annotations, and it cannot tell a stripped array from one
+        # that never had indexes, so the report's citations would silently break.
         create_kwargs: dict[str, Any] = dict(model=deployment_id, stream=True, messages=messages)
         client = openai.get_async_client(api_key=auth_context.api_key)
         time_start = time.monotonic()
@@ -204,6 +208,7 @@ class DeepResearchRunner:
                     stream_content=False,
                     show_debug_stages=show_debug_stages,
                     stages_config=details.stages_config,
+                    annotation_indexes=ChainParameters.get_annotation_indexes(inputs),
                 )
                 with dial_streamer:
                     stream = await client.chat.completions.create(**create_kwargs)

--- a/statgpt/app/chains/file_rags/dial_rag/dial_rag.py
+++ b/statgpt/app/chains/file_rags/dial_rag/dial_rag.py
@@ -255,7 +255,7 @@ class DialRagAgentFactory(BaseRAGFactory):
             stream_content=False,
             show_debug_stages=state.get(StateVarsConfig.SHOW_DEBUG_STAGES, False),
             stages_config=self._tool_config.details.stages_config,
-            annotation_indexes=ChainParameters.get_annotation_indexes(inputs),
+            annotation_index_space=ChainParameters.get_annotation_index_space(inputs),
         )
 
         with dial_streamer:

--- a/statgpt/app/chains/file_rags/dial_rag/dial_rag.py
+++ b/statgpt/app/chains/file_rags/dial_rag/dial_rag.py
@@ -255,6 +255,7 @@ class DialRagAgentFactory(BaseRAGFactory):
             stream_content=False,
             show_debug_stages=state.get(StateVarsConfig.SHOW_DEBUG_STAGES, False),
             stages_config=self._tool_config.details.stages_config,
+            annotation_indexes=ChainParameters.get_annotation_indexes(inputs),
         )
 
         with dial_streamer:

--- a/statgpt/app/chains/parameters.py
+++ b/statgpt/app/chains/parameters.py
@@ -78,6 +78,10 @@ class ChainParameters:
         the annotations of concurrently running sub-deployments do not reuse each other's
         indexes. It is kept here rather than in ``state`` because the state is persisted into
         the response and the SDK's chunk-merge rewrites the ``index`` keys of any list it holds.
+
+        Scaffolding, not a permanent parameter: it stands in for the counter the SDK's ``Choice``
+        already owns for stages and attachments but not for annotations. See the module docstring
+        of ``statgpt.app.utils.dial_annotations``.
         """
         return data[ChainParametersConfig.ANNOTATION_INDEX_SPACE]
 

--- a/statgpt/app/chains/parameters.py
+++ b/statgpt/app/chains/parameters.py
@@ -9,6 +9,7 @@ from statgpt.app.schemas.file_rags.dial_rag import RagFilterDial
 from statgpt.app.services.chat_facade import ChannelServiceFacade, VersionedDataSet
 from statgpt.app.utils.dial_stages import ChoiceI
 from statgpt.app.utils.message_history import History
+from statgpt.app.utils.openai_to_dial_streamer import AnnotationIndexes
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.data.base import DataResponse, DataSetQuery, DimensionQuery
 from statgpt.common.schemas.enums import InvocationSource
@@ -68,6 +69,17 @@ class ChainParameters:
     @staticmethod
     def get_target(data: dict) -> Stage:
         return data[ChainParametersConfig.TARGET]
+
+    @staticmethod
+    def get_annotation_indexes(data: dict) -> AnnotationIndexes:
+        """The annotation index space of the current response.
+
+        One dict per response, shared by every ``OpenAiToDialStreamer`` it creates so that the
+        annotations of concurrently running sub-deployments do not reuse each other's indexes.
+        It is kept here rather than in ``state`` because the state is persisted into the
+        response and the SDK's chunk-merge rewrites the ``index`` keys of any list it holds.
+        """
+        return data[ChainParametersConfig.ANNOTATION_INDEXES]
 
     @staticmethod
     def get_history(data: dict) -> History:

--- a/statgpt/app/chains/parameters.py
+++ b/statgpt/app/chains/parameters.py
@@ -9,7 +9,7 @@ from statgpt.app.schemas.file_rags.dial_rag import RagFilterDial
 from statgpt.app.services.chat_facade import ChannelServiceFacade, VersionedDataSet
 from statgpt.app.utils.dial_stages import ChoiceI
 from statgpt.app.utils.message_history import History
-from statgpt.app.utils.openai_to_dial_streamer import AnnotationIndexes
+from statgpt.app.utils.openai_to_dial_streamer import AnnotationIndexSpace
 from statgpt.common.auth.auth_context import AuthContext
 from statgpt.common.data.base import DataResponse, DataSetQuery, DimensionQuery
 from statgpt.common.schemas.enums import InvocationSource
@@ -71,15 +71,15 @@ class ChainParameters:
         return data[ChainParametersConfig.TARGET]
 
     @staticmethod
-    def get_annotation_indexes(data: dict) -> AnnotationIndexes:
-        """The annotation index space of the current response.
+    def get_annotation_index_space(data: dict) -> AnnotationIndexSpace:
+        """The annotation index counter of the current response.
 
-        One dict per response, shared by every ``OpenAiToDialStreamer`` it creates so that the
-        annotations of concurrently running sub-deployments do not reuse each other's indexes.
-        It is kept here rather than in ``state`` because the state is persisted into the
-        response and the SDK's chunk-merge rewrites the ``index`` keys of any list it holds.
+        One counter per response, shared by every ``OpenAiToDialStreamer`` it creates so that
+        the annotations of concurrently running sub-deployments do not reuse each other's
+        indexes. It is kept here rather than in ``state`` because the state is persisted into
+        the response and the SDK's chunk-merge rewrites the ``index`` keys of any list it holds.
         """
-        return data[ChainParametersConfig.ANNOTATION_INDEXES]
+        return data[ChainParametersConfig.ANNOTATION_INDEX_SPACE]
 
     @staticmethod
     def get_history(data: dict) -> History:

--- a/statgpt/app/chains/web_search/response_producer.py
+++ b/statgpt/app/chains/web_search/response_producer.py
@@ -93,6 +93,7 @@ class RagResponseProducer(ResponseProducerABC):
             stream_content=self._stream_content,
             show_debug_stages=state.get(StateVarsConfig.SHOW_DEBUG_STAGES, False),
             stages_config=self._stages_config,
+            annotation_indexes=ChainParameters.get_annotation_indexes(inputs),
         )
 
         res = None
@@ -146,6 +147,7 @@ class UrlOnlyResponseProducer(ResponseProducerABC):
                 stream_content=True,
                 show_debug_stages=state.get(StateVarsConfig.SHOW_DEBUG_STAGES, False),
                 stages_config=self._stages_config,
+                annotation_indexes=ChainParameters.get_annotation_indexes(inputs),
             )
 
             with dial_streamer:

--- a/statgpt/app/chains/web_search/response_producer.py
+++ b/statgpt/app/chains/web_search/response_producer.py
@@ -93,7 +93,7 @@ class RagResponseProducer(ResponseProducerABC):
             stream_content=self._stream_content,
             show_debug_stages=state.get(StateVarsConfig.SHOW_DEBUG_STAGES, False),
             stages_config=self._stages_config,
-            annotation_indexes=ChainParameters.get_annotation_indexes(inputs),
+            annotation_index_space=ChainParameters.get_annotation_index_space(inputs),
         )
 
         res = None
@@ -147,7 +147,7 @@ class UrlOnlyResponseProducer(ResponseProducerABC):
                 stream_content=True,
                 show_debug_stages=state.get(StateVarsConfig.SHOW_DEBUG_STAGES, False),
                 stages_config=self._stages_config,
-                annotation_indexes=ChainParameters.get_annotation_indexes(inputs),
+                annotation_index_space=ChainParameters.get_annotation_index_space(inputs),
             )
 
             with dial_streamer:

--- a/statgpt/app/config/chain_parameters.py
+++ b/statgpt/app/config/chain_parameters.py
@@ -20,6 +20,7 @@ class ChainParametersConfig:
     START_OF_REQUEST = "start_of_request"
     CONFIGURATION = "configuration"
     INVOCATION_SOURCE = "invocation_source"
+    ANNOTATION_INDEXES = "annotation_indexes"
 
     TARGET_PREFILTER = "target_prefilter"
     TARGET_CURRENT_DATE = "target_current_date"

--- a/statgpt/app/config/chain_parameters.py
+++ b/statgpt/app/config/chain_parameters.py
@@ -20,7 +20,7 @@ class ChainParametersConfig:
     START_OF_REQUEST = "start_of_request"
     CONFIGURATION = "configuration"
     INVOCATION_SOURCE = "invocation_source"
-    ANNOTATION_INDEXES = "annotation_indexes"
+    ANNOTATION_INDEX_SPACE = "annotation_index_space"
 
     TARGET_PREFILTER = "target_prefilter"
     TARGET_CURRENT_DATE = "target_current_date"

--- a/statgpt/app/mcp/provider.py
+++ b/statgpt/app/mcp/provider.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 from collections.abc import Sequence
 from datetime import datetime
@@ -42,7 +43,7 @@ def _build_mcp_inputs(
         ChainParametersConfig.INVOCATION_SOURCE: InvocationSource.MCP,
         # Present so a tool that relays annotations can run here too. Nothing is emitted: the
         # MCP context has no choice to stream them on.
-        ChainParametersConfig.ANNOTATION_INDEXES: {},
+        ChainParametersConfig.ANNOTATION_INDEX_SPACE: itertools.count(),
     }
 
 

--- a/statgpt/app/mcp/provider.py
+++ b/statgpt/app/mcp/provider.py
@@ -40,6 +40,9 @@ def _build_mcp_inputs(
         ChainParametersConfig.TARGET: DummyStage(),
         ChainParametersConfig.START_OF_REQUEST: datetime.now(configuration.tzinfo),
         ChainParametersConfig.INVOCATION_SOURCE: InvocationSource.MCP,
+        # Present so a tool that relays annotations can run here too. Nothing is emitted: the
+        # MCP context has no choice to stream them on.
+        ChainParametersConfig.ANNOTATION_INDEXES: {},
     }
 
 

--- a/statgpt/app/utils/dial_annotations.py
+++ b/statgpt/app/utils/dial_annotations.py
@@ -1,0 +1,58 @@
+"""Sending `custom_content.annotations` on a DIAL choice.
+
+An annotation claims a `<cit data-id="...">` marker tag in the message text and says what the
+tag cites: the file, its page, and the label of the pill the client draws in its place. A tag no
+annotation claims is rendered as literal text, so the array has to reach the reader for the
+citations to appear.
+"""
+
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+from aidial_sdk.chat_completion import Choice
+
+# Unexported import path: `ArbitraryChunk` and its `BaseChunk` are outside `aidial_sdk`'s
+# `__all__`, so this could change without deprecation. It is used because the SDK has no
+# annotations API, and this is the same mechanism its own state and attachment chunks go out
+# through. `choice.add_attachment` is not an alternative: it assigns attachment indexes from its
+# own counter and would renumber the annotations.
+from aidial_sdk.chat_completion.chunks import ArbitraryChunk
+
+from statgpt.app.utils.dial_stages import ChoiceI
+
+_log = logging.getLogger(__name__)
+
+
+def send_annotations(choice: ChoiceI, annotations: Sequence[dict[str, Any]]) -> None:
+    """Emit `annotations` as one streamed delta on `choice`.
+
+    Annotations belong to a message, so they are always sent to a choice and never to a stage.
+    The array may arrive before or after the text it annotates: the client resolves annotations
+    only once the message has finished streaming.
+
+    Does nothing but log on a choice that cannot stream (`NullChoice` in the MCP context), the
+    same way `NullChoice.add_attachment` does.
+    """
+    if not isinstance(choice, Choice):
+        _log.warning(
+            "send_annotations() called on %s, which cannot stream — %d annotation(s) dropped.",
+            type(choice).__name__,
+            len(annotations),
+        )
+        return
+
+    choice.send_chunk(
+        ArbitraryChunk(
+            {
+                "choices": [
+                    {
+                        "index": choice.index,
+                        "finish_reason": None,
+                        "delta": {"custom_content": {"annotations": list(annotations)}},
+                    }
+                ],
+                "usage": None,
+            }
+        )
+    )

--- a/statgpt/app/utils/dial_annotations.py
+++ b/statgpt/app/utils/dial_annotations.py
@@ -4,6 +4,21 @@ An annotation claims a `<cit data-id="...">` marker tag in the message text and 
 tag cites: the file, its page, and the label of the pill the client draws in its place. A tag no
 annotation claims is rendered as literal text, so the array has to reach the reader for the
 citations to appear.
+
+This module is a stand-in for an SDK method that does not exist yet, and is meant to be deleted
+rather than maintained. `Choice` numbers every child it knows about from its own counter —
+`create_stage` from `_last_stage_index`, `add_attachment` from `_last_attachment_index` — which
+is why `OpenAiToDialStreamer._process_stage` and `_process_attachment` hand over a payload and
+never an index. `aidial_sdk` (pinned `>=0.39.0,<0.40.0`) has no concept of an annotation, so
+there is no counter to borrow and no method to hand the array to.
+
+If the SDK grows a `Choice.add_annotation`, delete this module together with
+`AnnotationIndexSpace` and everything that threads it (`ChainParametersConfig`, the
+`ChainParameters` accessor, the streamer's constructor argument, and the two entry points that
+create the counter), and call the method from `_process_annotations` the way
+`_process_attachment` already calls `add_attachment`. That also returns the two things this
+workaround gives up: the `opened`/`closed` guard that `send_chunk` skips, and a real `NullChoice`
+no-op in place of the `isinstance` test in `send_annotations` below.
 """
 
 import logging

--- a/statgpt/app/utils/openai_to_dial_streamer.py
+++ b/statgpt/app/utils/openai_to_dial_streamer.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Iterator
 from typing import Any
 
 from aidial_sdk.chat_completion import Stage
@@ -10,10 +11,11 @@ from statgpt.common.schemas import StagesConfig
 from statgpt.common.schemas.token_usage import TokenUsageItem
 from statgpt.common.utils.token_usage_context import get_token_usage_manager
 
-# Maps (streamer, the index a sub-deployment gave one of its annotations) to the index this
-# response gives that annotation. One dict per response, shared by every streamer of that
-# response: see `OpenAiToDialStreamer._renumber_annotation`.
-AnnotationIndexes = dict[tuple["OpenAiToDialStreamer", int], int]
+# Hands out the index this response gives a relayed annotation. One counter per response,
+# created with `itertools.count()` and shared by every streamer of that response: see
+# `OpenAiToDialStreamer._renumber_annotation`. A counter rather than a map keyed by streamer,
+# so that the shared object outlives no streamer and none of their buffered reports.
+AnnotationIndexSpace = Iterator[int]
 
 
 class OpenAiToDialStreamer:
@@ -24,7 +26,7 @@ class OpenAiToDialStreamer:
         deployment: str,
         show_debug_stages: bool,
         stages_config: StagesConfig,
-        annotation_indexes: AnnotationIndexes,
+        annotation_index_space: AnnotationIndexSpace,
         stream_content: bool = True,
     ) -> None:
         """Creates a streamer that processes OpenAI ChatCompletionChunks and sends them to Dial.
@@ -33,9 +35,9 @@ class OpenAiToDialStreamer:
             target: Choice or Stage object to append content and attachments to.
             choice: Choice object to create new stages, and to send annotations to.
             deployment: Deployment id or name that will be used to track token usage.
-            annotation_indexes: The annotation index space of the whole response, shared with
-                every other streamer of the same response. Required rather than defaulted, so
-                that a new call site fails loudly instead of numbering annotations on its own.
+            annotation_index_space: The annotation index counter of the whole response, shared
+                with every other streamer of the same response. Required rather than defaulted,
+                so a new call site fails loudly instead of numbering annotations on its own.
             stream_content: If True, the content will be appended to the `target` as it is received.
             stream_stages: If True, the stages will be created with the content and attachments from the chunks.
         """
@@ -45,13 +47,16 @@ class OpenAiToDialStreamer:
         self._deployment = deployment
         self._show_debug_stages = show_debug_stages
         self._stages_config = stages_config
-        self._annotation_indexes = annotation_indexes
+        self._annotation_index_space = annotation_index_space
         self._stream_content = stream_content
 
         self._content = ""
         self._stages: dict[int, Stage] = {}
         self._attachments: list[dict[str, Any]] = []
         self._state: dict[str, Any] | None = None
+        # This streamer's own annotations only: the index its sub-deployment gave one, mapped
+        # to the index this response gave it. Dies with the streamer.
+        self._annotation_indexes: dict[int, int] = {}
 
     def __enter__(self):
         return self
@@ -164,6 +169,10 @@ class OpenAiToDialStreamer:
         An annotation that arrives without an index keeps none: the array it belongs to is
         either fully indexed or not indexed at all.
 
+        `_annotation_indexes` maps this streamer's incoming indexes and no one else's, so an
+        index that two sub-deployments both used stays two separate entries. Keeping the
+        numbers those entries resolve to apart is the shared counter's job.
+
         This lookup deliberately contains no `await`, so concurrent tool calls cannot interleave
         inside it and it needs no lock. Keep it synchronous for that reason.
         """
@@ -171,10 +180,9 @@ class OpenAiToDialStreamer:
         if index is None:
             return annotation
 
-        key = (self, index)
-        if key not in self._annotation_indexes:
-            self._annotation_indexes[key] = len(self._annotation_indexes)
-        return {**annotation, 'index': self._annotation_indexes[key]}
+        if index not in self._annotation_indexes:
+            self._annotation_indexes[index] = next(self._annotation_index_space)
+        return {**annotation, 'index': self._annotation_indexes[index]}
 
     def _process_stage(self, stage: dict[str, Any]) -> None:
         index = stage['index']

--- a/statgpt/app/utils/openai_to_dial_streamer.py
+++ b/statgpt/app/utils/openai_to_dial_streamer.py
@@ -4,10 +4,16 @@ from typing import Any
 from aidial_sdk.chat_completion import Stage
 from openai.types.chat import ChatCompletionChunk
 
+from statgpt.app.utils.dial_annotations import send_annotations
 from statgpt.app.utils.dial_stages import ChoiceI
 from statgpt.common.schemas import StagesConfig
 from statgpt.common.schemas.token_usage import TokenUsageItem
 from statgpt.common.utils.token_usage_context import get_token_usage_manager
+
+# Maps (streamer, the index a sub-deployment gave one of its annotations) to the index this
+# response gives that annotation. One dict per response, shared by every streamer of that
+# response: see `OpenAiToDialStreamer._renumber_annotation`.
+AnnotationIndexes = dict[tuple["OpenAiToDialStreamer", int], int]
 
 
 class OpenAiToDialStreamer:
@@ -18,14 +24,18 @@ class OpenAiToDialStreamer:
         deployment: str,
         show_debug_stages: bool,
         stages_config: StagesConfig,
+        annotation_indexes: AnnotationIndexes,
         stream_content: bool = True,
     ) -> None:
         """Creates a streamer that processes OpenAI ChatCompletionChunks and sends them to Dial.
 
         Args:
             target: Choice or Stage object to append content and attachments to.
-            choice: Choice object to create new stages.
+            choice: Choice object to create new stages, and to send annotations to.
             deployment: Deployment id or name that will be used to track token usage.
+            annotation_indexes: The annotation index space of the whole response, shared with
+                every other streamer of the same response. Required rather than defaulted, so
+                that a new call site fails loudly instead of numbering annotations on its own.
             stream_content: If True, the content will be appended to the `target` as it is received.
             stream_stages: If True, the stages will be created with the content and attachments from the chunks.
         """
@@ -35,6 +45,7 @@ class OpenAiToDialStreamer:
         self._deployment = deployment
         self._show_debug_stages = show_debug_stages
         self._stages_config = stages_config
+        self._annotation_indexes = annotation_indexes
         self._stream_content = stream_content
 
         self._content = ""
@@ -108,6 +119,9 @@ class OpenAiToDialStreamer:
             for attachment in attachments:
                 self._process_attachment(attachment)
 
+        if annotations := custom_content.get('annotations'):
+            self._process_annotations(annotations)
+
         if not self._stages_config.debug_only or self._show_debug_stages:
             for stage in custom_content.get('stages', []):
                 self._process_stage(stage)
@@ -126,6 +140,41 @@ class OpenAiToDialStreamer:
                 reference_url=attachment.get('reference_url'),
                 reference_type=attachment.get('reference_type'),
             )
+
+    def _process_annotations(self, annotations: list[dict[str, Any]]) -> None:
+        """Relay the sub-deployment's annotations to the user's message.
+
+        They go to `_choice` and never to `_target`, which is a stage on some paths: an
+        annotation claims a marker tag in a message, and a stage is not a message. Every field
+        is relayed unchanged except `index`.
+        """
+        send_annotations(
+            self._choice, [self._renumber_annotation(annotation) for annotation in annotations]
+        )
+
+    def _renumber_annotation(self, annotation: dict[str, Any]) -> dict[str, Any]:
+        """Move the annotation's `index` into the index space of the whole response.
+
+        Each sub-deployment numbers its own annotations from zero, and several of them run
+        concurrently in one response (the Supreme Agent and the direct-tool-calls chain both
+        dispatch tool calls with `asyncio.gather`), so the incoming numbers collide. The client
+        compares indexes before it consults the tag id, and two annotations that share an index
+        are read as one entry — which would hide the sources of a pill that cites several.
+
+        An annotation that arrives without an index keeps none: the array it belongs to is
+        either fully indexed or not indexed at all.
+
+        This lookup deliberately contains no `await`, so concurrent tool calls cannot interleave
+        inside it and it needs no lock. Keep it synchronous for that reason.
+        """
+        index = annotation.get('index')
+        if index is None:
+            return annotation
+
+        key = (self, index)
+        if key not in self._annotation_indexes:
+            self._annotation_indexes[key] = len(self._annotation_indexes)
+        return {**annotation, 'index': self._annotation_indexes[key]}
 
     def _process_stage(self, stage: dict[str, Any]) -> None:
         index = stage['index']

--- a/statgpt/app/utils/openai_to_dial_streamer.py
+++ b/statgpt/app/utils/openai_to_dial_streamer.py
@@ -15,6 +15,12 @@ from statgpt.common.utils.token_usage_context import get_token_usage_manager
 # created with `itertools.count()` and shared by every streamer of that response: see
 # `OpenAiToDialStreamer._renumber_annotation`. A counter rather than a map keyed by streamer,
 # so that the shared object outlives no streamer and none of their buffered reports.
+#
+# It exists only because the SDK owns no annotation index. `Choice` numbers stages and
+# attachments from its own counters, which is why `_process_stage` and `_process_attachment`
+# below pass a payload and never an index; annotations have no such method, so the numbering
+# falls to us. A `Choice.add_annotation` upstream would delete this alias and everything that
+# threads it — see the module docstring of `dial_annotations` for the full list.
 AnnotationIndexSpace = Iterator[int]
 
 

--- a/tests/unit/app/chains/test_deep_research_routing.py
+++ b/tests/unit/app/chains/test_deep_research_routing.py
@@ -267,6 +267,7 @@ def _inputs(
             messages=[DialMessage(role=Role.USER, content=user_text)]
         ),
         ChainParametersConfig.CONFIGURATION: StatGPTConfiguration(deep_research=deep_research),
+        ChainParametersConfig.ANNOTATION_INDEXES: {},
     }
 
 

--- a/tests/unit/app/chains/test_deep_research_routing.py
+++ b/tests/unit/app/chains/test_deep_research_routing.py
@@ -15,6 +15,7 @@ Deep Research is excluded from ``ChannelConfig.tool_fields`` and is reachable on
 These tests pin that behaviour and the deterministic toggle/session routing.
 """
 
+import itertools
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -267,7 +268,7 @@ def _inputs(
             messages=[DialMessage(role=Role.USER, content=user_text)]
         ),
         ChainParametersConfig.CONFIGURATION: StatGPTConfiguration(deep_research=deep_research),
-        ChainParametersConfig.ANNOTATION_INDEXES: {},
+        ChainParametersConfig.ANNOTATION_INDEX_SPACE: itertools.count(),
     }
 
 

--- a/tests/unit/app/chains/test_deep_research_session.py
+++ b/tests/unit/app/chains/test_deep_research_session.py
@@ -150,6 +150,7 @@ class TestStreamerStateCapture:
             deployment="d",
             show_debug_stages=False,
             stages_config=Mock(),
+            annotation_indexes={},
             stream_content=True,
         )
 

--- a/tests/unit/app/chains/test_deep_research_session.py
+++ b/tests/unit/app/chains/test_deep_research_session.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 from unittest.mock import Mock
 
@@ -150,7 +151,7 @@ class TestStreamerStateCapture:
             deployment="d",
             show_debug_stages=False,
             stages_config=Mock(),
-            annotation_indexes={},
+            annotation_index_space=itertools.count(),
             stream_content=True,
         )
 

--- a/tests/unit/app/utils/test_dial_annotations.py
+++ b/tests/unit/app/utils/test_dial_annotations.py
@@ -6,6 +6,9 @@ so the client can turn each claimed tag into a citation pill instead of showing 
 """
 
 import asyncio
+import gc
+import itertools
+import weakref
 from typing import Any
 from unittest.mock import Mock
 
@@ -15,7 +18,7 @@ from openai.types.chat import ChatCompletionChunk
 
 from statgpt.app.utils.dial_annotations import send_annotations
 from statgpt.app.utils.dial_stages import NullChoice
-from statgpt.app.utils.openai_to_dial_streamer import AnnotationIndexes, OpenAiToDialStreamer
+from statgpt.app.utils.openai_to_dial_streamer import AnnotationIndexSpace, OpenAiToDialStreamer
 
 
 def _annotation(index: int | None, tag_id: str = "cit-1", page: int = 3) -> dict[str, Any]:
@@ -87,15 +90,16 @@ def _relayed(choice: Choice) -> list[tuple[str, int]]:
 
 
 def _streamer(
-    choice: Choice, annotation_indexes: AnnotationIndexes, target: Any = None
+    choice: Choice, index_space: AnnotationIndexSpace | None = None, target: Any = None
 ) -> OpenAiToDialStreamer:
+    """A streamer on `choice`. Pass `index_space` to share one counter between streamers."""
     return OpenAiToDialStreamer(
         target if target is not None else choice,
         choice,
         deployment="deep-research",
         show_debug_stages=False,
         stages_config=Mock(debug_only=True),
-        annotation_indexes=annotation_indexes,
+        annotation_index_space=index_space if index_space is not None else itertools.count(),
     )
 
 
@@ -145,16 +149,14 @@ class TestStreamerRelaysAnnotations:
     def test_relays_every_field_unchanged(self):
         choice = _open_choice()
         annotation = _annotation(0)
-        _streamer(choice, {})._process_custom_content({"annotations": [annotation]})
+        _streamer(choice)._process_custom_content({"annotations": [annotation]})
 
         assert _sent_annotations(choice) == [annotation]
 
     def test_relays_to_the_choice_and_not_to_the_target_stage(self):
         choice = _open_choice()
         stage = Mock()
-        _streamer(choice, {}, target=stage)._process_custom_content(
-            {"annotations": [_annotation(0)]}
-        )
+        _streamer(choice, target=stage)._process_custom_content({"annotations": [_annotation(0)]})
 
         assert len(_sent_annotations(choice)) == 1
         stage.send_chunk.assert_not_called()
@@ -163,13 +165,13 @@ class TestStreamerRelaysAnnotations:
         """`custom_content` is not part of the OpenAI schema; the whole array has to come
         through `ChatCompletionChunk` parsing for the relay to have anything to send."""
         choice = _open_choice()
-        _streamer(choice, {}).send_chunk(_chunk([_annotation(0)]))
+        _streamer(choice).send_chunk(_chunk([_annotation(0)]))
 
         assert _sent_annotations(choice) == [_annotation(0)]
 
     def test_custom_content_without_annotations_sends_nothing(self):
         choice = _open_choice()
-        _streamer(choice, {})._process_custom_content({"state": {"research_started": True}})
+        _streamer(choice)._process_custom_content({"state": {"research_started": True}})
 
         assert _sent_annotations(choice) == []
 
@@ -179,13 +181,13 @@ class TestAnnotationIndexSpace:
         """Two tool calls of one response write to the one choice of that response, and each
         sub-deployment numbers its own annotations from zero. Sharing one index space keeps the
         pills of one from swallowing the pills of the other."""
-        indexes: AnnotationIndexes = {}
+        index_space = itertools.count()
         choice = _open_choice()
 
-        _streamer(choice, indexes)._process_custom_content(
+        _streamer(choice, index_space)._process_custom_content(
             {"annotations": [_annotation(0, tag_id="dr-1"), _annotation(1, tag_id="dr-2")]}
         )
-        _streamer(choice, indexes)._process_custom_content(
+        _streamer(choice, index_space)._process_custom_content(
             {"annotations": [_annotation(0, tag_id="rag-1")]}
         )
 
@@ -194,10 +196,10 @@ class TestAnnotationIndexSpace:
     def test_interleaved_streamers_produce_non_overlapping_indexes(self):
         """The two tool calls run concurrently, so their deltas reach the shared choice
         interleaved. Every annotation of the response must still end up with its own index."""
-        indexes: AnnotationIndexes = {}
+        index_space = itertools.count()
         choice = _open_choice()
-        deep_research = _streamer(choice, indexes)
-        rag = _streamer(choice, indexes)
+        deep_research = _streamer(choice, index_space)
+        rag = _streamer(choice, index_space)
 
         deep_research._process_custom_content({"annotations": [_annotation(0, tag_id="dr-1")]})
         rag._process_custom_content({"annotations": [_annotation(0, tag_id="rag-1")]})
@@ -211,9 +213,9 @@ class TestAnnotationIndexSpace:
     def test_one_streamer_keeps_an_index_stable_across_deltas(self):
         """The sub-deployment may re-send an annotation to extend it; the same incoming index
         must keep resolving to the same outgoing one, or the client would store two entries."""
-        indexes: AnnotationIndexes = {}
+        index_space = itertools.count()
         choice = _open_choice()
-        streamer = _streamer(choice, indexes)
+        streamer = _streamer(choice, index_space)
 
         streamer._process_custom_content({"annotations": [_annotation(0)]})
         streamer._process_custom_content({"annotations": [_annotation(1, tag_id="cit-2")]})
@@ -222,9 +224,25 @@ class TestAnnotationIndexSpace:
         assert [a["index"] for a in _sent_annotations(choice)] == [0, 1, 0]
 
     def test_an_index_less_annotation_stays_index_less(self):
-        indexes: AnnotationIndexes = {}
+        index_space = itertools.count()
         choice = _open_choice()
-        _streamer(choice, indexes)._process_custom_content({"annotations": [_annotation(None)]})
+        _streamer(choice, index_space)._process_custom_content({"annotations": [_annotation(None)]})
 
         assert _sent_annotations(choice) == [_annotation(None)]
-        assert indexes == {}
+        assert next(index_space) == 0, "an index-less annotation consumes no index"
+
+    def test_the_index_space_does_not_retain_a_streamer(self):
+        """Why the index space is a counter rather than a map keyed by streamer: it lives for
+        the whole response, and a streamer holds its sub-deployment's buffered report, its
+        attachments and its stages. Keying on the streamer would pin all of that until the
+        response ends, however many tool calls the turn makes."""
+        index_space = itertools.count()
+        choice = _open_choice()
+        streamer = _streamer(choice, index_space)
+        streamer._process_custom_content({"annotations": [_annotation(0)]})
+        collected = weakref.ref(streamer)
+
+        del streamer
+        gc.collect()
+
+        assert collected() is None

--- a/tests/unit/app/utils/test_dial_annotations.py
+++ b/tests/unit/app/utils/test_dial_annotations.py
@@ -1,0 +1,230 @@
+"""Relaying `custom_content.annotations` from a sub-deployment to the user's message (#659).
+
+A sub-deployment such as Deep Research writes an empty `<cit data-id="...">` tag at each cited
+position and describes the tags in `custom_content.annotations`. The streamer forwards that array
+so the client can turn each claimed tag into a citation pill instead of showing the raw markup.
+"""
+
+import asyncio
+from typing import Any
+from unittest.mock import Mock
+
+from aidial_sdk.chat_completion import Choice
+from aidial_sdk.chat_completion.chunks import BaseChunk
+from openai.types.chat import ChatCompletionChunk
+
+from statgpt.app.utils.dial_annotations import send_annotations
+from statgpt.app.utils.dial_stages import NullChoice
+from statgpt.app.utils.openai_to_dial_streamer import AnnotationIndexes, OpenAiToDialStreamer
+
+
+def _annotation(index: int | None, tag_id: str = "cit-1", page: int = 3) -> dict[str, Any]:
+    """One entry of the annotations array, in the shape Deep Research sends."""
+    annotation: dict[str, Any] = {
+        "target": {"selector": {"type": "html_tag", "tag": "cit", "id": tag_id}},
+        "body": {
+            "title": "Report.pdf, page 3",
+            "source": {
+                "type": "attachment",
+                "attachment": {
+                    "type": "application/pdf",
+                    "url": "files/bucket/Report.pdf",
+                    "title": "Report.pdf",
+                },
+            },
+            "selector": {"type": "pdf_bbox", "page": page, "x1": 0, "y1": 0, "x2": 0, "y2": 0},
+        },
+    }
+    if index is not None:
+        annotation["index"] = index
+    return annotation
+
+
+def _open_choice() -> Choice:
+    """A real SDK choice whose queue the test reads the emitted chunks from."""
+    choice = Choice(asyncio.Queue(), 0)
+    choice.open()
+    return choice
+
+
+def _annotation_chunks(choice: Choice) -> list[dict[str, Any]]:
+    """The chunks carrying annotations that the choice's queue holds, in the order sent.
+
+    Chunks of every other kind — the one `open()` sends, content, stages — are skipped.
+    """
+    chunks = []
+    while not choice._queue.empty():
+        queued = choice._queue.get_nowait()
+        # The queue also carries the end-of-stream and error markers, which have no payload.
+        if not isinstance(queued, BaseChunk):
+            continue
+        chunk = queued.to_dict()
+        for ch in chunk.get("choices", []):
+            if "annotations" in ch.get("delta", {}).get("custom_content", {}):
+                chunks.append(chunk)
+    return chunks
+
+
+def _sent_annotations(choice: Choice) -> list[dict[str, Any]]:
+    """Every annotation the choice's queue carries, in the order it was sent."""
+    return [
+        annotation
+        for chunk in _annotation_chunks(choice)
+        for annotation in chunk["choices"][0]["delta"]["custom_content"]["annotations"]
+    ]
+
+
+def _relayed(choice: Choice) -> list[tuple[str, int]]:
+    """The tag id and the relayed index of every annotation on the choice, in the order sent.
+
+    The tag id says which sub-deployment an annotation came from, which is what tells the two
+    relays apart once both have written to the one choice of the response.
+    """
+    return [
+        (annotation["target"]["selector"]["id"], annotation["index"])
+        for annotation in _sent_annotations(choice)
+    ]
+
+
+def _streamer(
+    choice: Choice, annotation_indexes: AnnotationIndexes, target: Any = None
+) -> OpenAiToDialStreamer:
+    return OpenAiToDialStreamer(
+        target if target is not None else choice,
+        choice,
+        deployment="deep-research",
+        show_debug_stages=False,
+        stages_config=Mock(debug_only=True),
+        annotation_indexes=annotation_indexes,
+    )
+
+
+def _chunk(annotations: list[dict[str, Any]]) -> ChatCompletionChunk:
+    """A completion chunk of the sub-deployment carrying an annotations array."""
+    return ChatCompletionChunk.model_validate(
+        {
+            "id": "1",
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": "deep-research",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": None,
+                    "delta": {
+                        "role": "assistant",
+                        "content": 'GDP rose <cit data-id="cit-1"></cit>.',
+                        "custom_content": {"annotations": annotations},
+                    },
+                }
+            ],
+        }
+    )
+
+
+class TestSendAnnotations:
+    def test_emits_one_delta_on_the_choice(self):
+        choice = _open_choice()
+        send_annotations(choice, [_annotation(0), _annotation(1, tag_id="cit-2")])
+
+        chunks = _annotation_chunks(choice)
+        assert len(chunks) == 1, "the array goes out as a single delta"
+        assert chunks[0]["choices"][0]["index"] == choice.index
+        assert chunks[0]["choices"][0]["delta"]["custom_content"]["annotations"] == [
+            _annotation(0),
+            _annotation(1, tag_id="cit-2"),
+        ]
+
+    def test_is_a_no_op_on_a_choice_that_cannot_stream(self, caplog):
+        send_annotations(NullChoice(), [_annotation(0)])
+
+        assert "cannot stream" in caplog.text
+
+
+class TestStreamerRelaysAnnotations:
+    def test_relays_every_field_unchanged(self):
+        choice = _open_choice()
+        annotation = _annotation(0)
+        _streamer(choice, {})._process_custom_content({"annotations": [annotation]})
+
+        assert _sent_annotations(choice) == [annotation]
+
+    def test_relays_to_the_choice_and_not_to_the_target_stage(self):
+        choice = _open_choice()
+        stage = Mock()
+        _streamer(choice, {}, target=stage)._process_custom_content(
+            {"annotations": [_annotation(0)]}
+        )
+
+        assert len(_sent_annotations(choice)) == 1
+        stage.send_chunk.assert_not_called()
+
+    def test_annotations_survive_the_openai_chunk_model(self):
+        """`custom_content` is not part of the OpenAI schema; the whole array has to come
+        through `ChatCompletionChunk` parsing for the relay to have anything to send."""
+        choice = _open_choice()
+        _streamer(choice, {}).send_chunk(_chunk([_annotation(0)]))
+
+        assert _sent_annotations(choice) == [_annotation(0)]
+
+    def test_custom_content_without_annotations_sends_nothing(self):
+        choice = _open_choice()
+        _streamer(choice, {})._process_custom_content({"state": {"research_started": True}})
+
+        assert _sent_annotations(choice) == []
+
+
+class TestAnnotationIndexSpace:
+    def test_two_streamers_do_not_reuse_each_other_indexes(self):
+        """Two tool calls of one response write to the one choice of that response, and each
+        sub-deployment numbers its own annotations from zero. Sharing one index space keeps the
+        pills of one from swallowing the pills of the other."""
+        indexes: AnnotationIndexes = {}
+        choice = _open_choice()
+
+        _streamer(choice, indexes)._process_custom_content(
+            {"annotations": [_annotation(0, tag_id="dr-1"), _annotation(1, tag_id="dr-2")]}
+        )
+        _streamer(choice, indexes)._process_custom_content(
+            {"annotations": [_annotation(0, tag_id="rag-1")]}
+        )
+
+        assert _relayed(choice) == [("dr-1", 0), ("dr-2", 1), ("rag-1", 2)]
+
+    def test_interleaved_streamers_produce_non_overlapping_indexes(self):
+        """The two tool calls run concurrently, so their deltas reach the shared choice
+        interleaved. Every annotation of the response must still end up with its own index."""
+        indexes: AnnotationIndexes = {}
+        choice = _open_choice()
+        deep_research = _streamer(choice, indexes)
+        rag = _streamer(choice, indexes)
+
+        deep_research._process_custom_content({"annotations": [_annotation(0, tag_id="dr-1")]})
+        rag._process_custom_content({"annotations": [_annotation(0, tag_id="rag-1")]})
+        deep_research._process_custom_content({"annotations": [_annotation(1, tag_id="dr-2")]})
+        rag._process_custom_content({"annotations": [_annotation(1, tag_id="rag-2")]})
+
+        relayed = _relayed(choice)
+        assert relayed == [("dr-1", 0), ("rag-1", 1), ("dr-2", 2), ("rag-2", 3)]
+        assert len({index for _, index in relayed}) == len(relayed), "indexes must not repeat"
+
+    def test_one_streamer_keeps_an_index_stable_across_deltas(self):
+        """The sub-deployment may re-send an annotation to extend it; the same incoming index
+        must keep resolving to the same outgoing one, or the client would store two entries."""
+        indexes: AnnotationIndexes = {}
+        choice = _open_choice()
+        streamer = _streamer(choice, indexes)
+
+        streamer._process_custom_content({"annotations": [_annotation(0)]})
+        streamer._process_custom_content({"annotations": [_annotation(1, tag_id="cit-2")]})
+        streamer._process_custom_content({"annotations": [_annotation(0)]})
+
+        assert [a["index"] for a in _sent_annotations(choice)] == [0, 1, 0]
+
+    def test_an_index_less_annotation_stays_index_less(self):
+        indexes: AnnotationIndexes = {}
+        choice = _open_choice()
+        _streamer(choice, indexes)._process_custom_content({"annotations": [_annotation(None)]})
+
+        assert _sent_annotations(choice) == [_annotation(None)]
+        assert indexes == {}


### PR DESCRIPTION
## Applicable issues

- closes #659

## Description of changes

A Deep Research report cites its sources with an empty `<cit data-id="…"></cit>` tag at each cited position and a `custom_content.annotations` array that says what each tag cites. StatGPT dropped the array, so the reader saw the raw tags. This relays it.

### How the issue's plan was followed

The issue prescribes eight steps. Steps 1 to 7 are implemented, step 6 with a change of shape explained below, and step 8 is not done.

| Step in the issue | Outcome |
|---|---|
| 1. Read `custom_content.annotations` in `_process_custom_content` | As specified. |
| 2. Send them to the streamer's `choice`, never its `target` | As specified. |
| 3. Emit through a module-level `send_annotations` built on `ArbitraryChunk` | As specified, mirroring `src/dial_deep_research/utils/dial_annotations.py` in `epam/ai-dial-deep-research-backend`. |
| 4. Make the helper a logging no-op on a choice that cannot stream | As specified. The check sits in the helper itself, so `NullChoice` needs no new method. |
| 5. Relay every field unchanged except `index` | As specified. An annotation that arrives without an index keeps none. |
| 6. Own the index space per response | Implemented, with a different shape. The issue prescribes one dict keyed by the streamer and the incoming index, assigning `len(dict)` on first sight; this is a shared `itertools.count()` plus a per-streamer `dict[int, int]`, which numbers identically without retaining the streamers. It is still passed as a required constructor argument, kept outside `state`, and looked up with no `await` so no lock is needed. See the deviations below. |
| 7. Keep the sub-deployment call streaming | `stream=True` is unchanged, and a comment now states why, so the next reader does not simplify it away. I confirmed the mechanism in the installed SDK: `aidial_sdk/utils/streaming.py` runs `cleanup_indices` over the merged message, and that is what strips `index` from every annotation in a blocking response. |
| 8. Confirm the rendering in a browser | **Not done.** See below. |

### Deviations and decisions worth reviewing

**The index space is a counter, not a map keyed by streamer.** This is the one departure from the issue's prescription, and the reason is lifetime. A dict key holds a strong reference, and the shared dict lives for the whole response, so keying it on `(streamer, incoming index)` would keep every streamer that relayed an annotation reachable after its `with` block exits — and with each streamer its buffered report, its attachments and its stages. In a turn making several RAG, web-search and Deep Research calls, all of those buffers would be retained at once instead of being freed as each tool finishes.

Uniqueness across streamers now comes from each streamer owning its own `dict[int, int]` rather than from the streamer being half of a shared key, and the response-wide numbering comes from the counter. Everything observable is unchanged: the same outgoing indexes, the same eager emission as each chunk arrives, and the same "no `await`, so no lock" property. The two schemes were checked to agree across 2000 random interleavings of up to five streamers, and `test_the_index_space_does_not_retain_a_streamer` fails against the keyed-dict version.

**Where the index space is kept.** The issue says to keep it "on `ChainParameters`", and two classes carry that name. I used the accessor over the chain inputs (`statgpt/app/chains/parameters.py`), adding a `ChainParametersConfig.ANNOTATION_INDEX_SPACE` key and a `get_annotation_index_space` accessor. I did not touch the pydantic model of the same name in `statgpt/app/config/chain_parameters.py`, because it is the base class of `LHCLChainState`, which is constructed as `LHCLChainState(**inputs)` in a dozen places; a required field there would break every one of them.

**The accessor raises instead of defaulting.** `get_annotation_index_space` reads the key directly, so an entry point that forgets to seed the index space fails immediately. This is the same intent as the required constructor argument in step 6.

**The MCP entry point seeds an index space too.** The issue does not mention MCP, but tools run there as well, so `_build_mcp_inputs` seeds a fresh counter. Nothing is emitted under MCP: the choice is a `NullChoice`, which cannot stream, and the helper logs instead of sending.

**Step 8 is not done, and it gates the user-visible outcome.** A pill is drawn only by the next-generation DIAL Chat, and only by a build carrying `epam/ai-dial-chat` [#8560](https://github.com/epam/ai-dial-chat/pull/8560) and [#8681](https://github.com/epam/ai-dial-chat/pull/8681), which is on `development` and in no release. Before merging, this should run in a Review environment with such a build, checking both an ordinary citation and a pill that covers several sources.

### Other things worth knowing

**The plumbing is scaffolding for a method the SDK does not have.** `Choice` numbers every child it knows about from its own counter: `create_stage` from `_last_stage_index`, `add_attachment` from `_last_attachment_index`. That is why `_process_stage` and `_process_attachment` hand over a payload and never an index. `aidial_sdk`, pinned `>=0.39.0,<0.40.0`, has no concept of an annotation, so there is no counter to borrow and no method to hand the array to — which is the whole reason step 6 exists. If the SDK grows a `Choice.add_annotation`, the `dial_annotations` module, the `AnnotationIndexSpace` alias, the config key, the accessor, the constructor argument and both entry-point lines all go away, and `_process_annotations` becomes a loop calling the method. The module docstring of `statgpt/app/utils/dial_annotations.py` records this, and [a comment on #659](https://github.com/epam/statgpt-backend/issues/659#issuecomment-5631889209) has the longer version.

**The issue's first assumption does not hold: statgpt-eval is a blocking caller.** The issue assumes no caller asks StatGPT for a non-streaming completion, because the SDK's blocking assembly (`aidial_sdk/utils/_indexed_list.py`) then requires every annotation to carry an index and the values to be dense from zero. In `statgpt_eval/core/clients.py`, `_send_request_with_retries` posts a body with no `stream` field and reads `response_dict['choices'][0]['message']`, so every evaluation request goes through that assembly — and evaluation runs on every merge request through `statgpt-review`.

Taking each index from a shared counter satisfies the density requirement by construction, so that half is safe. The exposure that remains is an array mixing indexed and index-less annotations, which raises `AssertionError: All elements of a list must be either indexed or not indexed` during assembly and returns a 500 rather than degrading. Step 5 is what allows the mix, by leaving an index-less annotation index-less. Giving such an annotation the next index instead would close this and, by the issue's own step 5 reasoning, also serve the client better, since two index-less annotations sharing a tag id are read as one entry. I have left it as the issue specifies; say the word and I will change it.

**The relay is unconditional, and that is deliberate.** It serves the Deep Research, web-search and DIAL RAG paths at once, which is the reason for putting it in the streamer rather than in the Deep Research tool. It rests on the issue's assumption that a sub-deployment emits annotations only for text that becomes the user's answer. That holds for Deep Research today, and DIAL RAG emits no annotations at all, so the branch is currently unreachable on that path. If DIAL RAG ever began emitting them, its text would go to the tool-result stage while the annotations went to the message, so they would claim tags the message does not contain and the stage would show the raw markup. The condition that would gate this correctly is `self._target is self._choice`, not `stream_content` — `UrlOnlyResponseProducer` passes `stream_content=True` with a debug stage as its target.

**What the tests pin.** Eleven unit tests, of which four are load-bearing. Two streamers relaying onto the one choice of a response, both sequentially and with their deltas interleaved, must end up with non-overlapping indexes. One streamer that sees the same incoming index twice must resolve it to the same outgoing index, so a re-sent annotation does not become a second entry. An annotations array must survive `ChatCompletionChunk` parsing, since `custom_content` is not part of the OpenAI schema and nothing else in the test suite would notice if the field were dropped there. And a streamer must be garbage-collected once its work is done, which is what keeps the index space from pinning the buffered reports of a whole turn.

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
