### PR TITLE
fix!: stop counting blank template rows as skipped in Grade C upload #662

### DIFF
--- a/statgpt/admin/services/discovery_dataset.py
+++ b/statgpt/admin/services/discovery_dataset.py
@@ -678,7 +678,6 @@ class AdminPortalDiscoveryDatasetService(DiscoveryDatasetService):
             delete_absent=mode is schemas.RecordUploadMode.REPLACE,
         )
         summary.rows_read = len(parsed.rows)
-        summary.rows_skipped = parsed.rows_skipped
         return summary
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ export / import ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/statgpt/admin/services/discovery_upload.py
+++ b/statgpt/admin/services/discovery_upload.py
@@ -127,8 +127,6 @@ class ParsedRow:
 @dataclass(frozen=True)
 class ParsedFile:
     rows: list[ParsedRow] = field(default_factory=list)
-    rows_skipped: int = 0
-    """Blank rows skipped, such as the ~300 empty formatted rows the template ships."""
 
     column_letters: dict[str, str] = field(default_factory=dict)
     """Field name -> column letter, so a problem can be reported as a cell reference."""
@@ -247,7 +245,7 @@ def _build_rows(
     data_rows: Iterable[tuple[int, Sequence[Any]]],
     headers: dict[int, str],
     max_rows: int,
-) -> tuple[list[ParsedRow], int]:
+) -> list[ParsedRow]:
     """Normalize the data rows of a file, stopping as soon as the row cap is exceeded.
 
     Takes an iterable rather than a list so the cap bounds memory: a sheet is streamed and
@@ -256,7 +254,6 @@ def _build_rows(
     expand by orders of magnitude.
     """
     rows: list[ParsedRow] = []
-    skipped = 0
 
     for row_number, cells in data_rows:
         values = {
@@ -266,8 +263,8 @@ def _build_rows(
         }
         if not any(values.values()):
             # The template ships hundreds of formatted-but-empty rows, and `ws.max_row`
-            # is inflated in read-only mode, so blanks are skipped rather than stopped at.
-            skipped += 1
+            # is inflated in read-only mode, so blanks are passed over rather than stopped
+            # at. They are not data, so they are dropped silently, not counted.
             continue
         rows.append(ParsedRow(row_number=row_number, values=values))
         if len(rows) > max_rows:
@@ -275,7 +272,7 @@ def _build_rows(
                 f"The file has more than {max_rows} data rows. Split it and upload the parts."
             )
 
-    return rows, skipped
+    return rows
 
 
 def _column_letters(headers: dict[int, str]) -> dict[str, str]:
@@ -320,11 +317,11 @@ def _parse_workbook(data: bytes, max_rows: int) -> ParsedFile:
         headers = _resolve_headers_or_positional(header_cells)
         # Consumed here, inside the `try`: streaming is what makes `max_rows` bound memory,
         # and the rows cannot be read once the `finally` below has closed the workbook.
-        rows, skipped = _build_rows(enumerate(rows_iter, start=2), headers, max_rows)
+        rows = _build_rows(enumerate(rows_iter, start=2), headers, max_rows)
     finally:
         workbook.close()
 
-    return ParsedFile(rows=rows, rows_skipped=skipped, column_letters=_column_letters(headers))
+    return ParsedFile(rows=rows, column_letters=_column_letters(headers))
 
 
 def _decode_csv(data: bytes) -> str:
@@ -357,9 +354,9 @@ def _parse_csv(data: bytes, max_rows: int) -> ParsedFile:
         raise DiscoveryUploadFormatError("The CSV file is empty.") from e
 
     headers = _resolve_headers_or_positional(header_cells)
-    rows, skipped = _build_rows(enumerate(reader, start=2), headers, max_rows)
+    rows = _build_rows(enumerate(reader, start=2), headers, max_rows)
     # A CSV has no spreadsheet coordinates, so problems are reported by row only.
-    return ParsedFile(rows=rows, rows_skipped=skipped)
+    return ParsedFile(rows=rows)
 
 
 def parse_discovery_file(data: bytes, filename: str | None, max_rows: int) -> ParsedFile:

--- a/statgpt/cli/shared/discovery.py
+++ b/statgpt/cli/shared/discovery.py
@@ -29,7 +29,6 @@ _SUMMARY_FIELDS = [
     ("unchanged", "Unchanged"),
     ("deleted", "Deleted"),
     ("rows_read", "Rows read"),
-    ("rows_skipped", "Rows skipped"),
 ]
 
 

--- a/statgpt/common/schemas/discovery_dataset.py
+++ b/statgpt/common/schemas/discovery_dataset.py
@@ -247,6 +247,3 @@ class DiscoveryUploadSummary(BaseYamlModel):
 
     rows_read: int = 0
     """Data rows found in the file, excluding the header and blank rows."""
-
-    rows_skipped: int = 0
-    """Blank rows skipped, such as the empty formatted rows the template ships with."""

--- a/tests/unit/admin/services/test_discovery_upload.py
+++ b/tests/unit/admin/services/test_discovery_upload.py
@@ -179,8 +179,12 @@ def test_whitespace_is_normalized() -> None:
     assert parsed.rows[0].values["agency"] == "Bank Indonesia (BI)"
 
 
-def test_blank_rows_are_skipped_without_stopping_the_scan() -> None:
-    """The template ships ~300 formatted-but-empty rows between and after the data."""
+def test_blank_rows_are_dropped_without_stopping_the_scan() -> None:
+    """The template ships ~300 formatted-but-empty rows between and after the data.
+
+    They are not data, so they are dropped silently rather than reported as skipped: a
+    count inflated by template formatting only misleads whoever reads the upload summary.
+    """
     blank: list = [None] * len(_DATASETS_HEADERS)
     whitespace_only = [" "] * len(_DATASETS_HEADERS)
     second = list(_ROW)
@@ -191,7 +195,6 @@ def test_blank_rows_are_skipped_without_stopping_the_scan() -> None:
     )
 
     assert [row.values["dataset_id"] for row in parsed.rows] == ["TABEL1_1", "TABEL1_2"]
-    assert parsed.rows_skipped == 3
     # Row numbers still point at the real spreadsheet rows.
     assert [row.row_number for row in parsed.rows] == [2, 5]
 


### PR DESCRIPTION
## Applicable issues

- closes #662

## Description of changes

The Grade C (discovery) upload summary reported every fully-blank row as **"Rows
Skipped"**. Because the customer template ships hundreds of formatted-but-empty (bordered)
rows below the data, an upload containing only valid records still surfaced a large,
misleading skipped count.

Blank rows carry no data, so they are now dropped silently instead of being tallied. Since
rows with bad data raise per-cell errors (they are never skipped), the `rows_skipped`
metric only ever counted template formatting — so it is removed end-to-end:

- **Parser** (`discovery_upload.py`): `_build_rows` no longer counts blanks and returns
  just the rows; `ParsedFile.rows_skipped` is dropped.
- **Upload summary** (`DiscoveryUploadSummary`): the `rows_skipped` field is removed; the
  summary now reports created / updated / unchanged / deleted plus `rows_read` (the
  filled-in rows), which is the "only filled rows" count the issue asks for.
- **CLI** results table: the "Rows skipped" row is removed.
- **Tests** updated to assert blank rows are dropped rather than counted.

> Note: the admin frontend "Upload Grade C datasets" modal reads `rows_skipped`; a matching
> frontend change is needed to drop that column now that the field is no longer returned.

## Checklist

- [x] Title of the pull request follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Deployed and tested in a `Review` environment

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
